### PR TITLE
Bump `ghostwriter/coding-standard` from `dev-main#cee15c1` to `dev-main#69b26a1`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2083,12 +2083,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "cee15c16811f29974605dd605c71bc464555b204"
+                "reference": "69b26a144926ec51cf447e32d7fd411aba02bd8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/cee15c16811f29974605dd605c71bc464555b204",
-                "reference": "cee15c16811f29974605dd605c71bc464555b204",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/69b26a144926ec51cf447e32d7fd411aba02bd8a",
+                "reference": "69b26a144926ec51cf447e32d7fd411aba02bd8a",
                 "shasum": ""
             },
             "require": {
@@ -2245,7 +2245,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-02T02:09:07+00:00"
+            "time": "2025-09-02T02:45:04+00:00"
         },
         {
             "name": "ghostwriter/filesystem",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#cee15c1` to `dev-main#69b26a1`.

This pull request changes the following file(s): 

- Update `composer.lock`