### PR TITLE
Update phpdocumentor phar 3.8.1 to 3.9.1

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -6,7 +6,7 @@
   <phar name="composer-unused" version="^0.9.5" installed="0.9.5" location="./tools/phar/composer-unused" copy="true"/>
   <phar name="infection" version="^0.31.9" installed="0.31.9" location="./tools/phar/infection" copy="true"/>
   <phar name="phpbench" version="^1.4.3" installed="1.4.3" location="./tools/phar/phpbench" copy="true"/>
-  <phar name="phpdocumentor" version="^3.8.1" installed="3.8.1" location="./tools/phar/phpdocumentor" copy="true"/>
+  <phar name="phpdocumentor" version="^3.9.1" installed="3.9.1" location="./tools/phar/phpdocumentor" copy="true"/>
   <phar name="phpunit" version="^12.3.1" installed="12.3.1" location="./tools/phar/phpunit" copy="true"/>
   <phar name="psalm" version="^7.0.0-beta11" installed="7.0.0-beta11" location="./tools/psalm" copy="true"/>
   <phar name="phive-io/phive" version="^0.16.0" installed="0.16.0" location="./tools/phar/phive" copy="true"/>


### PR DESCRIPTION
Updates phpdocumentor phar file from 3.8.1 to 3.9.1.

This pull request changes the following file(s): 

- Update `phive.xml`
- Update `tools/phar/phpdocumentor`