### PR TITLE
Update ghostwriter/case-converter to version 2.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "php": "~8.4.0 || ~8.5.0",
         "ext-curl": "*",
         "ext-mbstring": "*",
-        "ghostwriter/case-converter": "^2.1.0",
+        "ghostwriter/case-converter": "^2.2.0",
         "ghostwriter/collection": "^2.0.0",
         "ghostwriter/config": "^2.0.0",
         "ghostwriter/container": "^5.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "581cc3e00846a6bd34a682e9af6002d2",
+    "content-hash": "35156f5fb15e41f83e37def6dc3240cf",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -74,27 +74,38 @@
         },
         {
             "name": "ghostwriter/case-converter",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/case-converter.git",
-                "reference": "21ea17ef7518e2241b504895752a1957f5284cc3"
+                "reference": "0d9e4e54a80eaab35b38f0ed2482e45c31dde323"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/case-converter/zipball/21ea17ef7518e2241b504895752a1957f5284cc3",
-                "reference": "21ea17ef7518e2241b504895752a1957f5284cc3",
+                "url": "https://api.github.com/repos/ghostwriter/case-converter/zipball/0d9e4e54a80eaab35b38f0ed2482e45c31dde323",
+                "reference": "0d9e4e54a80eaab35b38f0ed2482e45c31dde323",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": "^8.4"
+                "php": "~8.4.0 || ~8.5.0"
             },
             "require-dev": {
+                "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
-                "ghostwriter/container": "^5.0.1"
+                "ghostwriter/container": "^6.0.1",
+                "mockery/mockery": "^1.6.12",
+                "phpunit/phpunit": "^12.4.4",
+                "symfony/var-dumper": "^7.3.5"
             },
             "type": "library",
+            "extra": {
+                "ghostwriter": {
+                    "container": {
+                        "definition": "Ghostwriter\\CaseConverter\\Container\\CaseConverterDefinition"
+                    }
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Ghostwriter\\CaseConverter\\": "src"
@@ -142,7 +153,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-21T01:13:07+00:00"
+            "time": "2025-11-25T03:02:29+00:00"
         },
         {
             "name": "ghostwriter/collection",


### PR DESCRIPTION
Updates the `ghostwriter/case-converter` dependency from `2.1.0` to `2.2.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`