### PR TITLE
Update composer-unused phar 0.9.5 to 0.9.6

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -3,7 +3,7 @@
   <phar name="composer" version="^2.9.5" installed="2.9.5" location="./tools/phar/composer" copy="true"/>
   <phar name="composer-normalize" version="^2.49.0" installed="2.49.0" location="./tools/phar/composer-normalize" copy="true"/>
   <phar name="composer-require-checker" version="^4.20.0" installed="4.20.0" location="./tools/phar/composer-require-checker" copy="true"/>
-  <phar name="composer-unused" version="^0.9.5" installed="0.9.5" location="./tools/phar/composer-unused" copy="true"/>
+  <phar name="composer-unused" version="^0.9.6" installed="0.9.6" location="./tools/phar/composer-unused" copy="true"/>
   <phar name="infection" version="^0.32.3" installed="0.32.3" location="./tools/phar/infection" copy="true"/>
   <phar name="phpbench" version="^1.4.3" installed="1.4.3" location="./tools/phar/phpbench" copy="true"/>
   <phar name="phpdocumentor" version="^3.9.1" installed="3.9.1" location="./tools/phar/phpdocumentor" copy="true"/>


### PR DESCRIPTION
Updates composer-unused phar file from 0.9.5 to 0.9.6.

This pull request changes the following file(s): 

- Update `phive.xml`
- Update `tools/phar/composer-unused`