### PR TITLE
Update ghostwriter/coding-standard to version dev-main#ac07617

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1478,16 +1478,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.9.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "5b236f4fb611083885d18031a9e503e1cdb6a3f6"
+                "reference": "35cb6d47d03b0cae52dc12d686f941365b20f08b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/5b236f4fb611083885d18031a9e503e1cdb6a3f6",
-                "reference": "5b236f4fb611083885d18031a9e503e1cdb6a3f6",
+                "url": "https://api.github.com/repos/composer/composer/zipball/35cb6d47d03b0cae52dc12d686f941365b20f08b",
+                "reference": "35cb6d47d03b0cae52dc12d686f941365b20f08b",
                 "shasum": ""
             },
             "require": {
@@ -1574,7 +1574,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.9.0"
+                "source": "https://github.com/composer/composer/tree/2.9.1"
             },
             "funding": [
                 {
@@ -1586,7 +1586,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-13T09:37:16+00:00"
+            "time": "2025-11-13T15:10:38+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -1965,18 +1965,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "db3ee7ef21d8451edde011bd7f4cc12fd5c20618"
+                "reference": "ac076177d2077c34bc35f96aac9b41d78742e21f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/db3ee7ef21d8451edde011bd7f4cc12fd5c20618",
-                "reference": "db3ee7ef21d8451edde011bd7f4cc12fd5c20618",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/ac076177d2077c34bc35f96aac9b41d78742e21f",
+                "reference": "ac076177d2077c34bc35f96aac9b41d78742e21f",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "~2.6.0",
                 "composer-runtime-api": "~2.2.2",
-                "composer/composer": "^2.9.0",
+                "composer/composer": "^2.9.1",
                 "ext-ctype": "*",
                 "ext-curl": "*",
                 "ext-dom": "*",
@@ -2114,7 +2114,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-13T10:45:03+00:00"
+            "time": "2025-11-13T15:45:57+00:00"
         },
         {
             "name": "ghostwriter/filesystem",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#db3ee7e` to `dev-main#ac07617`.

This pull request changes the following file(s): 

- Update `composer.lock`