### PR TITLE
Update php-http/curl-client to version 2.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "ghostwriter/result": "^2.0.0",
         "ghostwriter/uuid": "^1.0.3",
         "laminas/laminas-diactoros": "^3.8.0",
-        "php-http/curl-client": "^2.3.4",
+        "php-http/curl-client": "^2.4.0",
         "psr/http-client": "^1.0.3",
         "psr/http-factory": "^1.1.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c8b59710d7d00121944139e08c17d44",
+    "content-hash": "33df717d29c9a6312d4e2ee83159cdcf",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -744,21 +744,21 @@
         },
         {
             "name": "php-http/curl-client",
-            "version": "2.3.4",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/curl-client.git",
-                "reference": "cc3b48603b0181c7d9984503f7b70fd6a7b37592"
+                "reference": "f59d6992065f44be8b8fb484dd678a919c27dbf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/curl-client/zipball/cc3b48603b0181c7d9984503f7b70fd6a7b37592",
-                "reference": "cc3b48603b0181c7d9984503f7b70fd6a7b37592",
+                "url": "https://api.github.com/repos/php-http/curl-client/zipball/f59d6992065f44be8b8fb484dd678a919c27dbf2",
+                "reference": "f59d6992065f44be8b8fb484dd678a919c27dbf2",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
-                "php": "^7.4 || ^8.0",
+                "php": "^8.1",
                 "php-http/discovery": "^1.6",
                 "php-http/httplug": "^2.0",
                 "php-http/message": "^1.2",
@@ -774,9 +774,9 @@
             "require-dev": {
                 "guzzlehttp/psr7": "^2.0",
                 "laminas/laminas-diactoros": "^2.0 || ^3.0",
-                "php-http/client-integration-tests": "^3.0",
+                "php-http/client-integration-tests": "^4.0",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^7.5 || ^9.4"
+                "phpunit/phpunit": "^9.6.17 || ^10.0 || ^11.0 || ^12.0"
             },
             "type": "library",
             "autoload": {
@@ -803,9 +803,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-http/curl-client/issues",
-                "source": "https://github.com/php-http/curl-client/tree/2.3.4"
+                "source": "https://github.com/php-http/curl-client/tree/2.4.0"
             },
-            "time": "2025-12-08T14:11:43+00:00"
+            "time": "2025-12-09T12:02:56+00:00"
         },
         {
             "name": "php-http/discovery",


### PR DESCRIPTION
Updates the `php-http/curl-client` dependency from `2.3.4` to `2.4.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`