### PR TITLE
Bump `resources/bluesky-social/atproto` from `41b2050` to `174f86d`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3146,12 +3146,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "ce764e3c19df985cc4439f38cd9bc13d3e22c924"
+                "reference": "12f97f3183ded2ac38fbb9a11a11ef570eb626d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/ce764e3c19df985cc4439f38cd9bc13d3e22c924",
-                "reference": "ce764e3c19df985cc4439f38cd9bc13d3e22c924",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/12f97f3183ded2ac38fbb9a11a11ef570eb626d2",
+                "reference": "12f97f3183ded2ac38fbb9a11a11ef570eb626d2",
                 "shasum": ""
             },
             "require": {
@@ -3296,7 +3296,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-11T15:37:57+00:00"
+            "time": "2025-08-11T17:04:28+00:00"
         },
         {
             "name": "ghostwriter/filesystem",


### PR DESCRIPTION
Bumps `resources/bluesky-social/atproto` from `41b2050` to `174f86d`.

This pull request changes the following file(s): 

- Update `resources/bluesky-social/atproto`