### PR TITLE
Bump `ghostwriter/coding-standard` from `dev-main#9c059fa` to `dev-main#7d9c18e`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3189,12 +3189,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "9c059fac356bff97d94130ecdbeef8a4bf8dba44"
+                "reference": "7d9c18e561bdadb1332efda2734c6d3bc86ea0ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/9c059fac356bff97d94130ecdbeef8a4bf8dba44",
-                "reference": "9c059fac356bff97d94130ecdbeef8a4bf8dba44",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/7d9c18e561bdadb1332efda2734c6d3bc86ea0ee",
+                "reference": "7d9c18e561bdadb1332efda2734c6d3bc86ea0ee",
                 "shasum": ""
             },
             "require": {
@@ -3351,7 +3351,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-29T08:40:12+00:00"
+            "time": "2025-09-01T12:21:09+00:00"
         },
         {
             "name": "ghostwriter/filesystem",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#9c059fa` to `dev-main#7d9c18e`.

This pull request changes the following file(s): 

- Update `composer.lock`