### PR TITLE
Update phpunit phar 12.5.9 to 13.0.0

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -7,7 +7,7 @@
   <phar name="infection" version="^0.32.3" installed="0.32.3" location="./tools/phar/infection" copy="true"/>
   <phar name="phpbench" version="^1.4.3" installed="1.4.3" location="./tools/phar/phpbench" copy="true"/>
   <phar name="phpdocumentor" version="^3.9.1" installed="3.9.1" location="./tools/phar/phpdocumentor" copy="true"/>
-  <phar name="phpunit" version="^12.5.9" installed="12.5.9" location="./tools/phar/phpunit" copy="true"/>
+  <phar name="phpunit" version="^13.0.0" installed="13.0.0" location="./tools/phar/phpunit" copy="true"/>
   <phar name="psalm" version="^6.15.0" installed="6.15.0" location="./tools/phar/psalm" copy="true"/>
   <phar name="phar-io/phive" version="^0.16.0" installed="0.16.0" location="./tools/phar/phive" copy="true"/>
 </phive>

--- a/tools/phar/phpunit
+++ b/tools/phar/phpunit
@@ -15,12 +15,12 @@ if (!version_compare(PHP_VERSION, PHP_VERSION, '=')) {
     die(1);
 }
 
-if (version_compare('8.3.0', PHP_VERSION, '>')) {
+if (version_compare('8.4.1', PHP_VERSION, '>')) {
     fwrite(
         STDERR,
         sprintf(
-            'PHPUnit 12.5.9 by Sebastian Bergmann and contributors.' . PHP_EOL . PHP_EOL .
-            'This version of PHPUnit requires PHP >= 8.3.' . PHP_EOL .
+            'PHPUnit 13.0.0 by Sebastian Bergmann and contributors.' . PHP_EOL . PHP_EOL .
+            'This version of PHPUnit requires PHP >= 8.4.1.' . PHP_EOL .
             'You are using PHP %s (%s).' . PHP_EOL,
             PHP_VERSION,
             PHP_BINARY
@@ -74,9 +74,9 @@ if (isset($options['composer-lock'])) {
 unset($options);
 
 define('__PHPUNIT_PHAR__', str_replace(DIRECTORY_SEPARATOR, '/', __FILE__));
-define('__PHPUNIT_PHAR_ROOT__', 'phar://phpunit-12.5.9.phar');
+define('__PHPUNIT_PHAR_ROOT__', 'phar://phpunit-13.0.0.phar');
 
-Phar::mapPhar('phpunit-12.5.9.phar');
+Phar::mapPhar('phpunit-13.0.0.phar');
 
 spl_autoload_register(
     function ($class) {
@@ -594,7 +594,6 @@ spl_autoload_register(
                 'PHPUnitPHAR\\SebastianBergmann\\Diff\\Diff' => '/sebastian-diff/Diff.php',
                 'PHPUnitPHAR\\SebastianBergmann\\Diff\\Differ' => '/sebastian-diff/Differ.php',
                 'PHPUnitPHAR\\SebastianBergmann\\Diff\\Exception' => '/sebastian-diff/Exception/Exception.php',
-                'PHPUnitPHAR\\SebastianBergmann\\Diff\\InvalidArgumentException' => '/sebastian-diff/Exception/InvalidArgumentException.php',
                 'PHPUnitPHAR\\SebastianBergmann\\Diff\\Line' => '/sebastian-diff/Line.php',
                 'PHPUnitPHAR\\SebastianBergmann\\Diff\\LongestCommonSubsequenceCalculator' => '/sebastian-diff/LongestCommonSubsequenceCalculator.php',
                 'PHPUnitPHAR\\SebastianBergmann\\Diff\\MemoryEfficientLongestCommonSubsequenceCalculator' => '/sebastian-diff/MemoryEfficientLongestCommonSubsequenceCalculator.php',
@@ -840,6 +839,8 @@ spl_autoload_register(
                 'PHPUnit\\Event\\Test\\ComparatorRegisteredSubscriber' => '/phpunit/Event/Events/Test/ComparatorRegisteredSubscriber.php',
                 'PHPUnit\\Event\\Test\\ConsideredRisky' => '/phpunit/Event/Events/Test/Issue/ConsideredRisky.php',
                 'PHPUnit\\Event\\Test\\ConsideredRiskySubscriber' => '/phpunit/Event/Events/Test/Issue/ConsideredRiskySubscriber.php',
+                'PHPUnit\\Event\\Test\\CustomTestMethodInvocationUsed' => '/phpunit/Event/Events/Test/CustomTestMethodInvocationUsed.php',
+                'PHPUnit\\Event\\Test\\CustomTestMethodInvocationUsedSubscriber' => '/phpunit/Event/Events/Test/CustomTestMethodInvocationUsedSubscriber.php',
                 'PHPUnit\\Event\\Test\\DataProviderMethodCalled' => '/phpunit/Event/Events/Test/Lifecycle/DataProviderMethodCalled.php',
                 'PHPUnit\\Event\\Test\\DataProviderMethodCalledSubscriber' => '/phpunit/Event/Events/Test/Lifecycle/DataProviderMethodCalledSubscriber.php',
                 'PHPUnit\\Event\\Test\\DataProviderMethodFinished' => '/phpunit/Event/Events/Test/Lifecycle/DataProviderMethodFinished.php',
@@ -974,7 +975,6 @@ spl_autoload_register(
                 'PHPUnit\\Framework\\Attributes\\RequiresPhpunit' => '/phpunit/Framework/Attributes/RequiresPhpunit.php',
                 'PHPUnit\\Framework\\Attributes\\RequiresPhpunitExtension' => '/phpunit/Framework/Attributes/RequiresPhpunitExtension.php',
                 'PHPUnit\\Framework\\Attributes\\RequiresSetting' => '/phpunit/Framework/Attributes/RequiresSetting.php',
-                'PHPUnit\\Framework\\Attributes\\RunClassInSeparateProcess' => '/phpunit/Framework/Attributes/RunClassInSeparateProcess.php',
                 'PHPUnit\\Framework\\Attributes\\RunInSeparateProcess' => '/phpunit/Framework/Attributes/RunInSeparateProcess.php',
                 'PHPUnit\\Framework\\Attributes\\RunTestsInSeparateProcesses' => '/phpunit/Framework/Attributes/RunTestsInSeparateProcesses.php',
                 'PHPUnit\\Framework\\Attributes\\Small' => '/phpunit/Framework/Attributes/Small.php',
@@ -1000,7 +1000,10 @@ spl_autoload_register(
                 'PHPUnit\\Framework\\ComparisonMethodDoesNotDeclareExactlyOneParameterException' => '/phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotDeclareExactlyOneParameterException.php',
                 'PHPUnit\\Framework\\ComparisonMethodDoesNotDeclareParameterTypeException' => '/phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotDeclareParameterTypeException.php',
                 'PHPUnit\\Framework\\ComparisonMethodDoesNotExistException' => '/phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotExistException.php',
-                'PHPUnit\\Framework\\Constraint\\ArrayHasKey' => '/phpunit/Framework/Constraint/Traversable/ArrayHasKey.php',
+                'PHPUnit\\Framework\\Constraint\\ArrayComparison' => '/phpunit/Framework/Constraint/Array/ArrayComparison.php',
+                'PHPUnit\\Framework\\Constraint\\ArrayHasKey' => '/phpunit/Framework/Constraint/Array/ArrayHasKey.php',
+                'PHPUnit\\Framework\\Constraint\\ArraysAreEqual' => '/phpunit/Framework/Constraint/Array/ArraysAreEqual.php',
+                'PHPUnit\\Framework\\Constraint\\ArraysAreIdentical' => '/phpunit/Framework/Constraint/Array/ArraysAreIdentical.php',
                 'PHPUnit\\Framework\\Constraint\\BinaryOperator' => '/phpunit/Framework/Constraint/Operator/BinaryOperator.php',
                 'PHPUnit\\Framework\\Constraint\\Callback' => '/phpunit/Framework/Constraint/Callback.php',
                 'PHPUnit\\Framework\\Constraint\\Constraint' => '/phpunit/Framework/Constraint/Constraint.php',
@@ -1024,7 +1027,7 @@ spl_autoload_register(
                 'PHPUnit\\Framework\\Constraint\\IsInfinite' => '/phpunit/Framework/Constraint/Math/IsInfinite.php',
                 'PHPUnit\\Framework\\Constraint\\IsInstanceOf' => '/phpunit/Framework/Constraint/Type/IsInstanceOf.php',
                 'PHPUnit\\Framework\\Constraint\\IsJson' => '/phpunit/Framework/Constraint/String/IsJson.php',
-                'PHPUnit\\Framework\\Constraint\\IsList' => '/phpunit/Framework/Constraint/Traversable/IsList.php',
+                'PHPUnit\\Framework\\Constraint\\IsList' => '/phpunit/Framework/Constraint/Array/IsList.php',
                 'PHPUnit\\Framework\\Constraint\\IsNan' => '/phpunit/Framework/Constraint/Math/IsNan.php',
                 'PHPUnit\\Framework\\Constraint\\IsNull' => '/phpunit/Framework/Constraint/Type/IsNull.php',
                 'PHPUnit\\Framework\\Constraint\\IsReadable' => '/phpunit/Framework/Constraint/Filesystem/IsReadable.php',
@@ -1066,6 +1069,7 @@ spl_autoload_register(
                 'PHPUnit\\Framework\\InvalidDependencyException' => '/phpunit/Framework/Exception/InvalidDependencyException.php',
                 'PHPUnit\\Framework\\IsolatedTestRunner' => '/phpunit/Framework/TestRunner/IsolatedTestRunner.php',
                 'PHPUnit\\Framework\\IsolatedTestRunnerRegistry' => '/phpunit/Framework/TestRunner/IsolatedTestRunnerRegistry.php',
+                'PHPUnit\\Framework\\MockObject\\AbstractInvocationImplementation' => '/phpunit/Framework/MockObject/Runtime/AbstractInvocationImplementation.php',
                 'PHPUnit\\Framework\\MockObject\\BadMethodCallException' => '/phpunit/Framework/MockObject/Exception/BadMethodCallException.php',
                 'PHPUnit\\Framework\\MockObject\\CannotUseOnlyMethodsException' => '/phpunit/Framework/MockObject/Exception/CannotUseOnlyMethodsException.php',
                 'PHPUnit\\Framework\\MockObject\\ConfigurableMethod' => '/phpunit/Framework/MockObject/ConfigurableMethod.php',
@@ -1092,6 +1096,8 @@ spl_autoload_register(
                 'PHPUnit\\Framework\\MockObject\\IncompatibleReturnValueException' => '/phpunit/Framework/MockObject/Exception/IncompatibleReturnValueException.php',
                 'PHPUnit\\Framework\\MockObject\\Invocation' => '/phpunit/Framework/MockObject/Runtime/Invocation.php',
                 'PHPUnit\\Framework\\MockObject\\InvocationHandler' => '/phpunit/Framework/MockObject/Runtime/InvocationHandler.php',
+                'PHPUnit\\Framework\\MockObject\\InvocationMocker' => '/phpunit/Framework/MockObject/Runtime/Interface/InvocationMocker.php',
+                'PHPUnit\\Framework\\MockObject\\InvocationMockerImplementation' => '/phpunit/Framework/MockObject/Runtime/InvocationMockerImplementation.php',
                 'PHPUnit\\Framework\\MockObject\\InvocationStubber' => '/phpunit/Framework/MockObject/Runtime/Interface/InvocationStubber.php',
                 'PHPUnit\\Framework\\MockObject\\InvocationStubberImplementation' => '/phpunit/Framework/MockObject/Runtime/InvocationStubberImplementation.php',
                 'PHPUnit\\Framework\\MockObject\\MatchBuilderNotFoundException' => '/phpunit/Framework/MockObject/Exception/MatchBuilderNotFoundException.php',
@@ -1108,6 +1114,7 @@ spl_autoload_register(
                 'PHPUnit\\Framework\\MockObject\\MockObjectApi' => '/phpunit/Framework/MockObject/Runtime/Api/MockObjectApi.php',
                 'PHPUnit\\Framework\\MockObject\\MockObjectInternal' => '/phpunit/Framework/MockObject/Runtime/Interface/MockObjectInternal.php',
                 'PHPUnit\\Framework\\MockObject\\NeverReturningMethodException' => '/phpunit/Framework/MockObject/Exception/NeverReturningMethodException.php',
+                'PHPUnit\\Framework\\MockObject\\NoMoreParameterSetsConfiguredException' => '/phpunit/Framework/MockObject/Exception/NoMoreParameterSetsConfiguredException.php',
                 'PHPUnit\\Framework\\MockObject\\NoMoreReturnValuesConfiguredException' => '/phpunit/Framework/MockObject/Exception/NoMoreReturnValuesConfiguredException.php',
                 'PHPUnit\\Framework\\MockObject\\ProxiedCloneMethod' => '/phpunit/Framework/MockObject/Runtime/Api/ProxiedCloneMethod.php',
                 'PHPUnit\\Framework\\MockObject\\ReturnValueGenerator' => '/phpunit/Framework/MockObject/Runtime/ReturnValueGenerator.php',
@@ -1120,8 +1127,10 @@ spl_autoload_register(
                 'PHPUnit\\Framework\\MockObject\\Rule\\InvokedAtMostCount' => '/phpunit/Framework/MockObject/Runtime/Rule/InvokedAtMostCount.php',
                 'PHPUnit\\Framework\\MockObject\\Rule\\InvokedCount' => '/phpunit/Framework/MockObject/Runtime/Rule/InvokedCount.php',
                 'PHPUnit\\Framework\\MockObject\\Rule\\MethodName' => '/phpunit/Framework/MockObject/Runtime/Rule/MethodName.php',
+                'PHPUnit\\Framework\\MockObject\\Rule\\OrderedParameterSets' => '/phpunit/Framework/MockObject/Runtime/Rule/OrderedParameterSets.php',
                 'PHPUnit\\Framework\\MockObject\\Rule\\Parameters' => '/phpunit/Framework/MockObject/Runtime/Rule/Parameters.php',
                 'PHPUnit\\Framework\\MockObject\\Rule\\ParametersRule' => '/phpunit/Framework/MockObject/Runtime/Rule/ParametersRule.php',
+                'PHPUnit\\Framework\\MockObject\\Rule\\UnorderedParameterSets' => '/phpunit/Framework/MockObject/Runtime/Rule/UnorderedParameterSets.php',
                 'PHPUnit\\Framework\\MockObject\\RuntimeException' => '/phpunit/Framework/MockObject/Exception/RuntimeException.php',
                 'PHPUnit\\Framework\\MockObject\\Runtime\\PropertyGetHook' => '/phpunit/Framework/MockObject/Runtime/PropertyHook/PropertyGetHook.php',
                 'PHPUnit\\Framework\\MockObject\\Runtime\\PropertyHook' => '/phpunit/Framework/MockObject/Runtime/PropertyHook/PropertyHook.php',
@@ -1139,6 +1148,7 @@ spl_autoload_register(
                 'PHPUnit\\Framework\\MockObject\\Stub\\ReturnValueMap' => '/phpunit/Framework/MockObject/Runtime/Stub/ReturnValueMap.php',
                 'PHPUnit\\Framework\\MockObject\\Stub\\Stub' => '/phpunit/Framework/MockObject/Runtime/Stub/Stub.php',
                 'PHPUnit\\Framework\\MockObject\\TestDoubleBuilder' => '/phpunit/Framework/MockObject/TestDoubleBuilder.php',
+                'PHPUnit\\Framework\\MockObject\\TestDoubleSealedException' => '/phpunit/Framework/MockObject/Exception/TestDoubleSealedException.php',
                 'PHPUnit\\Framework\\MockObject\\TestDoubleState' => '/phpunit/Framework/MockObject/Runtime/Api/TestDoubleState.php',
                 'PHPUnit\\Framework\\MockObject\\TestStubBuilder' => '/phpunit/Framework/MockObject/TestStubBuilder.php',
                 'PHPUnit\\Framework\\NativeType' => '/phpunit/Framework/NativeType.php',
@@ -1291,6 +1301,7 @@ spl_autoload_register(
                 'PHPUnit\\Metadata\\IgnorePhpunitWarnings' => '/phpunit/Metadata/IgnorePhpunitWarnings.php',
                 'PHPUnit\\Metadata\\InvalidAttributeException' => '/phpunit/Metadata/Exception/InvalidAttributeException.php',
                 'PHPUnit\\Metadata\\InvalidVersionRequirementException' => '/phpunit/Metadata/Exception/InvalidVersionRequirementException.php',
+                'PHPUnit\\Metadata\\Level' => '/phpunit/Metadata/Level.php',
                 'PHPUnit\\Metadata\\Metadata' => '/phpunit/Metadata/Metadata.php',
                 'PHPUnit\\Metadata\\MetadataCollection' => '/phpunit/Metadata/MetadataCollection.php',
                 'PHPUnit\\Metadata\\MetadataCollectionIterator' => '/phpunit/Metadata/MetadataCollectionIterator.php',
@@ -1312,7 +1323,6 @@ spl_autoload_register(
                 'PHPUnit\\Metadata\\RequiresPhpunit' => '/phpunit/Metadata/RequiresPhpunit.php',
                 'PHPUnit\\Metadata\\RequiresPhpunitExtension' => '/phpunit/Metadata/RequiresPhpunitExtension.php',
                 'PHPUnit\\Metadata\\RequiresSetting' => '/phpunit/Metadata/RequiresSetting.php',
-                'PHPUnit\\Metadata\\RunClassInSeparateProcess' => '/phpunit/Metadata/RunClassInSeparateProcess.php',
                 'PHPUnit\\Metadata\\RunInSeparateProcess' => '/phpunit/Metadata/RunInSeparateProcess.php',
                 'PHPUnit\\Metadata\\RunTestsInSeparateProcesses' => '/phpunit/Metadata/RunTestsInSeparateProcesses.php',
                 'PHPUnit\\Metadata\\Test' => '/phpunit/Metadata/Test.php',
@@ -1511,6 +1521,7 @@ spl_autoload_register(
                 'PHPUnit\\TextUI\\Configuration\\NoCustomCssFileException' => '/phpunit/TextUI/Configuration/Exception/NoCustomCssFileException.php',
                 'PHPUnit\\TextUI\\Configuration\\NoDefaultTestSuiteException' => '/phpunit/TextUI/Configuration/Exception/NoDefaultTestSuiteException.php',
                 'PHPUnit\\TextUI\\Configuration\\NoPharExtensionDirectoryException' => '/phpunit/TextUI/Configuration/Exception/NoPharExtensionDirectoryException.php',
+                'PHPUnit\\TextUI\\Configuration\\NoTestFilesFileException' => '/phpunit/TextUI/Configuration/Exception/NoTestFilesFileException.php',
                 'PHPUnit\\TextUI\\Configuration\\Php' => '/phpunit/TextUI/Configuration/Value/Php.php',
                 'PHPUnit\\TextUI\\Configuration\\PhpHandler' => '/phpunit/TextUI/Configuration/PhpHandler.php',
                 'PHPUnit\\TextUI\\Configuration\\Registry' => '/phpunit/TextUI/Configuration/Registry.php',
@@ -1674,7 +1685,7 @@ spl_autoload_register(
         }
 
         if (isset($classes[$class])) {
-            require_once 'phar://phpunit-12.5.9.phar' . $classes[$class];
+            require_once 'phar://phpunit-13.0.0.phar' . $classes[$class];
         }
     },
     true,
@@ -2192,7 +2203,6 @@ foreach (['PHPUnitPHAR\\DeepCopy\\DeepCopy' => '/myclabs-deep-copy/DeepCopy/Deep
                 'PHPUnitPHAR\\SebastianBergmann\\Diff\\Diff' => '/sebastian-diff/Diff.php',
                 'PHPUnitPHAR\\SebastianBergmann\\Diff\\Differ' => '/sebastian-diff/Differ.php',
                 'PHPUnitPHAR\\SebastianBergmann\\Diff\\Exception' => '/sebastian-diff/Exception/Exception.php',
-                'PHPUnitPHAR\\SebastianBergmann\\Diff\\InvalidArgumentException' => '/sebastian-diff/Exception/InvalidArgumentException.php',
                 'PHPUnitPHAR\\SebastianBergmann\\Diff\\Line' => '/sebastian-diff/Line.php',
                 'PHPUnitPHAR\\SebastianBergmann\\Diff\\LongestCommonSubsequenceCalculator' => '/sebastian-diff/LongestCommonSubsequenceCalculator.php',
                 'PHPUnitPHAR\\SebastianBergmann\\Diff\\MemoryEfficientLongestCommonSubsequenceCalculator' => '/sebastian-diff/MemoryEfficientLongestCommonSubsequenceCalculator.php',
@@ -2438,6 +2448,8 @@ foreach (['PHPUnitPHAR\\DeepCopy\\DeepCopy' => '/myclabs-deep-copy/DeepCopy/Deep
                 'PHPUnit\\Event\\Test\\ComparatorRegisteredSubscriber' => '/phpunit/Event/Events/Test/ComparatorRegisteredSubscriber.php',
                 'PHPUnit\\Event\\Test\\ConsideredRisky' => '/phpunit/Event/Events/Test/Issue/ConsideredRisky.php',
                 'PHPUnit\\Event\\Test\\ConsideredRiskySubscriber' => '/phpunit/Event/Events/Test/Issue/ConsideredRiskySubscriber.php',
+                'PHPUnit\\Event\\Test\\CustomTestMethodInvocationUsed' => '/phpunit/Event/Events/Test/CustomTestMethodInvocationUsed.php',
+                'PHPUnit\\Event\\Test\\CustomTestMethodInvocationUsedSubscriber' => '/phpunit/Event/Events/Test/CustomTestMethodInvocationUsedSubscriber.php',
                 'PHPUnit\\Event\\Test\\DataProviderMethodCalled' => '/phpunit/Event/Events/Test/Lifecycle/DataProviderMethodCalled.php',
                 'PHPUnit\\Event\\Test\\DataProviderMethodCalledSubscriber' => '/phpunit/Event/Events/Test/Lifecycle/DataProviderMethodCalledSubscriber.php',
                 'PHPUnit\\Event\\Test\\DataProviderMethodFinished' => '/phpunit/Event/Events/Test/Lifecycle/DataProviderMethodFinished.php',
@@ -2572,7 +2584,6 @@ foreach (['PHPUnitPHAR\\DeepCopy\\DeepCopy' => '/myclabs-deep-copy/DeepCopy/Deep
                 'PHPUnit\\Framework\\Attributes\\RequiresPhpunit' => '/phpunit/Framework/Attributes/RequiresPhpunit.php',
                 'PHPUnit\\Framework\\Attributes\\RequiresPhpunitExtension' => '/phpunit/Framework/Attributes/RequiresPhpunitExtension.php',
                 'PHPUnit\\Framework\\Attributes\\RequiresSetting' => '/phpunit/Framework/Attributes/RequiresSetting.php',
-                'PHPUnit\\Framework\\Attributes\\RunClassInSeparateProcess' => '/phpunit/Framework/Attributes/RunClassInSeparateProcess.php',
                 'PHPUnit\\Framework\\Attributes\\RunInSeparateProcess' => '/phpunit/Framework/Attributes/RunInSeparateProcess.php',
                 'PHPUnit\\Framework\\Attributes\\RunTestsInSeparateProcesses' => '/phpunit/Framework/Attributes/RunTestsInSeparateProcesses.php',
                 'PHPUnit\\Framework\\Attributes\\Small' => '/phpunit/Framework/Attributes/Small.php',
@@ -2598,7 +2609,10 @@ foreach (['PHPUnitPHAR\\DeepCopy\\DeepCopy' => '/myclabs-deep-copy/DeepCopy/Deep
                 'PHPUnit\\Framework\\ComparisonMethodDoesNotDeclareExactlyOneParameterException' => '/phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotDeclareExactlyOneParameterException.php',
                 'PHPUnit\\Framework\\ComparisonMethodDoesNotDeclareParameterTypeException' => '/phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotDeclareParameterTypeException.php',
                 'PHPUnit\\Framework\\ComparisonMethodDoesNotExistException' => '/phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotExistException.php',
-                'PHPUnit\\Framework\\Constraint\\ArrayHasKey' => '/phpunit/Framework/Constraint/Traversable/ArrayHasKey.php',
+                'PHPUnit\\Framework\\Constraint\\ArrayComparison' => '/phpunit/Framework/Constraint/Array/ArrayComparison.php',
+                'PHPUnit\\Framework\\Constraint\\ArrayHasKey' => '/phpunit/Framework/Constraint/Array/ArrayHasKey.php',
+                'PHPUnit\\Framework\\Constraint\\ArraysAreEqual' => '/phpunit/Framework/Constraint/Array/ArraysAreEqual.php',
+                'PHPUnit\\Framework\\Constraint\\ArraysAreIdentical' => '/phpunit/Framework/Constraint/Array/ArraysAreIdentical.php',
                 'PHPUnit\\Framework\\Constraint\\BinaryOperator' => '/phpunit/Framework/Constraint/Operator/BinaryOperator.php',
                 'PHPUnit\\Framework\\Constraint\\Callback' => '/phpunit/Framework/Constraint/Callback.php',
                 'PHPUnit\\Framework\\Constraint\\Constraint' => '/phpunit/Framework/Constraint/Constraint.php',
@@ -2622,7 +2636,7 @@ foreach (['PHPUnitPHAR\\DeepCopy\\DeepCopy' => '/myclabs-deep-copy/DeepCopy/Deep
                 'PHPUnit\\Framework\\Constraint\\IsInfinite' => '/phpunit/Framework/Constraint/Math/IsInfinite.php',
                 'PHPUnit\\Framework\\Constraint\\IsInstanceOf' => '/phpunit/Framework/Constraint/Type/IsInstanceOf.php',
                 'PHPUnit\\Framework\\Constraint\\IsJson' => '/phpunit/Framework/Constraint/String/IsJson.php',
-                'PHPUnit\\Framework\\Constraint\\IsList' => '/phpunit/Framework/Constraint/Traversable/IsList.php',
+                'PHPUnit\\Framework\\Constraint\\IsList' => '/phpunit/Framework/Constraint/Array/IsList.php',
                 'PHPUnit\\Framework\\Constraint\\IsNan' => '/phpunit/Framework/Constraint/Math/IsNan.php',
                 'PHPUnit\\Framework\\Constraint\\IsNull' => '/phpunit/Framework/Constraint/Type/IsNull.php',
                 'PHPUnit\\Framework\\Constraint\\IsReadable' => '/phpunit/Framework/Constraint/Filesystem/IsReadable.php',
@@ -2664,6 +2678,7 @@ foreach (['PHPUnitPHAR\\DeepCopy\\DeepCopy' => '/myclabs-deep-copy/DeepCopy/Deep
                 'PHPUnit\\Framework\\InvalidDependencyException' => '/phpunit/Framework/Exception/InvalidDependencyException.php',
                 'PHPUnit\\Framework\\IsolatedTestRunner' => '/phpunit/Framework/TestRunner/IsolatedTestRunner.php',
                 'PHPUnit\\Framework\\IsolatedTestRunnerRegistry' => '/phpunit/Framework/TestRunner/IsolatedTestRunnerRegistry.php',
+                'PHPUnit\\Framework\\MockObject\\AbstractInvocationImplementation' => '/phpunit/Framework/MockObject/Runtime/AbstractInvocationImplementation.php',
                 'PHPUnit\\Framework\\MockObject\\BadMethodCallException' => '/phpunit/Framework/MockObject/Exception/BadMethodCallException.php',
                 'PHPUnit\\Framework\\MockObject\\CannotUseOnlyMethodsException' => '/phpunit/Framework/MockObject/Exception/CannotUseOnlyMethodsException.php',
                 'PHPUnit\\Framework\\MockObject\\ConfigurableMethod' => '/phpunit/Framework/MockObject/ConfigurableMethod.php',
@@ -2690,6 +2705,8 @@ foreach (['PHPUnitPHAR\\DeepCopy\\DeepCopy' => '/myclabs-deep-copy/DeepCopy/Deep
                 'PHPUnit\\Framework\\MockObject\\IncompatibleReturnValueException' => '/phpunit/Framework/MockObject/Exception/IncompatibleReturnValueException.php',
                 'PHPUnit\\Framework\\MockObject\\Invocation' => '/phpunit/Framework/MockObject/Runtime/Invocation.php',
                 'PHPUnit\\Framework\\MockObject\\InvocationHandler' => '/phpunit/Framework/MockObject/Runtime/InvocationHandler.php',
+                'PHPUnit\\Framework\\MockObject\\InvocationMocker' => '/phpunit/Framework/MockObject/Runtime/Interface/InvocationMocker.php',
+                'PHPUnit\\Framework\\MockObject\\InvocationMockerImplementation' => '/phpunit/Framework/MockObject/Runtime/InvocationMockerImplementation.php',
                 'PHPUnit\\Framework\\MockObject\\InvocationStubber' => '/phpunit/Framework/MockObject/Runtime/Interface/InvocationStubber.php',
                 'PHPUnit\\Framework\\MockObject\\InvocationStubberImplementation' => '/phpunit/Framework/MockObject/Runtime/InvocationStubberImplementation.php',
                 'PHPUnit\\Framework\\MockObject\\MatchBuilderNotFoundException' => '/phpunit/Framework/MockObject/Exception/MatchBuilderNotFoundException.php',
@@ -2706,6 +2723,7 @@ foreach (['PHPUnitPHAR\\DeepCopy\\DeepCopy' => '/myclabs-deep-copy/DeepCopy/Deep
                 'PHPUnit\\Framework\\MockObject\\MockObjectApi' => '/phpunit/Framework/MockObject/Runtime/Api/MockObjectApi.php',
                 'PHPUnit\\Framework\\MockObject\\MockObjectInternal' => '/phpunit/Framework/MockObject/Runtime/Interface/MockObjectInternal.php',
                 'PHPUnit\\Framework\\MockObject\\NeverReturningMethodException' => '/phpunit/Framework/MockObject/Exception/NeverReturningMethodException.php',
+                'PHPUnit\\Framework\\MockObject\\NoMoreParameterSetsConfiguredException' => '/phpunit/Framework/MockObject/Exception/NoMoreParameterSetsConfiguredException.php',
                 'PHPUnit\\Framework\\MockObject\\NoMoreReturnValuesConfiguredException' => '/phpunit/Framework/MockObject/Exception/NoMoreReturnValuesConfiguredException.php',
                 'PHPUnit\\Framework\\MockObject\\ProxiedCloneMethod' => '/phpunit/Framework/MockObject/Runtime/Api/ProxiedCloneMethod.php',
                 'PHPUnit\\Framework\\MockObject\\ReturnValueGenerator' => '/phpunit/Framework/MockObject/Runtime/ReturnValueGenerator.php',
@@ -2718,8 +2736,10 @@ foreach (['PHPUnitPHAR\\DeepCopy\\DeepCopy' => '/myclabs-deep-copy/DeepCopy/Deep
                 'PHPUnit\\Framework\\MockObject\\Rule\\InvokedAtMostCount' => '/phpunit/Framework/MockObject/Runtime/Rule/InvokedAtMostCount.php',
                 'PHPUnit\\Framework\\MockObject\\Rule\\InvokedCount' => '/phpunit/Framework/MockObject/Runtime/Rule/InvokedCount.php',
                 'PHPUnit\\Framework\\MockObject\\Rule\\MethodName' => '/phpunit/Framework/MockObject/Runtime/Rule/MethodName.php',
+                'PHPUnit\\Framework\\MockObject\\Rule\\OrderedParameterSets' => '/phpunit/Framework/MockObject/Runtime/Rule/OrderedParameterSets.php',
                 'PHPUnit\\Framework\\MockObject\\Rule\\Parameters' => '/phpunit/Framework/MockObject/Runtime/Rule/Parameters.php',
                 'PHPUnit\\Framework\\MockObject\\Rule\\ParametersRule' => '/phpunit/Framework/MockObject/Runtime/Rule/ParametersRule.php',
+                'PHPUnit\\Framework\\MockObject\\Rule\\UnorderedParameterSets' => '/phpunit/Framework/MockObject/Runtime/Rule/UnorderedParameterSets.php',
                 'PHPUnit\\Framework\\MockObject\\RuntimeException' => '/phpunit/Framework/MockObject/Exception/RuntimeException.php',
                 'PHPUnit\\Framework\\MockObject\\Runtime\\PropertyGetHook' => '/phpunit/Framework/MockObject/Runtime/PropertyHook/PropertyGetHook.php',
                 'PHPUnit\\Framework\\MockObject\\Runtime\\PropertyHook' => '/phpunit/Framework/MockObject/Runtime/PropertyHook/PropertyHook.php',
@@ -2737,6 +2757,7 @@ foreach (['PHPUnitPHAR\\DeepCopy\\DeepCopy' => '/myclabs-deep-copy/DeepCopy/Deep
                 'PHPUnit\\Framework\\MockObject\\Stub\\ReturnValueMap' => '/phpunit/Framework/MockObject/Runtime/Stub/ReturnValueMap.php',
                 'PHPUnit\\Framework\\MockObject\\Stub\\Stub' => '/phpunit/Framework/MockObject/Runtime/Stub/Stub.php',
                 'PHPUnit\\Framework\\MockObject\\TestDoubleBuilder' => '/phpunit/Framework/MockObject/TestDoubleBuilder.php',
+                'PHPUnit\\Framework\\MockObject\\TestDoubleSealedException' => '/phpunit/Framework/MockObject/Exception/TestDoubleSealedException.php',
                 'PHPUnit\\Framework\\MockObject\\TestDoubleState' => '/phpunit/Framework/MockObject/Runtime/Api/TestDoubleState.php',
                 'PHPUnit\\Framework\\MockObject\\TestStubBuilder' => '/phpunit/Framework/MockObject/TestStubBuilder.php',
                 'PHPUnit\\Framework\\NativeType' => '/phpunit/Framework/NativeType.php',
@@ -2889,6 +2910,7 @@ foreach (['PHPUnitPHAR\\DeepCopy\\DeepCopy' => '/myclabs-deep-copy/DeepCopy/Deep
                 'PHPUnit\\Metadata\\IgnorePhpunitWarnings' => '/phpunit/Metadata/IgnorePhpunitWarnings.php',
                 'PHPUnit\\Metadata\\InvalidAttributeException' => '/phpunit/Metadata/Exception/InvalidAttributeException.php',
                 'PHPUnit\\Metadata\\InvalidVersionRequirementException' => '/phpunit/Metadata/Exception/InvalidVersionRequirementException.php',
+                'PHPUnit\\Metadata\\Level' => '/phpunit/Metadata/Level.php',
                 'PHPUnit\\Metadata\\Metadata' => '/phpunit/Metadata/Metadata.php',
                 'PHPUnit\\Metadata\\MetadataCollection' => '/phpunit/Metadata/MetadataCollection.php',
                 'PHPUnit\\Metadata\\MetadataCollectionIterator' => '/phpunit/Metadata/MetadataCollectionIterator.php',
@@ -2910,7 +2932,6 @@ foreach (['PHPUnitPHAR\\DeepCopy\\DeepCopy' => '/myclabs-deep-copy/DeepCopy/Deep
                 'PHPUnit\\Metadata\\RequiresPhpunit' => '/phpunit/Metadata/RequiresPhpunit.php',
                 'PHPUnit\\Metadata\\RequiresPhpunitExtension' => '/phpunit/Metadata/RequiresPhpunitExtension.php',
                 'PHPUnit\\Metadata\\RequiresSetting' => '/phpunit/Metadata/RequiresSetting.php',
-                'PHPUnit\\Metadata\\RunClassInSeparateProcess' => '/phpunit/Metadata/RunClassInSeparateProcess.php',
                 'PHPUnit\\Metadata\\RunInSeparateProcess' => '/phpunit/Metadata/RunInSeparateProcess.php',
                 'PHPUnit\\Metadata\\RunTestsInSeparateProcesses' => '/phpunit/Metadata/RunTestsInSeparateProcesses.php',
                 'PHPUnit\\Metadata\\Test' => '/phpunit/Metadata/Test.php',
@@ -3109,6 +3130,7 @@ foreach (['PHPUnitPHAR\\DeepCopy\\DeepCopy' => '/myclabs-deep-copy/DeepCopy/Deep
                 'PHPUnit\\TextUI\\Configuration\\NoCustomCssFileException' => '/phpunit/TextUI/Configuration/Exception/NoCustomCssFileException.php',
                 'PHPUnit\\TextUI\\Configuration\\NoDefaultTestSuiteException' => '/phpunit/TextUI/Configuration/Exception/NoDefaultTestSuiteException.php',
                 'PHPUnit\\TextUI\\Configuration\\NoPharExtensionDirectoryException' => '/phpunit/TextUI/Configuration/Exception/NoPharExtensionDirectoryException.php',
+                'PHPUnit\\TextUI\\Configuration\\NoTestFilesFileException' => '/phpunit/TextUI/Configuration/Exception/NoTestFilesFileException.php',
                 'PHPUnit\\TextUI\\Configuration\\Php' => '/phpunit/TextUI/Configuration/Value/Php.php',
                 'PHPUnit\\TextUI\\Configuration\\PhpHandler' => '/phpunit/TextUI/Configuration/PhpHandler.php',
                 'PHPUnit\\TextUI\\Configuration\\Registry' => '/phpunit/TextUI/Configuration/Registry.php',
@@ -3269,7 +3291,7 @@ foreach (['PHPUnitPHAR\\DeepCopy\\DeepCopy' => '/myclabs-deep-copy/DeepCopy/Deep
                 'PHPUnit\\Util\\Xml' => '/phpunit/Util/Xml/Xml.php',
                 'PHPUnit\\Util\\Xml\\Loader' => '/phpunit/Util/Xml/Loader.php',
                 'PHPUnit\\Util\\Xml\\XmlException' => '/phpunit/Util/Exception/XmlException.php'] as $file) {
-    require_once 'phar://phpunit-12.5.9.phar' . $file;
+    require_once 'phar://phpunit-13.0.0.phar' . $file;
 }
 
 require __PHPUNIT_PHAR_ROOT__ . '/phpunit/Framework/Assert/Functions.php';
@@ -3299,110 +3321,115 @@ if ($execute) {
 }
 
 __HALT_COMPILER(); ?>
-|          phpunit-12.5.9.phar       composer.lock¿å  EN„i¿å  ß'ª‘¤         manifest.txtÄ  EN„iÄ  Ù“^}¤      '   myclabs-deep-copy/DeepCopy/DeepCopy.php@!  EN„i@!  në=¤      7   myclabs-deep-copy/DeepCopy/Exception/CloneException.phpŠ   EN„iŠ   JDéÈ¤      :   myclabs-deep-copy/DeepCopy/Exception/PropertyException.phpƒ   EN„iƒ   o‘¼#¤      5   myclabs-deep-copy/DeepCopy/Filter/ChainableFilter.phpË  EN„iË  –=(e¤      G   myclabs-deep-copy/DeepCopy/Filter/Doctrine/DoctrineCollectionFilter.phpL  EN„iL  6b]U¤      L   myclabs-deep-copy/DeepCopy/Filter/Doctrine/DoctrineEmptyCollectionFilter.php%  EN„i%  Œd²-¤      B   myclabs-deep-copy/DeepCopy/Filter/Doctrine/DoctrineProxyFilter.phpª  EN„iª  fQc_¤      ,   myclabs-deep-copy/DeepCopy/Filter/Filter.phph  EN„ih  ¸ß½¤      0   myclabs-deep-copy/DeepCopy/Filter/KeepFilter.php  EN„i  ÿ7#¤      3   myclabs-deep-copy/DeepCopy/Filter/ReplaceFilter.phpÙ  EN„iÙ  ²{C¤      3   myclabs-deep-copy/DeepCopy/Filter/SetNullFilter.php.  EN„i.  ~ğ^¤      D   myclabs-deep-copy/DeepCopy/Matcher/Doctrine/DoctrineProxyMatcher.php‹  EN„i‹  ‹3ä¤      .   myclabs-deep-copy/DeepCopy/Matcher/Matcher.phpá   EN„iá   ÈfËÃ¤      6   myclabs-deep-copy/DeepCopy/Matcher/PropertyMatcher.phpº  EN„iº  İÀA^¤      :   myclabs-deep-copy/DeepCopy/Matcher/PropertyNameMatcher.php  EN„i  Ñì¡P¤      :   myclabs-deep-copy/DeepCopy/Matcher/PropertyTypeMatcher.phpn  EN„in  m$Ãu¤      :   myclabs-deep-copy/DeepCopy/Reflection/ReflectionHelper.php9  EN„i9  1•¦†¤      A   myclabs-deep-copy/DeepCopy/TypeFilter/Date/DateIntervalFilter.php“  EN„i“  [‚ã¤      ?   myclabs-deep-copy/DeepCopy/TypeFilter/Date/DatePeriodFilter.php`  EN„i`  m9£œ¤      7   myclabs-deep-copy/DeepCopy/TypeFilter/ReplaceFilter.php  EN„i  »8;¤      ;   myclabs-deep-copy/DeepCopy/TypeFilter/ShallowCopyFilter.phpë   EN„ië   F_e ¤      ?   myclabs-deep-copy/DeepCopy/TypeFilter/Spl/ArrayObjectFilter.phpğ  EN„iğ  £Ø©¤      A   myclabs-deep-copy/DeepCopy/TypeFilter/Spl/SplDoublyLinkedList.php¼   EN„i¼   Kí”¤      G   myclabs-deep-copy/DeepCopy/TypeFilter/Spl/SplDoublyLinkedListFilter.php*  EN„i*  L-Ø ¤      4   myclabs-deep-copy/DeepCopy/TypeFilter/TypeFilter.phpÎ   EN„iÎ   ÔŠ‡¤      6   myclabs-deep-copy/DeepCopy/TypeMatcher/TypeMatcher.phpŞ  EN„iŞ  û×$¤      (   myclabs-deep-copy/DeepCopy/deep_copy.php¥  EN„i¥  ¢WÈ•¤         myclabs-deep-copy/LICENSE5  EN„i5  Ê­Ë„¤         nikic-php-parser/LICENSEğ  EN„iğ  ¥ä”*¤      &   nikic-php-parser/PhpParser/Builder.php×   EN„i×   ’[uÌ¤      1   nikic-php-parser/PhpParser/Builder/ClassConst.php;  EN„i;  (kïü¤      -   nikic-php-parser/PhpParser/Builder/Class_.phpk  EN„ik  ÓŞQ¤      2   nikic-php-parser/PhpParser/Builder/Declaration.phpş  EN„iş  `X:¤      /   nikic-php-parser/PhpParser/Builder/EnumCase.phpÖ  EN„iÖ  È¸Ú¤      ,   nikic-php-parser/PhpParser/Builder/Enum_.phpà  EN„ià  ÅUfƒ¤      3   nikic-php-parser/PhpParser/Builder/FunctionLike.php9  EN„i9  B¹ã¤      0   nikic-php-parser/PhpParser/Builder/Function_.php‹  EN„i‹  ¥33A¤      1   nikic-php-parser/PhpParser/Builder/Interface_.phph
-  EN„ih
-  £‹·|¤      -   nikic-php-parser/PhpParser/Builder/Method.php§  EN„i§  Ú·t„¤      1   nikic-php-parser/PhpParser/Builder/Namespace_.phpu  EN„iu  Öî¤      ,   nikic-php-parser/PhpParser/Builder/Param.php¬  EN„i¬  _ë¨Š¤      /   nikic-php-parser/PhpParser/Builder/Property.phpx  EN„ix  VÆnâ¤      /   nikic-php-parser/PhpParser/Builder/TraitUse.php¼  EN„i¼  !rÑ¤      9   nikic-php-parser/PhpParser/Builder/TraitUseAdaptation.phpú  EN„iú  Œ0¤      -   nikic-php-parser/PhpParser/Builder/Trait_.php4	  EN„i4	  ëÑ¬Z¤      +   nikic-php-parser/PhpParser/Builder/Use_.php,  EN„i,  K,g¤      -   nikic-php-parser/PhpParser/BuilderFactory.php)  EN„i)   –Ò½¤      -   nikic-php-parser/PhpParser/BuilderHelpers.phpl%  EN„il%  ‚^Š[¤      &   nikic-php-parser/PhpParser/Comment.php  EN„i  VUG¤      *   nikic-php-parser/PhpParser/Comment/Doc.php€   EN„i€   Íè¢¤      ;   nikic-php-parser/PhpParser/ConstExprEvaluationException.php}   EN„i}   ÍŞO¤      1   nikic-php-parser/PhpParser/ConstExprEvaluator.php&  EN„i&  V7=å¤      $   nikic-php-parser/PhpParser/Error.php]  EN„i]  ×:¸¤      +   nikic-php-parser/PhpParser/ErrorHandler.php9  EN„i9  –yo¤      6   nikic-php-parser/PhpParser/ErrorHandler/Collecting.php•  EN„i•  HÏr(¤      4   nikic-php-parser/PhpParser/ErrorHandler/Throwing.php˜  EN„i˜  Îr¾£¤      0   nikic-php-parser/PhpParser/Internal/DiffElem.php
-  EN„i
-  à_P¤      .   nikic-php-parser/PhpParser/Internal/Differ.phpÇ  EN„iÇ  d;v,¤      A   nikic-php-parser/PhpParser/Internal/PrintableNewAnonClassNode.phpe
-  EN„ie
-  ²G×o¤      5   nikic-php-parser/PhpParser/Internal/TokenPolyfill.php·$  EN„i·$  wdz®¤      3   nikic-php-parser/PhpParser/Internal/TokenStream.php£#  EN„i£#  GzÙ¤      *   nikic-php-parser/PhpParser/JsonDecoder.php®  EN„i®  
-øn¤      $   nikic-php-parser/PhpParser/Lexer.php(  EN„i(  &Àì ¤      .   nikic-php-parser/PhpParser/Lexer/Emulative.phpû   EN„iû   YÃøI¤      T   nikic-php-parser/PhpParser/Lexer/TokenEmulator/AsymmetricVisibilityTokenEmulator.php²  EN„i²  ÑÆÍ¤      D   nikic-php-parser/PhpParser/Lexer/TokenEmulator/AttributeEmulator.phpÏ  EN„iÏ  æ	g$¤      D   nikic-php-parser/PhpParser/Lexer/TokenEmulator/EnumTokenEmulator.php¾  EN„i¾  ¿¾¤      H   nikic-php-parser/PhpParser/Lexer/TokenEmulator/ExplicitOctalEmulator.php  EN„i  HU¨j¤      B   nikic-php-parser/PhpParser/Lexer/TokenEmulator/KeywordEmulator.php2  EN„i2  $ĞG­¤      E   nikic-php-parser/PhpParser/Lexer/TokenEmulator/MatchTokenEmulator.phpÈ  EN„iÈ  Â9æG¤      H   nikic-php-parser/PhpParser/Lexer/TokenEmulator/NullsafeTokenEmulator.php-  EN„i-  [SÅ¤      G   nikic-php-parser/PhpParser/Lexer/TokenEmulator/PipeOperatorEmulator.php€  EN„i€  ÷uMß¤      H   nikic-php-parser/PhpParser/Lexer/TokenEmulator/PropertyTokenEmulator.php×  EN„i×  ü4"Ù¤      P   nikic-php-parser/PhpParser/Lexer/TokenEmulator/ReadonlyFunctionTokenEmulator.phpõ  EN„iõ  ÜP“Î¤      H   nikic-php-parser/PhpParser/Lexer/TokenEmulator/ReadonlyTokenEmulator.phpd  EN„id  /Cê¤      B   nikic-php-parser/PhpParser/Lexer/TokenEmulator/ReverseEmulator.php  EN„i  ï—‚Ù¤      @   nikic-php-parser/PhpParser/Lexer/TokenEmulator/TokenEmulator.phpW  EN„iW  3˜ù¤      C   nikic-php-parser/PhpParser/Lexer/TokenEmulator/VoidCastEmulator.php*  EN„i*  q	ô„¤      (   nikic-php-parser/PhpParser/Modifiers.phpF
-  EN„iF
-  `Ø¤      *   nikic-php-parser/PhpParser/NameContext.php&  EN„i&   8ÄÕ¤      #   nikic-php-parser/PhpParser/Node.php  EN„i  ¶h¦m¤      '   nikic-php-parser/PhpParser/Node/Arg.php   EN„i   #Eªˆ¤      -   nikic-php-parser/PhpParser/Node/ArrayItem.phpŞ  EN„iŞ  ¸ªÙİ¤      -   nikic-php-parser/PhpParser/Node/Attribute.php`  EN„i`  –vÂ¤      2   nikic-php-parser/PhpParser/Node/AttributeGroup.php¨  EN„i¨  GãiÊ¤      .   nikic-php-parser/PhpParser/Node/ClosureUse.phpî  EN„iî  \±jt¤      /   nikic-php-parser/PhpParser/Node/ComplexType.php[  EN„i[  š0Us¤      *   nikic-php-parser/PhpParser/Node/Const_.phpë  EN„ië  T¼=y¤      /   nikic-php-parser/PhpParser/Node/DeclareItem.php  EN„i  ¸o#¤      (   nikic-php-parser/PhpParser/Node/Expr.php   EN„i   |Å)¬¤      6   nikic-php-parser/PhpParser/Node/Expr/ArrayDimFetch.phpW  EN„iW  Sé!¤      /   nikic-php-parser/PhpParser/Node/Expr/Array_.phpr  EN„ir  Â§sG¤      6   nikic-php-parser/PhpParser/Node/Expr/ArrowFunction.php>
-  EN„i>
-  «ÚM¤      /   nikic-php-parser/PhpParser/Node/Expr/Assign.php'  EN„i'  0)œ
-¤      1   nikic-php-parser/PhpParser/Node/Expr/AssignOp.phpô  EN„iô  ¢Œb/¤      <   nikic-php-parser/PhpParser/Node/Expr/AssignOp/BitwiseAnd.php  EN„i  Æ?Q¤      ;   nikic-php-parser/PhpParser/Node/Expr/AssignOp/BitwiseOr.php  EN„i  )Şñ¤      <   nikic-php-parser/PhpParser/Node/Expr/AssignOp/BitwiseXor.php  EN„i  &ÉTş¤      :   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Coalesce.php  EN„i  9˜·¤¤      8   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Concat.phpÿ   EN„iÿ   GÅ3¤      5   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Div.phpù   EN„iù   ÍÔ/¤      7   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Minus.phpı   EN„iı   ¦„¶c¤      5   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Mod.phpù   EN„iù   ÃjŒ¤      5   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Mul.phpù   EN„iù   Y:Å;¤      6   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Plus.phpû   EN„iû   KÍã]¤      5   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Pow.phpù   EN„iù   ßŠÍA¤      ;   nikic-php-parser/PhpParser/Node/Expr/AssignOp/ShiftLeft.php  EN„i  –(?¤      <   nikic-php-parser/PhpParser/Node/Expr/AssignOp/ShiftRight.php  EN„i  ®·íâ¤      2   nikic-php-parser/PhpParser/Node/Expr/AssignRef.phpX  EN„iX  [—·¤      1   nikic-php-parser/PhpParser/Node/Expr/BinaryOp.phpd  EN„id  ñ`˜­¤      <   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/BitwiseAnd.phpV  EN„iV  NVD¤      ;   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/BitwiseOr.phpT  EN„iT  İŸ¤      <   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/BitwiseXor.phpV  EN„iV  à3$¶¤      <   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/BooleanAnd.phpW  EN„iW  ú€İÿ¤      ;   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/BooleanOr.phpU  EN„iU  ‰¡G¤      :   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Coalesce.phpS  EN„iS  ¯ /à¤      8   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Concat.phpN  EN„iN  ¶€¤      5   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Div.phpH  EN„iH  ¨A+¤      7   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Equal.phpM  EN„iM  á$3¤      9   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Greater.phpP  EN„iP  X‡Š¤      @   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/GreaterOrEqual.php_  EN„i_  ³Âå¤      ;   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Identical.phpV  EN„iV  ´Ğã¤      <   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/LogicalAnd.phpX  EN„iX  Fü—=¤      ;   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/LogicalOr.phpU  EN„iU  -”š3¤      <   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/LogicalXor.phpX  EN„iX  ŞÁŠé¤      7   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Minus.phpL  EN„iL  "7®æ¤      5   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Mod.phpH  EN„iH  Ó
+W ›         phpunit-13.0.0.phar       composer.lockKö  ©t…iKö  "ÙÛ¤         manifest.txtÄ  ©t…iÄ   ş™Ø¤      '   myclabs-deep-copy/DeepCopy/DeepCopy.php@!  ©t…i@!  në=¤      7   myclabs-deep-copy/DeepCopy/Exception/CloneException.phpŠ   ©t…iŠ   JDéÈ¤      :   myclabs-deep-copy/DeepCopy/Exception/PropertyException.phpƒ   ©t…iƒ   o‘¼#¤      5   myclabs-deep-copy/DeepCopy/Filter/ChainableFilter.phpË  ©t…iË  –=(e¤      G   myclabs-deep-copy/DeepCopy/Filter/Doctrine/DoctrineCollectionFilter.phpL  ©t…iL  6b]U¤      L   myclabs-deep-copy/DeepCopy/Filter/Doctrine/DoctrineEmptyCollectionFilter.php%  ©t…i%  Œd²-¤      B   myclabs-deep-copy/DeepCopy/Filter/Doctrine/DoctrineProxyFilter.phpª  ©t…iª  fQc_¤      ,   myclabs-deep-copy/DeepCopy/Filter/Filter.phph  ©t…ih  ¸ß½¤      0   myclabs-deep-copy/DeepCopy/Filter/KeepFilter.php  ©t…i  ÿ7#¤      3   myclabs-deep-copy/DeepCopy/Filter/ReplaceFilter.phpÙ  ©t…iÙ  ²{C¤      3   myclabs-deep-copy/DeepCopy/Filter/SetNullFilter.php.  ©t…i.  ~ğ^¤      D   myclabs-deep-copy/DeepCopy/Matcher/Doctrine/DoctrineProxyMatcher.php‹  ©t…i‹  ‹3ä¤      .   myclabs-deep-copy/DeepCopy/Matcher/Matcher.phpá   ©t…iá   ÈfËÃ¤      6   myclabs-deep-copy/DeepCopy/Matcher/PropertyMatcher.phpº  ©t…iº  İÀA^¤      :   myclabs-deep-copy/DeepCopy/Matcher/PropertyNameMatcher.php  ©t…i  Ñì¡P¤      :   myclabs-deep-copy/DeepCopy/Matcher/PropertyTypeMatcher.phpn  ©t…in  m$Ãu¤      :   myclabs-deep-copy/DeepCopy/Reflection/ReflectionHelper.php9  ©t…i9  1•¦†¤      A   myclabs-deep-copy/DeepCopy/TypeFilter/Date/DateIntervalFilter.php“  ©t…i“  [‚ã¤      ?   myclabs-deep-copy/DeepCopy/TypeFilter/Date/DatePeriodFilter.php`  ©t…i`  m9£œ¤      7   myclabs-deep-copy/DeepCopy/TypeFilter/ReplaceFilter.php  ©t…i  »8;¤      ;   myclabs-deep-copy/DeepCopy/TypeFilter/ShallowCopyFilter.phpë   ©t…ië   F_e ¤      ?   myclabs-deep-copy/DeepCopy/TypeFilter/Spl/ArrayObjectFilter.phpğ  ©t…iğ  £Ø©¤      A   myclabs-deep-copy/DeepCopy/TypeFilter/Spl/SplDoublyLinkedList.php¼   ©t…i¼   Kí”¤      G   myclabs-deep-copy/DeepCopy/TypeFilter/Spl/SplDoublyLinkedListFilter.php*  ©t…i*  L-Ø ¤      4   myclabs-deep-copy/DeepCopy/TypeFilter/TypeFilter.phpÎ   ©t…iÎ   ÔŠ‡¤      6   myclabs-deep-copy/DeepCopy/TypeMatcher/TypeMatcher.phpŞ  ©t…iŞ  û×$¤      (   myclabs-deep-copy/DeepCopy/deep_copy.php¥  ©t…i¥  ¢WÈ•¤         myclabs-deep-copy/LICENSE5  ©t…i5  Ê­Ë„¤         nikic-php-parser/LICENSEğ  ©t…iğ  ¥ä”*¤      &   nikic-php-parser/PhpParser/Builder.php×   ©t…i×   ’[uÌ¤      1   nikic-php-parser/PhpParser/Builder/ClassConst.php;  ©t…i;  (kïü¤      -   nikic-php-parser/PhpParser/Builder/Class_.phpk  ©t…ik  ÓŞQ¤      2   nikic-php-parser/PhpParser/Builder/Declaration.phpş  ©t…iş  `X:¤      /   nikic-php-parser/PhpParser/Builder/EnumCase.phpÖ  ©t…iÖ  È¸Ú¤      ,   nikic-php-parser/PhpParser/Builder/Enum_.phpà  ©t…ià  ÅUfƒ¤      3   nikic-php-parser/PhpParser/Builder/FunctionLike.php9  ©t…i9  B¹ã¤      0   nikic-php-parser/PhpParser/Builder/Function_.php‹  ©t…i‹  ¥33A¤      1   nikic-php-parser/PhpParser/Builder/Interface_.phph
+  ©t…ih
+  £‹·|¤      -   nikic-php-parser/PhpParser/Builder/Method.php§  ©t…i§  Ú·t„¤      1   nikic-php-parser/PhpParser/Builder/Namespace_.phpu  ©t…iu  Öî¤      ,   nikic-php-parser/PhpParser/Builder/Param.php¬  ©t…i¬  _ë¨Š¤      /   nikic-php-parser/PhpParser/Builder/Property.phpx  ©t…ix  VÆnâ¤      /   nikic-php-parser/PhpParser/Builder/TraitUse.php¼  ©t…i¼  !rÑ¤      9   nikic-php-parser/PhpParser/Builder/TraitUseAdaptation.phpú  ©t…iú  Œ0¤      -   nikic-php-parser/PhpParser/Builder/Trait_.php4	  ©t…i4	  ëÑ¬Z¤      +   nikic-php-parser/PhpParser/Builder/Use_.php,  ©t…i,  K,g¤      -   nikic-php-parser/PhpParser/BuilderFactory.php)  ©t…i)   –Ò½¤      -   nikic-php-parser/PhpParser/BuilderHelpers.phpl%  ©t…il%  ‚^Š[¤      &   nikic-php-parser/PhpParser/Comment.php  ©t…i  VUG¤      *   nikic-php-parser/PhpParser/Comment/Doc.php€   ©t…i€   Íè¢¤      ;   nikic-php-parser/PhpParser/ConstExprEvaluationException.php}   ©t…i}   ÍŞO¤      1   nikic-php-parser/PhpParser/ConstExprEvaluator.php&  ©t…i&  V7=å¤      $   nikic-php-parser/PhpParser/Error.php]  ©t…i]  ×:¸¤      +   nikic-php-parser/PhpParser/ErrorHandler.php9  ©t…i9  –yo¤      6   nikic-php-parser/PhpParser/ErrorHandler/Collecting.php•  ©t…i•  HÏr(¤      4   nikic-php-parser/PhpParser/ErrorHandler/Throwing.php˜  ©t…i˜  Îr¾£¤      0   nikic-php-parser/PhpParser/Internal/DiffElem.php
+  ©t…i
+  à_P¤      .   nikic-php-parser/PhpParser/Internal/Differ.phpÇ  ©t…iÇ  d;v,¤      A   nikic-php-parser/PhpParser/Internal/PrintableNewAnonClassNode.phpe
+  ©t…ie
+  ²G×o¤      5   nikic-php-parser/PhpParser/Internal/TokenPolyfill.php·$  ©t…i·$  wdz®¤      3   nikic-php-parser/PhpParser/Internal/TokenStream.php£#  ©t…i£#  GzÙ¤      *   nikic-php-parser/PhpParser/JsonDecoder.php®  ©t…i®  
+øn¤      $   nikic-php-parser/PhpParser/Lexer.php(  ©t…i(  &Àì ¤      .   nikic-php-parser/PhpParser/Lexer/Emulative.phpû   ©t…iû   YÃøI¤      T   nikic-php-parser/PhpParser/Lexer/TokenEmulator/AsymmetricVisibilityTokenEmulator.php²  ©t…i²  ÑÆÍ¤      D   nikic-php-parser/PhpParser/Lexer/TokenEmulator/AttributeEmulator.phpÏ  ©t…iÏ  æ	g$¤      D   nikic-php-parser/PhpParser/Lexer/TokenEmulator/EnumTokenEmulator.php¾  ©t…i¾  ¿¾¤      H   nikic-php-parser/PhpParser/Lexer/TokenEmulator/ExplicitOctalEmulator.php  ©t…i  HU¨j¤      B   nikic-php-parser/PhpParser/Lexer/TokenEmulator/KeywordEmulator.php2  ©t…i2  $ĞG­¤      E   nikic-php-parser/PhpParser/Lexer/TokenEmulator/MatchTokenEmulator.phpÈ  ©t…iÈ  Â9æG¤      H   nikic-php-parser/PhpParser/Lexer/TokenEmulator/NullsafeTokenEmulator.php-  ©t…i-  [SÅ¤      G   nikic-php-parser/PhpParser/Lexer/TokenEmulator/PipeOperatorEmulator.php€  ©t…i€  ÷uMß¤      H   nikic-php-parser/PhpParser/Lexer/TokenEmulator/PropertyTokenEmulator.php×  ©t…i×  ü4"Ù¤      P   nikic-php-parser/PhpParser/Lexer/TokenEmulator/ReadonlyFunctionTokenEmulator.phpõ  ©t…iõ  ÜP“Î¤      H   nikic-php-parser/PhpParser/Lexer/TokenEmulator/ReadonlyTokenEmulator.phpd  ©t…id  /Cê¤      B   nikic-php-parser/PhpParser/Lexer/TokenEmulator/ReverseEmulator.php  ©t…i  ï—‚Ù¤      @   nikic-php-parser/PhpParser/Lexer/TokenEmulator/TokenEmulator.phpW  ©t…iW  3˜ù¤      C   nikic-php-parser/PhpParser/Lexer/TokenEmulator/VoidCastEmulator.php*  ©t…i*  q	ô„¤      (   nikic-php-parser/PhpParser/Modifiers.phpF
+  ©t…iF
+  `Ø¤      *   nikic-php-parser/PhpParser/NameContext.php&  ©t…i&   8ÄÕ¤      #   nikic-php-parser/PhpParser/Node.php  ©t…i  ¶h¦m¤      '   nikic-php-parser/PhpParser/Node/Arg.php   ©t…i   #Eªˆ¤      -   nikic-php-parser/PhpParser/Node/ArrayItem.phpŞ  ©t…iŞ  ¸ªÙİ¤      -   nikic-php-parser/PhpParser/Node/Attribute.php`  ©t…i`  –vÂ¤      2   nikic-php-parser/PhpParser/Node/AttributeGroup.php¨  ©t…i¨  GãiÊ¤      .   nikic-php-parser/PhpParser/Node/ClosureUse.phpî  ©t…iî  \±jt¤      /   nikic-php-parser/PhpParser/Node/ComplexType.php[  ©t…i[  š0Us¤      *   nikic-php-parser/PhpParser/Node/Const_.phpë  ©t…ië  T¼=y¤      /   nikic-php-parser/PhpParser/Node/DeclareItem.php  ©t…i  ¸o#¤      (   nikic-php-parser/PhpParser/Node/Expr.php   ©t…i   |Å)¬¤      6   nikic-php-parser/PhpParser/Node/Expr/ArrayDimFetch.phpW  ©t…iW  Sé!¤      /   nikic-php-parser/PhpParser/Node/Expr/Array_.phpr  ©t…ir  Â§sG¤      6   nikic-php-parser/PhpParser/Node/Expr/ArrowFunction.php>
+  ©t…i>
+  «ÚM¤      /   nikic-php-parser/PhpParser/Node/Expr/Assign.php'  ©t…i'  0)œ
+¤      1   nikic-php-parser/PhpParser/Node/Expr/AssignOp.phpô  ©t…iô  ¢Œb/¤      <   nikic-php-parser/PhpParser/Node/Expr/AssignOp/BitwiseAnd.php  ©t…i  Æ?Q¤      ;   nikic-php-parser/PhpParser/Node/Expr/AssignOp/BitwiseOr.php  ©t…i  )Şñ¤      <   nikic-php-parser/PhpParser/Node/Expr/AssignOp/BitwiseXor.php  ©t…i  &ÉTş¤      :   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Coalesce.php  ©t…i  9˜·¤¤      8   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Concat.phpÿ   ©t…iÿ   GÅ3¤      5   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Div.phpù   ©t…iù   ÍÔ/¤      7   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Minus.phpı   ©t…iı   ¦„¶c¤      5   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Mod.phpù   ©t…iù   ÃjŒ¤      5   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Mul.phpù   ©t…iù   Y:Å;¤      6   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Plus.phpû   ©t…iû   KÍã]¤      5   nikic-php-parser/PhpParser/Node/Expr/AssignOp/Pow.phpù   ©t…iù   ßŠÍA¤      ;   nikic-php-parser/PhpParser/Node/Expr/AssignOp/ShiftLeft.php  ©t…i  –(?¤      <   nikic-php-parser/PhpParser/Node/Expr/AssignOp/ShiftRight.php  ©t…i  ®·íâ¤      2   nikic-php-parser/PhpParser/Node/Expr/AssignRef.phpX  ©t…iX  [—·¤      1   nikic-php-parser/PhpParser/Node/Expr/BinaryOp.phpd  ©t…id  ñ`˜­¤      <   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/BitwiseAnd.phpV  ©t…iV  NVD¤      ;   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/BitwiseOr.phpT  ©t…iT  İŸ¤      <   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/BitwiseXor.phpV  ©t…iV  à3$¶¤      <   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/BooleanAnd.phpW  ©t…iW  ú€İÿ¤      ;   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/BooleanOr.phpU  ©t…iU  ‰¡G¤      :   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Coalesce.phpS  ©t…iS  ¯ /à¤      8   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Concat.phpN  ©t…iN  ¶€¤      5   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Div.phpH  ©t…iH  ¨A+¤      7   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Equal.phpM  ©t…iM  á$3¤      9   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Greater.phpP  ©t…iP  X‡Š¤      @   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/GreaterOrEqual.php_  ©t…i_  ³Âå¤      ;   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Identical.phpV  ©t…iV  ´Ğã¤      <   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/LogicalAnd.phpX  ©t…iX  Fü—=¤      ;   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/LogicalOr.phpU  ©t…iU  -”š3¤      <   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/LogicalXor.phpX  ©t…iX  ŞÁŠé¤      7   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Minus.phpL  ©t…iL  "7®æ¤      5   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Mod.phpH  ©t…iH  Ó
 
-ñ¤      5   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Mul.phpH  EN„iH  	œt¤      :   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/NotEqual.phpS  EN„iS  ¨½£Í¤      >   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/NotIdentical.php\  EN„i\  õc_¤      6   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Pipe.phpK  EN„iK  uõ$¤      6   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Plus.phpJ  EN„iJ  cmÂ¤      5   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Pow.phpI  EN„iI  ­Ş,ô¤      ;   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/ShiftLeft.phpU  EN„iU  C”Xe¤      <   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/ShiftRight.phpW  EN„iW  ü;‘¤      9   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Smaller.phpP  EN„iP  T— å¤      @   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/SmallerOrEqual.php_  EN„i_  èJ³¤      ;   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Spaceship.phpV  EN„iV  ã”Ex¤      3   nikic-php-parser/PhpParser/Node/Expr/BitwiseNot.php­  EN„i­  }lMË¤      3   nikic-php-parser/PhpParser/Node/Expr/BooleanNot.php­  EN„i­  sÂ7Ş¤      1   nikic-php-parser/PhpParser/Node/Expr/CallLike.php  EN„i  ö$‘b¤      -   nikic-php-parser/PhpParser/Node/Expr/Cast.phpU  EN„iU  ¼ö³ğ¤      4   nikic-php-parser/PhpParser/Node/Expr/Cast/Array_.phpî   EN„iî   È¯¾š¤      3   nikic-php-parser/PhpParser/Node/Expr/Cast/Bool_.php  EN„i  uxå¤      4   nikic-php-parser/PhpParser/Node/Expr/Cast/Double.php·  EN„i·  S(Û¤      2   nikic-php-parser/PhpParser/Node/Expr/Cast/Int_.php{  EN„i{  ú{¤      5   nikic-php-parser/PhpParser/Node/Expr/Cast/Object_.phpğ   EN„iğ   \­‘°¤      5   nikic-php-parser/PhpParser/Node/Expr/Cast/String_.php…  EN„i…  Øú{Æ¤      4   nikic-php-parser/PhpParser/Node/Expr/Cast/Unset_.phpî   EN„iî   É”™Ô¤      3   nikic-php-parser/PhpParser/Node/Expr/Cast/Void_.phpì   EN„iì   šõ±d¤      8   nikic-php-parser/PhpParser/Node/Expr/ClassConstFetch.php  EN„i  2å¤      /   nikic-php-parser/PhpParser/Node/Expr/Clone_.php  EN„i  ™×¤      0   nikic-php-parser/PhpParser/Node/Expr/Closure.phpj  EN„ij  òI¶¤      3   nikic-php-parser/PhpParser/Node/Expr/ConstFetch.phpØ  EN„iØ  s>6¤      /   nikic-php-parser/PhpParser/Node/Expr/Empty_.php¡  EN„i¡  ¸¨İ¤      .   nikic-php-parser/PhpParser/Node/Expr/Error.php  EN„i  $ŸLŒ¤      6   nikic-php-parser/PhpParser/Node/Expr/ErrorSuppress.php·  EN„i·  Î	&¤      .   nikic-php-parser/PhpParser/Node/Expr/Eval_.php  EN„i  A[¤      .   nikic-php-parser/PhpParser/Node/Expr/Exit_.php  EN„i  gİí¼¤      1   nikic-php-parser/PhpParser/Node/Expr/FuncCall.php  EN„i  @"]¤      1   nikic-php-parser/PhpParser/Node/Expr/Include_.phpÍ  EN„iÍ  —ÀÊ¤      4   nikic-php-parser/PhpParser/Node/Expr/Instanceof_.php•  EN„i•  .§B ¤      /   nikic-php-parser/PhpParser/Node/Expr/Isset_.php£  EN„i£  ò>:¤      .   nikic-php-parser/PhpParser/Node/Expr/List_.php£  EN„i£  2ò¿)¤      /   nikic-php-parser/PhpParser/Node/Expr/Match_.php;  EN„i;  hü¤      3   nikic-php-parser/PhpParser/Node/Expr/MethodCall.phpQ  EN„iQ  OD¥å¤      -   nikic-php-parser/PhpParser/Node/Expr/New_.php•  EN„i•  <~h¤      ;   nikic-php-parser/PhpParser/Node/Expr/NullsafeMethodCall.phph  EN„ih  k[˜S¤      >   nikic-php-parser/PhpParser/Node/Expr/NullsafePropertyFetch.php  EN„i  k*¢¤      0   nikic-php-parser/PhpParser/Node/Expr/PostDec.php   EN„i   Ph@¤      0   nikic-php-parser/PhpParser/Node/Expr/PostInc.php   EN„i   dŞ‡¤      /   nikic-php-parser/PhpParser/Node/Expr/PreDec.php  EN„i  ÍmB'¤      /   nikic-php-parser/PhpParser/Node/Expr/PreInc.php  EN„i  Ô·$x¤      /   nikic-php-parser/PhpParser/Node/Expr/Print_.php¡  EN„i¡  U¤óô¤      6   nikic-php-parser/PhpParser/Node/Expr/PropertyFetch.phpê  EN„iê  :%g¤      2   nikic-php-parser/PhpParser/Node/Expr/ShellExec.phpH  EN„iH  edü¤      3   nikic-php-parser/PhpParser/Node/Expr/StaticCall.php\  EN„i\  ©ÁP¼¤      <   nikic-php-parser/PhpParser/Node/Expr/StaticPropertyFetch.php;  EN„i;  ç.½ ¤      0   nikic-php-parser/PhpParser/Node/Expr/Ternary.phpè  EN„iè  :X(¤      /   nikic-php-parser/PhpParser/Node/Expr/Throw_.php½  EN„i½  #‚6¢¤      3   nikic-php-parser/PhpParser/Node/Expr/UnaryMinus.php­  EN„i­  ¾*C‰¤      2   nikic-php-parser/PhpParser/Node/Expr/UnaryPlus.phpª  EN„iª  F!Ä¤      1   nikic-php-parser/PhpParser/Node/Expr/Variable.php  EN„i  ìEk¤      2   nikic-php-parser/PhpParser/Node/Expr/YieldFrom.php»  EN„i»  ôBß¤      /   nikic-php-parser/PhpParser/Node/Expr/Yield_.phpo  EN„io  ‘Æ´¤      0   nikic-php-parser/PhpParser/Node/FunctionLike.phpï  EN„iï  Êj¸¤      .   nikic-php-parser/PhpParser/Node/Identifier.phpR  EN„iR  ¦œú¤      :   nikic-php-parser/PhpParser/Node/InterpolatedStringPart.phpr  EN„ir  kGşn¤      4   nikic-php-parser/PhpParser/Node/IntersectionType.php¯  EN„i¯  €”u«¤      ,   nikic-php-parser/PhpParser/Node/MatchArm.php¹  EN„i¹  ›Q\¤¤      (   nikic-php-parser/PhpParser/Node/Name.phpÙ!  EN„iÙ!  ÿ6VË¤      7   nikic-php-parser/PhpParser/Node/Name/FullyQualified.phpÂ  EN„iÂ  ø 2¤      1   nikic-php-parser/PhpParser/Node/Name/Relative.php¿  EN„i¿  ‰8½V¤      0   nikic-php-parser/PhpParser/Node/NullableType.phpÈ  EN„iÈ  Õä¤      )   nikic-php-parser/PhpParser/Node/Param.phpë  EN„ië  r
-@¤      0   nikic-php-parser/PhpParser/Node/PropertyHook.phpÉ  EN„iÉ  \üBA¤      0   nikic-php-parser/PhpParser/Node/PropertyItem.php\  EN„i\  ¦`º¤      *   nikic-php-parser/PhpParser/Node/Scalar.phpo   EN„io   ­¦ş=¤      1   nikic-php-parser/PhpParser/Node/Scalar/Float_.phpW  EN„iW  j©Æ¤      /   nikic-php-parser/PhpParser/Node/Scalar/Int_.phpø	  EN„iø	  Ÿ‘¤      =   nikic-php-parser/PhpParser/Node/Scalar/InterpolatedString.phpİ  EN„iİ  ?Ã	Z¤      5   nikic-php-parser/PhpParser/Node/Scalar/MagicConst.phpx  EN„ix  ÷Ï®÷¤      <   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Class_.phpZ  EN„iZ  ÁÆÓ5¤      9   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Dir.phpS  EN„iS  rÙfÉ¤      :   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/File.phpV  EN„iV  6›Q¤      ?   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Function_.phpc  EN„ic  —5¤¤      :   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Line.phpV  EN„iV  èDEš¤      <   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Method.php\  EN„i\  Ë2N¤      @   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Namespace_.phpf  EN„if  ‹Ãq¤      >   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Property.phpb  EN„ib  0º«¤      <   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Trait_.phpZ  EN„iZ  Ëµİ¤      2   nikic-php-parser/PhpParser/Node/Scalar/String_.phpÀ  EN„iÀ  ‰–ƒË¤      -   nikic-php-parser/PhpParser/Node/StaticVar.php  EN„i  ñT>¤      (   nikic-php-parser/PhpParser/Node/Stmt.php   EN„i   «yş¤      .   nikic-php-parser/PhpParser/Node/Stmt/Block.php§  EN„i§  ×j¤      /   nikic-php-parser/PhpParser/Node/Stmt/Break_.phpÛ  EN„iÛ  mj–¤      .   nikic-php-parser/PhpParser/Node/Stmt/Case_.php†  EN„i†  İ¸O/¤      /   nikic-php-parser/PhpParser/Node/Stmt/Catch_.phpy  EN„iy  {é^}¤      3   nikic-php-parser/PhpParser/Node/Stmt/ClassConst.phpS  EN„iS  /ê¾¬¤      2   nikic-php-parser/PhpParser/Node/Stmt/ClassLike.php  EN„i  üÄsİ¤      4   nikic-php-parser/PhpParser/Node/Stmt/ClassMethod.php÷  EN„i÷  #c¤      /   nikic-php-parser/PhpParser/Node/Stmt/Class_.php¸  EN„i¸  Æ1è?¤      /   nikic-php-parser/PhpParser/Node/Stmt/Const_.phpÊ  EN„iÊ  ¤      2   nikic-php-parser/PhpParser/Node/Stmt/Continue_.phpê  EN„iê  Çò¥€¤      1   nikic-php-parser/PhpParser/Node/Stmt/Declare_.php½  EN„i½  5‹`ä¤      ,   nikic-php-parser/PhpParser/Node/Stmt/Do_.phpT  EN„iT  %ú0¤      .   nikic-php-parser/PhpParser/Node/Stmt/Echo_.php´  EN„i´  ±°`)¤      0   nikic-php-parser/PhpParser/Node/Stmt/ElseIf_.php[  EN„i[  bE·Ñ¤      .   nikic-php-parser/PhpParser/Node/Stmt/Else_.php·  EN„i·  &ô¡Á¤      1   nikic-php-parser/PhpParser/Node/Stmt/EnumCase.php»  EN„i»  w4m¤      .   nikic-php-parser/PhpParser/Node/Stmt/Enum_.phpJ  EN„iJ  ›Œï?¤      3   nikic-php-parser/PhpParser/Node/Stmt/Expression.php÷  EN„i÷  À¤      1   nikic-php-parser/PhpParser/Node/Stmt/Finally_.php¿  EN„i¿  8ååå¤      -   nikic-php-parser/PhpParser/Node/Stmt/For_.php¼  EN„i¼  €‚½+¤      1   nikic-php-parser/PhpParser/Node/Stmt/Foreach_.phpĞ  EN„iĞ  µ0–×¤      2   nikic-php-parser/PhpParser/Node/Stmt/Function_.php¬
-  EN„i¬
-  f*í‚¤      0   nikic-php-parser/PhpParser/Node/Stmt/Global_.phpÇ  EN„iÇ  Po6¤      .   nikic-php-parser/PhpParser/Node/Stmt/Goto_.php"  EN„i"  ĞX–¤      1   nikic-php-parser/PhpParser/Node/Stmt/GroupUse.php^  EN„i^  €¦7Ñ¤      5   nikic-php-parser/PhpParser/Node/Stmt/HaltCompiler.php!  EN„i!  ˜×y¤      ,   nikic-php-parser/PhpParser/Node/Stmt/If_.php‘  EN„i‘  4‡o¤      3   nikic-php-parser/PhpParser/Node/Stmt/InlineHTML.php´  EN„i´  oûÈ‡¤      3   nikic-php-parser/PhpParser/Node/Stmt/Interface_.phpN  EN„iN  ™yáÆ¤      .   nikic-php-parser/PhpParser/Node/Stmt/Label.phpü  EN„iü  ŸäJ¤      3   nikic-php-parser/PhpParser/Node/Stmt/Namespace_.phpİ  EN„iİ  SvEj¤      ,   nikic-php-parser/PhpParser/Node/Stmt/Nop.phpF  EN„iF  $6¿Ø¤      1   nikic-php-parser/PhpParser/Node/Stmt/Property.phpÑ  EN„iÑ  rİ¦¥¤      0   nikic-php-parser/PhpParser/Node/Stmt/Return_.phpÈ  EN„iÈ  |M¤      0   nikic-php-parser/PhpParser/Node/Stmt/Static_.phpş  EN„iş  ’ÙœŞ¤      0   nikic-php-parser/PhpParser/Node/Stmt/Switch_.phpI  EN„iI  iËÇü¤      1   nikic-php-parser/PhpParser/Node/Stmt/TraitUse.phpš  EN„iš  ?óô\¤      ;   nikic-php-parser/PhpParser/Node/Stmt/TraitUseAdaptation.php=  EN„i=  {:Š¤      A   nikic-php-parser/PhpParser/Node/Stmt/TraitUseAdaptation/Alias.php1  EN„i1  b Ö¤      F   nikic-php-parser/PhpParser/Node/Stmt/TraitUseAdaptation/Precedence.php>  EN„i>  ¶Ñÿ ¤      /   nikic-php-parser/PhpParser/Node/Stmt/Trait_.phpQ  EN„iQ  ËEøQ¤      1   nikic-php-parser/PhpParser/Node/Stmt/TryCatch.php6  EN„i6  ‚ã2.¤      /   nikic-php-parser/PhpParser/Node/Stmt/Unset_.php¿  EN„i¿  :VÉÉ¤      -   nikic-php-parser/PhpParser/Node/Stmt/Use_.phpÔ  EN„iÔ  Ç|¤      /   nikic-php-parser/PhpParser/Node/Stmt/While_.phpW  EN„iW  Q/£×¤      -   nikic-php-parser/PhpParser/Node/UnionType.php»  EN„i»  ’Hš­¤      +   nikic-php-parser/PhpParser/Node/UseItem.phpÇ  EN„iÇ  73Uƒ¤      5   nikic-php-parser/PhpParser/Node/VarLikeIdentifier.php  EN„i  y .¤      7   nikic-php-parser/PhpParser/Node/VariadicPlaceholder.php¯  EN„i¯  mäWè¤      +   nikic-php-parser/PhpParser/NodeAbstract.php7  EN„i7  ë¾i‚¤      )   nikic-php-parser/PhpParser/NodeDumper.phpû'  EN„iû'  ŒÍO ¤      )   nikic-php-parser/PhpParser/NodeFinder.phpW
-  EN„iW
-  ¥¹^‘¤      ,   nikic-php-parser/PhpParser/NodeTraverser.php«&  EN„i«&  ñ†øm¤      5   nikic-php-parser/PhpParser/NodeTraverserInterface.phpa  EN„ia  ½©ìğ¤      *   nikic-php-parser/PhpParser/NodeVisitor.phpX  EN„iX  İp}ª¤      9   nikic-php-parser/PhpParser/NodeVisitor/CloningVisitor.php  EN„i  î"Û¤      C   nikic-php-parser/PhpParser/NodeVisitor/CommentAnnotatingVisitor.php¶
-  EN„i¶
-  ªÉ^µ¤      9   nikic-php-parser/PhpParser/NodeVisitor/FindingVisitor.php¥  EN„i¥  í1A¤      >   nikic-php-parser/PhpParser/NodeVisitor/FirstFindingVisitor.php  EN„i  ~Ä¬*¤      7   nikic-php-parser/PhpParser/NodeVisitor/NameResolver.phpA(  EN„iA(  x_Á¤      @   nikic-php-parser/PhpParser/NodeVisitor/NodeConnectingVisitor.php$	  EN„i$	  Vü ¤      B   nikic-php-parser/PhpParser/NodeVisitor/ParentConnectingVisitor.phpk  EN„ik  [>¤      2   nikic-php-parser/PhpParser/NodeVisitorAbstract.phpÙ  EN„iÙ  ¡¿é~¤      %   nikic-php-parser/PhpParser/Parser.php	  EN„i	  œ0@¤      *   nikic-php-parser/PhpParser/Parser/Php7.phpå EN„iå ©?/}¤      *   nikic-php-parser/PhpParser/Parser/Php8.phpm EN„im Á†DÊ¤      -   nikic-php-parser/PhpParser/ParserAbstract.phpÇ  EN„iÇ  .€m©¤      ,   nikic-php-parser/PhpParser/ParserFactory.phpÖ  EN„iÖ  (ŸÉc¤      )   nikic-php-parser/PhpParser/PhpVersion.php—  EN„i—  ªşßj¤      ,   nikic-php-parser/PhpParser/PrettyPrinter.php¸  EN„i¸  >¹—´¤      5   nikic-php-parser/PhpParser/PrettyPrinter/Standard.phpÏ  EN„iÏ  ­Û'{¤      4   nikic-php-parser/PhpParser/PrettyPrinterAbstract.php
- EN„i
- 8f(¤      $   nikic-php-parser/PhpParser/Token.phpû  EN„iû  ÇãÌ¤      3   nikic-php-parser/PhpParser/compatibility_tokens.php1	  EN„i1	  ¬”‚É¤         object-enumerator/LICENSEû  EN„iû  ¨ïÔë¤         object-reflector/LICENSEû  EN„iû  œ|±ß¤         phar-io-manifest/LICENSE`  EN„i`  ÷şp¤      +   phar-io-manifest/ManifestDocumentMapper.phpë  EN„ië  ^DŒï¤      #   phar-io-manifest/ManifestLoader.phpÿ  EN„iÿ  ÙX©j¤      '   phar-io-manifest/ManifestSerializer.phpÏ  EN„iÏ  ?jª'¤      :   phar-io-manifest/exceptions/ElementCollectionException.php  EN„i  In‡¤      )   phar-io-manifest/exceptions/Exception.phpÓ  EN„iÓ  Ö½Ğ¤      ?   phar-io-manifest/exceptions/InvalidApplicationNameException.php<  EN„i<  °°¯W¤      5   phar-io-manifest/exceptions/InvalidEmailException.php  EN„i  )Ïª}¤      3   phar-io-manifest/exceptions/InvalidUrlException.php  EN„i  xá³¤      9   phar-io-manifest/exceptions/ManifestDocumentException.php  EN„i  /úï"¤      @   phar-io-manifest/exceptions/ManifestDocumentLoadingException.php~  EN„i~  H}»¤      ?   phar-io-manifest/exceptions/ManifestDocumentMapperException.php  EN„i  J¯R1¤      8   phar-io-manifest/exceptions/ManifestElementException.php  EN„i  Ìæ¤      7   phar-io-manifest/exceptions/ManifestLoaderException.phpä  EN„iä  Íl
-½¤      7   phar-io-manifest/exceptions/NoEmailAddressException.php  EN„i  áÁü¤      '   phar-io-manifest/values/Application.php	  EN„i	  ;Äk¤      +   phar-io-manifest/values/ApplicationName.php…  EN„i…  á”ù¤      "   phar-io-manifest/values/Author.php   EN„i   ÷x•ü¤      ,   phar-io-manifest/values/AuthorCollection.php-  EN„i-  àÍá¤      4   phar-io-manifest/values/AuthorCollectionIterator.php¡  EN„i¡  ¨Ğªe¤      ,   phar-io-manifest/values/BundledComponent.phpd  EN„id  7õõ¤      6   phar-io-manifest/values/BundledComponentCollection.php¹  EN„i¹  ·æß¤      >   phar-io-manifest/values/BundledComponentCollectionIterator.php  EN„i   _»¤      0   phar-io-manifest/values/CopyrightInformation.phpp  EN„ip  ‚“æP¤      !   phar-io-manifest/values/Email.php¦  EN„i¦  «S·¤      %   phar-io-manifest/values/Extension.phpÅ  EN„iÅ  F {¤      #   phar-io-manifest/values/Library.php  EN„i  ±ıv¤      #   phar-io-manifest/values/License.php  EN„i  4Êıç¤      $   phar-io-manifest/values/Manifest.php&
-  EN„i&
-  ¾øüú¤      3   phar-io-manifest/values/PhpExtensionRequirement.php¼  EN„i¼  ²PÎ·¤      1   phar-io-manifest/values/PhpVersionRequirement.phpA  EN„iA  Äñi‰¤      '   phar-io-manifest/values/Requirement.php´  EN„i´  ŸïU¤      1   phar-io-manifest/values/RequirementCollection.phps  EN„is  6ı•M¤      9   phar-io-manifest/values/RequirementCollectionIterator.phpİ  EN„iİ  U¤          phar-io-manifest/values/Type.phpÔ  EN„iÔ  Ü²3«¤         phar-io-manifest/values/Url.phpÁ  EN„iÁ  ëO©ƒ¤      &   phar-io-manifest/xml/AuthorElement.phpğ  EN„iğ  ÎÊÂÚ¤      0   phar-io-manifest/xml/AuthorElementCollection.phpM  EN„iM  j£·¤      '   phar-io-manifest/xml/BundlesElement.phpt  EN„it  ]Y´‹¤      )   phar-io-manifest/xml/ComponentElement.php™  EN„i™  ”na¤      3   phar-io-manifest/xml/ComponentElementCollection.phpV  EN„iV  ú¥?¤      (   phar-io-manifest/xml/ContainsElement.phpŒ  EN„iŒ  l8è¤      )   phar-io-manifest/xml/CopyrightElement.phpó  EN„ió  ¹hDp¤      *   phar-io-manifest/xml/ElementCollection.phpÂ  EN„iÂ  <^ÉŞ¤      #   phar-io-manifest/xml/ExtElement.php*  EN„i*  ^º×¤      -   phar-io-manifest/xml/ExtElementCollection.phpD  EN„iD  Î²Só¤      )   phar-io-manifest/xml/ExtensionElement.php  EN„i  €JŒ¤      '   phar-io-manifest/xml/LicenseElement.php  EN„i  vâ/!¤      )   phar-io-manifest/xml/ManifestDocument.phpƒ  EN„iƒ  ™Åi_¤      (   phar-io-manifest/xml/ManifestElement.phpİ  EN„iİ  #¨=¤      #   phar-io-manifest/xml/PhpElement.php  EN„i  YÊ¤      (   phar-io-manifest/xml/RequiresElement.phpE  EN„iE  dwÊ¤      !   phar-io-version/BuildMetaData.phpã  EN„iã  3A(*¤         phar-io-version/LICENSE&  EN„i&  Òª	¤      $   phar-io-version/PreReleaseSuffix.php  EN„i  8^æ¤         phar-io-version/Version.phpñ  EN„iñ  ‘¬¤      +   phar-io-version/VersionConstraintParser.phpN  EN„iN  n­%Ë¤      *   phar-io-version/VersionConstraintValue.phpA
-  EN„iA
-  ²fi™¤      !   phar-io-version/VersionNumber.phpµ  EN„iµ  Kp‘_¤      9   phar-io-version/constraints/AbstractVersionConstraint.phpÁ  EN„iÁ  42ƒo¤      9   phar-io-version/constraints/AndVersionConstraintGroup.phpé  EN„ié  k O•¤      4   phar-io-version/constraints/AnyVersionConstraint.phpT  EN„iT  ¸v¤      6   phar-io-version/constraints/ExactVersionConstraint.phpÖ  EN„iÖ  gÉĞq¤      E   phar-io-version/constraints/GreaterThanOrEqualToVersionConstraint.php‰  EN„i‰  ©ŞÚ_¤      8   phar-io-version/constraints/OrVersionConstraintGroup.php  EN„i  £¥ƒ6¤      F   phar-io-version/constraints/SpecificMajorAndMinorVersionConstraint.phpÌ  EN„iÌ  Bº”,¤      >   phar-io-version/constraints/SpecificMajorVersionConstraint.php  EN„i  êÒé¤      1   phar-io-version/constraints/VersionConstraint.phpø  EN„iø  ï¾dã¤      (   phar-io-version/exceptions/Exception.php³  EN„i³  ôÓ<²¤      ?   phar-io-version/exceptions/InvalidPreReleaseSuffixException.php›   EN„i›   Ë[–¤      6   phar-io-version/exceptions/InvalidVersionException.php¡   EN„i¡   ·ğy¤      7   phar-io-version/exceptions/NoBuildMetaDataException.php“   EN„i“   +${¡¤      :   phar-io-version/exceptions/NoPreReleaseSuffixException.php–   EN„i–   º"Ï÷¤      D   phar-io-version/exceptions/UnsupportedVersionConstraintException.phpß  EN„iß  ¤´æ¨¤      "   php-code-coverage/CodeCoverage.phpHI  EN„iHI  bWœ±¤      6   php-code-coverage/Data/ProcessedBranchCoverageData.php§	  EN„i§	  ”qô–¤      -   php-code-coverage/Data/ProcessedClassType.php#  EN„i#  £M~k¤      4   php-code-coverage/Data/ProcessedCodeCoverageData.php—"  EN„i—"  Ğ‹¤      8   php-code-coverage/Data/ProcessedFunctionCoverageData.php¨  EN„i¨  ßp¤      0   php-code-coverage/Data/ProcessedFunctionType.php˜  EN„i˜  MvÕ·¤      .   php-code-coverage/Data/ProcessedMethodType.php’  EN„i’  ö3c—¤      4   php-code-coverage/Data/ProcessedPathCoverageData.phpµ  EN„iµ  i*€¤      -   php-code-coverage/Data/ProcessedTraitType.php#  EN„i#  ³í-1¤      .   php-code-coverage/Data/RawCodeCoverageData.php‰#  EN„i‰#  kºk¤      #   php-code-coverage/Driver/Driver.phpÿ  EN„iÿ  “j	£¤      '   php-code-coverage/Driver/PcovDriver.php¢  EN„i¢  X^‰¹¤      %   php-code-coverage/Driver/Selector.php(  EN„i(  ƒ¹Ú¤      )   php-code-coverage/Driver/XdebugDriver.php/  EN„i/  0|:¤      J   php-code-coverage/Exception/BranchAndPathCoverageNotSupportedException.phpÇ  EN„iÇ  z¤      C   php-code-coverage/Exception/DirectoryCouldNotBeCreatedException.phpÿ  EN„iÿ  <î6'¤      )   php-code-coverage/Exception/Exception.php  EN„i  +’ËQ¤      >   php-code-coverage/Exception/FileCouldNotBeWrittenException.php»  EN„i»  £ó’¤      8   php-code-coverage/Exception/InvalidArgumentException.php¨  EN„i¨  lÕ~Ğ¤      B   php-code-coverage/Exception/InvalidCodeCoverageTargetException.phpÃ  EN„iÃ  yØ¯¤      F   php-code-coverage/Exception/NoCodeCoverageDriverAvailableException.php3  EN„i3  5oYC¤      ]   php-code-coverage/Exception/NoCodeCoverageDriverWithPathCoverageSupportAvailableException.phpe  EN„ie  ®X3Ÿ¤      /   php-code-coverage/Exception/ParserException.php¬  EN„i¬  pÏêÚ¤      D   php-code-coverage/Exception/PathExistsButIsNotDirectoryException.phpd  EN„id  ±@¿¤      9   php-code-coverage/Exception/PcovNotAvailableException.phpi  EN„ii  Áq¤      3   php-code-coverage/Exception/ReflectionException.php°  EN„i°  ö`¤      ?   php-code-coverage/Exception/ReportAlreadyFinalizedException.php>  EN„i>  ÒmU=¤      I   php-code-coverage/Exception/StaticAnalysisCacheNotConfiguredException.phpÆ  EN„iÆ  Ûpé¤      6   php-code-coverage/Exception/TestIdMissingException.php  EN„i  3ÄOê¤      C   php-code-coverage/Exception/UnintentionallyCoveredCodeException.phpÒ  EN„iÒ  [‹ã¤      =   php-code-coverage/Exception/WriteOperationFailedException.phpO  EN„iO  Hç‰"¤      ;   php-code-coverage/Exception/XdebugNotAvailableException.phpm  EN„im  í{F¤      9   php-code-coverage/Exception/XdebugNotEnabledException.php³  EN„i³  J]0¤      B   php-code-coverage/Exception/XdebugVersionNotSupportedException.phpò  EN„iò  Øİ2¤      ,   php-code-coverage/Exception/XmlException.php©  EN„i©  0)ƒR¤         php-code-coverage/Filter.phpˆ  EN„iˆ  SÿÑ¤         php-code-coverage/LICENSEû  EN„iû  ã1?¤      '   php-code-coverage/Node/AbstractNode.php   EN„i   -nP‡¤      "   php-code-coverage/Node/Builder.phpâ  EN„iâ  ½à¢8¤      $   php-code-coverage/Node/CrapIndex.phpÂ  EN„iÂ  Wx\´¤      $   php-code-coverage/Node/Directory.php'  EN„i'  Y¤>ù¤         php-code-coverage/Node/File.php«P  EN„i«P  ü„Ù»¤      #   php-code-coverage/Node/Iterator.php3  EN„i3  lÎ¤      #   php-code-coverage/Report/Clover.phpK%  EN„iK%  äI¸¤      &   php-code-coverage/Report/Cobertura.phpo/  EN„io/  ŠT·|¤      #   php-code-coverage/Report/Crap4j.phpY  EN„iY  ÊáÊ¤      (   php-code-coverage/Report/Html/Colors.phpš  EN„iš  Ö]­ÿ¤      /   php-code-coverage/Report/Html/CustomCssFile.php5  EN„i5  ©ZÇ0¤      (   php-code-coverage/Report/Html/Facade.php{  EN„i{  †Ş~¤      *   php-code-coverage/Report/Html/Renderer.php%!  EN„i%!  É°~9¤      4   php-code-coverage/Report/Html/Renderer/Dashboard.php'  EN„i'  
-ÃÔ¤      4   php-code-coverage/Report/Html/Renderer/Directory.phpK  EN„iK  ¹88a¤      /   php-code-coverage/Report/Html/Renderer/File.php‰  EN„i‰  <îv¤      B   php-code-coverage/Report/Html/Renderer/Template/branches.html.distô  EN„iô  h2+¤      F   php-code-coverage/Report/Html/Renderer/Template/coverage_bar.html.dist/  EN„i/  ÕchÁ¤      M   php-code-coverage/Report/Html/Renderer/Template/coverage_bar_branch.html.dist/  EN„i/  ÕchÁ¤      E   php-code-coverage/Report/Html/Renderer/Template/css/billboard.min.cssu  EN„iu  Ã(Zœ¤      E   php-code-coverage/Report/Html/Renderer/Template/css/bootstrap.min.cssRŠ EN„iRŠ 	Ìı¤      >   php-code-coverage/Report/Html/Renderer/Template/css/custom.css    EN„i        ¤      @   php-code-coverage/Report/Html/Renderer/Template/css/octicons.cssX   EN„iX   '#ï¤      =   php-code-coverage/Report/Html/Renderer/Template/css/style.css   EN„i   ¦{n§¤      C   php-code-coverage/Report/Html/Renderer/Template/dashboard.html.distv  EN„iv  ,©Rt¤      J   php-code-coverage/Report/Html/Renderer/Template/dashboard_branch.html.dist  EN„i  «ŒÅÏ¤      C   php-code-coverage/Report/Html/Renderer/Template/directory.html.distö  EN„iö  ÎÕ†á¤      J   php-code-coverage/Report/Html/Renderer/Template/directory_branch.html.dist”  EN„i”  n2]¤      H   php-code-coverage/Report/Html/Renderer/Template/directory_item.html.distA  EN„iA  ds¤      O   php-code-coverage/Report/Html/Renderer/Template/directory_item_branch.html.dist;  EN„i;  ªm½Û¤      >   php-code-coverage/Report/Html/Renderer/Template/file.html.distö  EN„iö  9Á¤      E   php-code-coverage/Report/Html/Renderer/Template/file_branch.html.dist“	  EN„i“	  ûu ¤      C   php-code-coverage/Report/Html/Renderer/Template/file_item.html.distr  EN„ir  éğ/y¤      J   php-code-coverage/Report/Html/Renderer/Template/file_item_branch.html.distl  EN„il  ¡-°÷¤      C   php-code-coverage/Report/Html/Renderer/Template/icons/file-code.svg0  EN„i0  ÙQUU¤      H   php-code-coverage/Report/Html/Renderer/Template/icons/file-directory.svgê   EN„iê   ıÚZÿ¤      H   php-code-coverage/Report/Html/Renderer/Template/js/billboard.pkgd.min.jsÂ· EN„iÂ· ‰4E”¤      J   php-code-coverage/Report/Html/Renderer/Template/js/bootstrap.bundle.min.jsg; EN„ig; âOê$¤      :   php-code-coverage/Report/Html/Renderer/Template/js/file.jsÈ  EN„iÈ  5-¤      @   php-code-coverage/Report/Html/Renderer/Template/js/jquery.min.jsìU EN„iìU ¥ŸGœ¤      >   php-code-coverage/Report/Html/Renderer/Template/line.html.distÃ   EN„iÃ   ·ä´_¤      ?   php-code-coverage/Report/Html/Renderer/Template/lines.html.diste   EN„ie   df¤      E   php-code-coverage/Report/Html/Renderer/Template/method_item.html.dist«  EN„i«  ‹j×¤      L   php-code-coverage/Report/Html/Renderer/Template/method_item_branch.html.dist¥  EN„i¥  yÄk¤      ?   php-code-coverage/Report/Html/Renderer/Template/paths.html.distò  EN„iò  ã*'İ¤      '   php-code-coverage/Report/OpenClover.phpı/  EN„iı/  Oó©¦¤          php-code-coverage/Report/PHP.phpo  EN„io  Ê4n’¤      !   php-code-coverage/Report/Text.phpÙ&  EN„iÙ&  C÷º¤      '   php-code-coverage/Report/Thresholds.phpH  EN„iH  ™¡^}¤      1   php-code-coverage/Report/Xml/BuildInformation.phpC  EN„iC  Í—½¤      )   php-code-coverage/Report/Xml/Coverage.php\  EN„i\  ©¤¤      *   php-code-coverage/Report/Xml/Directory.phpí  EN„ií  ôFn¤      '   php-code-coverage/Report/Xml/Facade.phpp&  EN„ip&  p§?q¤      %   php-code-coverage/Report/Xml/File.php¢  EN„i¢  ü³8 ¤      '   php-code-coverage/Report/Xml/Method.php  EN„i  c‚¾á¤      %   php-code-coverage/Report/Xml/Node.phpş  EN„iş  ¢[3é¤      (   php-code-coverage/Report/Xml/Project.php’  EN„i’  ±J¬¤      '   php-code-coverage/Report/Xml/Report.php]
-  EN„i]
-  6½â1¤      '   php-code-coverage/Report/Xml/Source.phpø  EN„iø  ò]‚¤      &   php-code-coverage/Report/Xml/Tests.phpø  EN„iø  pt
-!¤      '   php-code-coverage/Report/Xml/Totals.php:  EN„i:  ìx8w¤      %   php-code-coverage/Report/Xml/Unit.phpï  EN„iï  ­££J¤      0   php-code-coverage/StaticAnalysis/CacheWarmer.php±  EN„i±  PZu$¤      :   php-code-coverage/StaticAnalysis/CachingSourceAnalyser.php5  EN„i5  T—ó.¤      1   php-code-coverage/StaticAnalysis/FileAnalyser.phpA  EN„iA  á7Ü¤      :   php-code-coverage/StaticAnalysis/ParsingSourceAnalyser.phpâ  EN„iâ  F¹_Y¤      3   php-code-coverage/StaticAnalysis/SourceAnalyser.phpÄ  EN„iÄ  _›n¤      9   php-code-coverage/StaticAnalysis/Value/AnalysisResult.phpÄ
-  EN„iÄ
-  P»‚’¤      1   php-code-coverage/StaticAnalysis/Value/Class_.phpÔ  EN„iÔ  }×¼`¤      4   php-code-coverage/StaticAnalysis/Value/Function_.php
-  EN„i
-  fw¨¤      5   php-code-coverage/StaticAnalysis/Value/Interface_.phpv	  EN„iv	  ™6=¤      6   php-code-coverage/StaticAnalysis/Value/LinesOfCode.phpP  EN„iP  é8,|¤      1   php-code-coverage/StaticAnalysis/Value/Method.phpè  EN„iè  (¤      1   php-code-coverage/StaticAnalysis/Value/Trait_.phpË  EN„iË  ÕÂ;¤      5   php-code-coverage/StaticAnalysis/Value/Visibility.phpI  EN„iI  Ì**¤      M   php-code-coverage/StaticAnalysis/Visitor/AttributeParentConnectingVisitor.php  EN„i  Dùö»¤      C   php-code-coverage/StaticAnalysis/Visitor/CodeUnitFindingVisitor.phpZ,  EN„iZ,  Ÿ“Á¤      J   php-code-coverage/StaticAnalysis/Visitor/ExecutableLinesFindingVisitor.php +  EN„i +  ±‹Z¤      G   php-code-coverage/StaticAnalysis/Visitor/IgnoredLinesFindingVisitor.php[  EN„i[  ¢ájş¤      #   php-code-coverage/Target/Class_.phpG  EN„iG  æLÁå¤      3   php-code-coverage/Target/ClassesThatExtendClass.php‹  EN„i‹  “!x¤      :   php-code-coverage/Target/ClassesThatImplementInterface.phpÇ  EN„iÇ  \<x¤      &   php-code-coverage/Target/Function_.phpv  EN„iv  ”½'¤      '   php-code-coverage/Target/MapBuilder.php$  EN„i$  ©ñá¤      #   php-code-coverage/Target/Mapper.phpd  EN„id  d#ø¤      #   php-code-coverage/Target/Method.php¤  EN„i¤  îf£¤      '   php-code-coverage/Target/Namespace_.phpb  EN„ib  Ê¾!¤      #   php-code-coverage/Target/Target.phpÕ
-  EN„iÕ
-  EÂÌ¤      -   php-code-coverage/Target/TargetCollection.phpî  EN„iî  3aª?¤      5   php-code-coverage/Target/TargetCollectionIterator.phpò  EN„iò  Û÷M¤      6   php-code-coverage/Target/TargetCollectionValidator.php  EN„i  Š>Sy¤      #   php-code-coverage/Target/Trait_.phpF  EN„iF  üWÃ
-¤      .   php-code-coverage/Target/ValidationFailure.php  EN„i  ™¬md¤      -   php-code-coverage/Target/ValidationResult.php\  EN„i\  T¼¤      .   php-code-coverage/Target/ValidationSuccess.phpt  EN„it  !Ãb¤      $   php-code-coverage/TestSize/Known.php  EN„i  ”ñQ¤      $   php-code-coverage/TestSize/Large.php‰  EN„i‰  88çq¤      %   php-code-coverage/TestSize/Medium.php‹  EN„i‹  û›¤      $   php-code-coverage/TestSize/Small.php}  EN„i}  O¾Dä¤      '   php-code-coverage/TestSize/TestSize.phpš  EN„iš  fSúv¤      &   php-code-coverage/TestSize/Unknown.php*  EN„i*  T4Uv¤      (   php-code-coverage/TestStatus/Failure.php)  EN„i)  %$¤      &   php-code-coverage/TestStatus/Known.phpà  EN„ià  sŒ¤      (   php-code-coverage/TestStatus/Success.php)  EN„i)  ë²!¤      +   php-code-coverage/TestStatus/TestStatus.phpĞ  EN„iĞ  Äñyå¤      (   php-code-coverage/TestStatus/Unknown.php.  EN„i.  Xæl¤      %   php-code-coverage/Util/Filesystem.phpı  EN„iı  d2A¤      %   php-code-coverage/Util/Percentage.phpU  EN„iU  wªfÀ¤         php-code-coverage/Util/Xml.php•  EN„i•  W‹¨¤         php-code-coverage/Version.php¯  EN„i¯  4
-¤      %   php-file-iterator/ExcludeIterator.php"  EN„i"  æ¤…¤         php-file-iterator/Facade.php•  EN„i•  Í…!Z¤         php-file-iterator/Factory.phpW  EN„iW  .]è²¤         php-file-iterator/Iterator.phpf  EN„if  és¤         php-file-iterator/LICENSEû  EN„iû  „+•K¤         php-invoker/Invoker.php7  EN„i7  >(6Ê¤      $   php-invoker/exceptions/Exception.phpv  EN„iv  'P=¤      D   php-invoker/exceptions/ProcessControlExtensionNotLoadedException.phpÑ  EN„iÑ  ed e¤      +   php-invoker/exceptions/TimeoutException.php¢  EN„i¢  —tJï¤         php-text-template/LICENSEû  EN„iû  ã1?¤         php-text-template/Template.php»  EN„i»  Çëhª¤      *   php-text-template/exceptions/Exception.php}  EN„i}  Áã`"¤      9   php-text-template/exceptions/InvalidArgumentException.php¤  EN„i¤  ô¼¸Â¤      1   php-text-template/exceptions/RuntimeException.php¹  EN„i¹  Ö]Mp¤         php-timer/Duration.php	  EN„i	  }h#¤         php-timer/LICENSEû  EN„iû  …‰R¤      $   php-timer/ResourceUsageFormatter.php  EN„i  °”vø¤         php-timer/Timer.phpŠ  EN„iŠ  ĞôúÊ¤      "   php-timer/exceptions/Exception.phpr  EN„ir  ˜›<¤      /   php-timer/exceptions/NoActiveTimerException.php   EN„i   *®õ¤      E   php-timer/exceptions/TimeSinceStartOfRequestNotAvailableException.phpº  EN„iº  Ğ.ñ¤         phpunit.xsdXN  EN„iXN  ç#õ¤      1   phpunit/Event/Dispatcher/CollectingDispatcher.php  EN„i  Ø­:¤      0   phpunit/Event/Dispatcher/DeferringDispatcher.php¢  EN„i¢  MW°‰¤      -   phpunit/Event/Dispatcher/DirectDispatcher.php  EN„i  Ğ$"e¤      '   phpunit/Event/Dispatcher/Dispatcher.php}  EN„i}  ;G`œ¤      3   phpunit/Event/Dispatcher/SubscribableDispatcher.php  EN„i  »>òL¤      ,   phpunit/Event/Emitter/DispatchingEmitter.php„ˆ  EN„i„ˆ  š2¡¿¤      !   phpunit/Event/Emitter/Emitter.phpª/  EN„iª/  …š ­¤      -   phpunit/Event/Events/Application/Finished.php¨  EN„i¨  9ÒsS¤      7   phpunit/Event/Events/Application/FinishedSubscriber.php6  EN„i6  Íş)÷¤      ,   phpunit/Event/Events/Application/Started.php¦  EN„i¦  ëó0Á¤      6   phpunit/Event/Events/Application/StartedSubscriber.php4  EN„i4  JÜ'¤         phpunit/Event/Events/Event.php:  EN„i:  ¾ûké¤      (   phpunit/Event/Events/EventCollection.phpJ  EN„iJ  ·æI¤      0   phpunit/Event/Events/EventCollectionIterator.php   EN„i   ‘˜Ò¤      ;   phpunit/Event/Events/Test/AdditionalInformationProvided.phpw  EN„iw  †—x†¤      E   phpunit/Event/Events/Test/AdditionalInformationProvidedSubscriber.phpR  EN„iR  j6ü¤      2   phpunit/Event/Events/Test/ComparatorRegistered.phpv  EN„iv  Eø¤      <   phpunit/Event/Events/Test/ComparatorRegisteredSubscriber.php@  EN„i@  Ú­êö¤      B   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodCalled.php­  EN„i­  q€+0¤      L   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodCalledSubscriber.phpJ  EN„iJ  ‘Éü ¤      C   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodErrored.php+  EN„i+  Ã¦P¤      M   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodErroredSubscriber.phpL  EN„iL  ø¿¤      B   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodFailed.php)  EN„i)  ujµ‘¤      L   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodFailedSubscriber.phpJ  EN„iJ   ¶0¤      D   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodFinished.php˜  EN„i˜  ëª ¤      N   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodFinishedSubscriber.phpN  EN„iN  wœàK¤      >   phpunit/Event/Events/Test/HookMethod/AfterTestMethodCalled.phpœ  EN„iœ  ãû'9¤      H   phpunit/Event/Events/Test/HookMethod/AfterTestMethodCalledSubscriber.phpB  EN„iB  £R‘ÿ¤      ?   phpunit/Event/Events/Test/HookMethod/AfterTestMethodErrored.php  EN„i  ñ¦|¤      I   phpunit/Event/Events/Test/HookMethod/AfterTestMethodErroredSubscriber.phpD  EN„iD  %?±ò¤      >   phpunit/Event/Events/Test/HookMethod/AfterTestMethodFailed.php8  EN„i8  ”(%h¤      H   phpunit/Event/Events/Test/HookMethod/AfterTestMethodFailedSubscriber.phpB  EN„iB  ŞÙ¤      @   phpunit/Event/Events/Test/HookMethod/AfterTestMethodFinished.php‡  EN„i‡  ‡]Õû¤      J   phpunit/Event/Events/Test/HookMethod/AfterTestMethodFinishedSubscriber.phpF  EN„iF  –^‰_¤      D   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodCalled.php±  EN„i±  ë@½¤      N   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodCalledSubscriber.phpN  EN„iN  eÚäu¤      E   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodErrored.php/  EN„i/  «ÍÖÚ¤      O   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodErroredSubscriber.phpP  EN„iP  ñ¨¥²¤      D   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodFailed.php-  EN„i-  Ú1ÇÛ¤      N   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodFailedSubscriber.phpN  EN„iN  æõ¤      F   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodFinished.phpœ  EN„iœ  æå3¼¤      P   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodFinishedSubscriber.phpR  EN„iR  ½Á“\¤      ?   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodCalled.php  EN„i  ¡oS[¤      I   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodCalledSubscriber.phpD  EN„iD  ¿şÆ¾¤      @   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodErrored.php  EN„i  çiËõ¤      J   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodErroredSubscriber.phpF  EN„iF  ¦ó„0¤      ?   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodFailed.php:  EN„i:  ½Âça¤      I   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodFailedSubscriber.phpD  EN„iD  }&°ö¤      A   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodFinished.php‰  EN„i‰  ªƒê¤      K   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodFinishedSubscriber.phpH  EN„iH  x—ŠS¤      <   phpunit/Event/Events/Test/HookMethod/PostConditionCalled.php  EN„i  işòŒ¤      F   phpunit/Event/Events/Test/HookMethod/PostConditionCalledSubscriber.php>  EN„i>  b*¤      =   phpunit/Event/Events/Test/HookMethod/PostConditionErrored.php  EN„i  ;N›¤      G   phpunit/Event/Events/Test/HookMethod/PostConditionErroredSubscriber.php@  EN„i@  qhÀ÷¤      <   phpunit/Event/Events/Test/HookMethod/PostConditionFailed.php:  EN„i:  Î‰¥L¤      F   phpunit/Event/Events/Test/HookMethod/PostConditionFailedSubscriber.php>  EN„i>  åàœ¤      >   phpunit/Event/Events/Test/HookMethod/PostConditionFinished.php‰  EN„i‰  •Şì¤      H   phpunit/Event/Events/Test/HookMethod/PostConditionFinishedSubscriber.phpB  EN„iB  WXF“¤      ;   phpunit/Event/Events/Test/HookMethod/PreConditionCalled.phpœ  EN„iœ  º›b±¤      E   phpunit/Event/Events/Test/HookMethod/PreConditionCalledSubscriber.php<  EN„i<  u8O&¤      <   phpunit/Event/Events/Test/HookMethod/PreConditionErrored.php  EN„i  Ü»Pb¤      F   phpunit/Event/Events/Test/HookMethod/PreConditionErroredSubscriber.php>  EN„i>  ‘§¤      ;   phpunit/Event/Events/Test/HookMethod/PreConditionFailed.php8  EN„i8  òÈsƒ¤      E   phpunit/Event/Events/Test/HookMethod/PreConditionFailedSubscriber.php<  EN„i<  >Äw¤      =   phpunit/Event/Events/Test/HookMethod/PreConditionFinished.php‡  EN„i‡  <)Ğj¤      G   phpunit/Event/Events/Test/HookMethod/PreConditionFinishedSubscriber.php@  EN„i@  ¡µX¤      3   phpunit/Event/Events/Test/Issue/ConsideredRisky.phpô  EN„iô  ë1Ÿ ¤      =   phpunit/Event/Events/Test/Issue/ConsideredRiskySubscriber.php6  EN„i6  S%LT¤      8   phpunit/Event/Events/Test/Issue/DeprecationTriggered.phpx  EN„ix  ¼ÿö¤      B   phpunit/Event/Events/Test/Issue/DeprecationTriggeredSubscriber.php@  EN„i@  ö†“¤      2   phpunit/Event/Events/Test/Issue/ErrorTriggered.phpÚ	  EN„iÚ	  ¼W”¤      <   phpunit/Event/Events/Test/Issue/ErrorTriggeredSubscriber.php4  EN„i4  R¹Â5¤      3   phpunit/Event/Events/Test/Issue/NoticeTriggered.php  EN„i  m©ÓX¤      =   phpunit/Event/Events/Test/Issue/NoticeTriggeredSubscriber.php6  EN„i6  'T$¤      ;   phpunit/Event/Events/Test/Issue/PhpDeprecationTriggered.phpC  EN„iC  Šr„¤      E   phpunit/Event/Events/Test/Issue/PhpDeprecationTriggeredSubscriber.phpF  EN„iF  ˆs†¤      6   phpunit/Event/Events/Test/Issue/PhpNoticeTriggered.php  EN„i  Í-+¤      @   phpunit/Event/Events/Test/Issue/PhpNoticeTriggeredSubscriber.php<  EN„i<   M¥s¤      7   phpunit/Event/Events/Test/Issue/PhpWarningTriggered.php  EN„i  fğ2û¤      A   phpunit/Event/Events/Test/Issue/PhpWarningTriggeredSubscriber.php>  EN„i>  «
-d¤      ?   phpunit/Event/Events/Test/Issue/PhpunitDeprecationTriggered.phpi  EN„ii  ¨ªa/¤      I   phpunit/Event/Events/Test/Issue/PhpunitDeprecationTriggeredSubscriber.phpN  EN„iN  lp®¤      9   phpunit/Event/Events/Test/Issue/PhpunitErrorTriggered.phpv  EN„iv  iÎÙ¤      C   phpunit/Event/Events/Test/Issue/PhpunitErrorTriggeredSubscriber.phpB  EN„iB  °Ÿ³;¤      :   phpunit/Event/Events/Test/Issue/PhpunitNoticeTriggered.phpx  EN„ix  dSS8¤      D   phpunit/Event/Events/Test/Issue/PhpunitNoticeTriggeredSubscriber.phpD  EN„iD  
-—¤      ;   phpunit/Event/Events/Test/Issue/PhpunitWarningTriggered.php¿  EN„i¿  )ß¤      E   phpunit/Event/Events/Test/Issue/PhpunitWarningTriggeredSubscriber.phpF  EN„iF  ¶²â¤      4   phpunit/Event/Events/Test/Issue/WarningTriggered.php  EN„i  üæĞ¤      >   phpunit/Event/Events/Test/Issue/WarningTriggeredSubscriber.php8  EN„i8  £®Z{¤      @   phpunit/Event/Events/Test/Lifecycle/DataProviderMethodCalled.phpF  EN„iF  Ÿ?åR¤      J   phpunit/Event/Events/Test/Lifecycle/DataProviderMethodCalledSubscriber.phpH  EN„iH  ë~-r¤      B   phpunit/Event/Events/Test/Lifecycle/DataProviderMethodFinished.php  EN„i  ¯(ín¤      L   phpunit/Event/Events/Test/Lifecycle/DataProviderMethodFinishedSubscriber.phpL  EN„iL  Ç?¤      0   phpunit/Event/Events/Test/Lifecycle/Finished.php8  EN„i8  <ï4¤      :   phpunit/Event/Events/Test/Lifecycle/FinishedSubscriber.php(  EN„i(  .ÍµP¤      :   phpunit/Event/Events/Test/Lifecycle/PreparationErrored.php  EN„i  ’ĞÍ¤      D   phpunit/Event/Events/Test/Lifecycle/PreparationErroredSubscriber.php<  EN„i<  ‰ê¯€¤      9   phpunit/Event/Events/Test/Lifecycle/PreparationFailed.php  EN„i  7+%¤      C   phpunit/Event/Events/Test/Lifecycle/PreparationFailedSubscriber.php:  EN„i:  ØÌ"»¤      :   phpunit/Event/Events/Test/Lifecycle/PreparationStarted.php“  EN„i“  k¹İ¤      D   phpunit/Event/Events/Test/Lifecycle/PreparationStartedSubscriber.php<  EN„i<  &Uep¤      0   phpunit/Event/Events/Test/Lifecycle/Prepared.php~  EN„i~  Öîj¤      :   phpunit/Event/Events/Test/Lifecycle/PreparedSubscriber.php(  EN„i(  Ä§K”¤      -   phpunit/Event/Events/Test/Outcome/Errored.php  EN„i  Èx8¤      7   phpunit/Event/Events/Test/Outcome/ErroredSubscriber.php&  EN„i&  èd3¤      ,   phpunit/Event/Events/Test/Outcome/Failed.php¸  EN„i¸  Ù²!¤      6   phpunit/Event/Events/Test/Outcome/FailedSubscriber.php$  EN„i$  À\*¤      6   phpunit/Event/Events/Test/Outcome/MarkedIncomplete.php$  EN„i$  ş^ß¤      @   phpunit/Event/Events/Test/Outcome/MarkedIncompleteSubscriber.php8  EN„i8  
-6‹¤      ,   phpunit/Event/Events/Test/Outcome/Passed.phpz  EN„iz  Òü—¤      6   phpunit/Event/Events/Test/Outcome/PassedSubscriber.php$  EN„i$  ÂĞ:y¤      -   phpunit/Event/Events/Test/Outcome/Skipped.php´  EN„i´  ŞÔ-¤      7   phpunit/Event/Events/Test/Outcome/SkippedSubscriber.php&  EN„i&  {ªdz¤      5   phpunit/Event/Events/Test/PrintedUnexpectedOutput.php4  EN„i4  D ¤      ?   phpunit/Event/Events/Test/PrintedUnexpectedOutputSubscriber.phpF  EN„iF  ¾4¾­¤      :   phpunit/Event/Events/Test/TestDouble/MockObjectCreated.php  EN„i  ì[~¤      D   phpunit/Event/Events/Test/TestDouble/MockObjectCreatedSubscriber.php:  EN„i:  E¨'á¤      U   phpunit/Event/Events/Test/TestDouble/MockObjectForIntersectionOfInterfacesCreated.phpj  EN„ij  ’Œ¤      _   phpunit/Event/Events/Test/TestDouble/MockObjectForIntersectionOfInterfacesCreatedSubscriber.phpp  EN„ip  -¤      A   phpunit/Event/Events/Test/TestDouble/PartialMockObjectCreated.php3  EN„i3  ÓE„¤      K   phpunit/Event/Events/Test/TestDouble/PartialMockObjectCreatedSubscriber.phpH  EN„iH  øş¡£¤      8   phpunit/Event/Events/Test/TestDouble/TestStubCreated.php  EN„i  ·ÚÅû¤      B   phpunit/Event/Events/Test/TestDouble/TestStubCreatedSubscriber.php6  EN„i6  íà¤      S   phpunit/Event/Events/Test/TestDouble/TestStubForIntersectionOfInterfacesCreated.phpf  EN„if  ¥“Æ‡¤      ]   phpunit/Event/Events/Test/TestDouble/TestStubForIntersectionOfInterfacesCreatedSubscriber.phpl  EN„il  ŠªR¤      5   phpunit/Event/Events/TestRunner/BootstrapFinished.php  EN„i  ySó¤      ?   phpunit/Event/Events/TestRunner/BootstrapFinishedSubscriber.phpF  EN„iF  €2¸=¤      7   phpunit/Event/Events/TestRunner/ChildProcessErrored.php¯  EN„i¯  œR[ª¤      A   phpunit/Event/Events/TestRunner/ChildProcessErroredSubscriber.phpJ  EN„iJ  @$$¤      8   phpunit/Event/Events/TestRunner/ChildProcessFinished.phpé  EN„ié  O†º¤      B   phpunit/Event/Events/TestRunner/ChildProcessFinishedSubscriber.phpL  EN„iL  `¨&¤      7   phpunit/Event/Events/TestRunner/ChildProcessStarted.php¯  EN„i¯  °ıÙg¤      A   phpunit/Event/Events/TestRunner/ChildProcessStartedSubscriber.phpJ  EN„iJ  "4¤      .   phpunit/Event/Events/TestRunner/Configured.php¡  EN„i¡  nTúĞ¤      8   phpunit/Event/Events/TestRunner/ConfiguredSubscriber.php8  EN„i8  ÍL¿Ï¤      8   phpunit/Event/Events/TestRunner/DeprecationTriggered.php'  EN„i'  Ù¾ˆ¤      B   phpunit/Event/Events/TestRunner/DeprecationTriggeredSubscriber.phpL  EN„iL  öñ`2¤      5   phpunit/Event/Events/TestRunner/EventFacadeSealed.php«  EN„i«  jÌ¾¤      ?   phpunit/Event/Events/TestRunner/EventFacadeSealedSubscriber.phpF  EN„iF  $¬v^¤      4   phpunit/Event/Events/TestRunner/ExecutionAborted.php´  EN„i´  uÓ-¤      >   phpunit/Event/Events/TestRunner/ExecutionAbortedSubscriber.phpD  EN„iD  ²sl|¤      5   phpunit/Event/Events/TestRunner/ExecutionFinished.php¶  EN„i¶  ¶"Àq¤      ?   phpunit/Event/Events/TestRunner/ExecutionFinishedSubscriber.phpF  EN„iF  Ó¾ñ¤      4   phpunit/Event/Events/TestRunner/ExecutionStarted.php  EN„i  Ş#<ü¤      >   phpunit/Event/Events/TestRunner/ExecutionStartedSubscriber.phpD  EN„iD  ÿ.¤      9   phpunit/Event/Events/TestRunner/ExtensionBootstrapped.phpr  EN„ir   ½)¼¤      C   phpunit/Event/Events/TestRunner/ExtensionBootstrappedSubscriber.phpN  EN„iN  Ã¥³¤      ;   phpunit/Event/Events/TestRunner/ExtensionLoadedFromPhar.phps  EN„is  Rë¡¤      E   phpunit/Event/Events/TestRunner/ExtensionLoadedFromPharSubscriber.phpR  EN„iR  A‹Æ¾¤      ,   phpunit/Event/Events/TestRunner/Finished.php£  EN„i£  p™¤      6   phpunit/Event/Events/TestRunner/FinishedSubscriber.php4  EN„i4  [Ixé¤      =   phpunit/Event/Events/TestRunner/GarbageCollectionDisabled.phpÇ  EN„iÇ  A\¤      G   phpunit/Event/Events/TestRunner/GarbageCollectionDisabledSubscriber.phpV  EN„iV  yÃW¤      <   phpunit/Event/Events/TestRunner/GarbageCollectionEnabled.phpÅ  EN„iÅ  ‡­M«¤      F   phpunit/Event/Events/TestRunner/GarbageCollectionEnabledSubscriber.phpT  EN„iT  yÄ
-¤      >   phpunit/Event/Events/TestRunner/GarbageCollectionTriggered.phpÉ  EN„iÉ  4†”d¤      H   phpunit/Event/Events/TestRunner/GarbageCollectionTriggeredSubscriber.phpX  EN„iX  €Jz¤      3   phpunit/Event/Events/TestRunner/NoticeTriggered.phpˆ  EN„iˆ  ğ¤      =   phpunit/Event/Events/TestRunner/NoticeTriggeredSubscriber.phpB  EN„iB  ¾ĞòÂ¤      +   phpunit/Event/Events/TestRunner/Started.php¡  EN„i¡  [i¶W¤      5   phpunit/Event/Events/TestRunner/StartedSubscriber.php2  EN„i2  }ÃRp¤      I   phpunit/Event/Events/TestRunner/StaticAnalysisForCodeCoverageFinished.php²  EN„i²  €œRÖ¤      S   phpunit/Event/Events/TestRunner/StaticAnalysisForCodeCoverageFinishedSubscriber.phpn  EN„in  öÏLû¤      H   phpunit/Event/Events/TestRunner/StaticAnalysisForCodeCoverageStarted.phpÔ  EN„iÔ  FCàò¤      R   phpunit/Event/Events/TestRunner/StaticAnalysisForCodeCoverageStartedSubscriber.phpl  EN„il  êÙ§Ó¤      4   phpunit/Event/Events/TestRunner/WarningTriggered.php  EN„i  _Ìò¤      >   phpunit/Event/Events/TestRunner/WarningTriggeredSubscriber.phpD  EN„iD  Ê‰ú±¤      +   phpunit/Event/Events/TestSuite/Filtered.php  EN„i  ñ˜_Õ¤      5   phpunit/Event/Events/TestSuite/FilteredSubscriber.php2  EN„i2  ™?¾Ë¤      +   phpunit/Event/Events/TestSuite/Finished.php3  EN„i3  8›ó¤      5   phpunit/Event/Events/TestSuite/FinishedSubscriber.php2  EN„i2  JVˆ8¤      )   phpunit/Event/Events/TestSuite/Loaded.php  EN„i  ¤      3   phpunit/Event/Events/TestSuite/LoadedSubscriber.php.  EN„i.  ˜š)¤      *   phpunit/Event/Events/TestSuite/Skipped.php•  EN„i•  ëİL¤      4   phpunit/Event/Events/TestSuite/SkippedSubscriber.php0  EN„i0  èÇ¤      )   phpunit/Event/Events/TestSuite/Sorted.php1  EN„i1  úl9´¤      3   phpunit/Event/Events/TestSuite/SortedSubscriber.php.  EN„i.  İIN"¤      *   phpunit/Event/Events/TestSuite/Started.php1  EN„i1  9ˆÇ¤      4   phpunit/Event/Events/TestSuite/StartedSubscriber.php0  EN„i0  ¿İ.¤      9   phpunit/Event/Exception/EventAlreadyAssignedException.php  EN„i  0•É¤      8   phpunit/Event/Exception/EventFacadeIsSealedException.php
-  EN„i
-  JÂØ¤      %   phpunit/Event/Exception/Exception.php½  EN„i½  /7rr¤      4   phpunit/Event/Exception/InvalidArgumentException.phpù  EN„iù  Ûä€¤      1   phpunit/Event/Exception/InvalidEventException.php  EN„i  E>¯¤      6   phpunit/Event/Exception/InvalidSubscriberException.php  EN„i  SÜg¤      $   phpunit/Event/Exception/MapError.phpö  EN„iö  Õ÷äR¤      8   phpunit/Event/Exception/NoComparisonFailureException.php  EN„i  â{k ¤      >   phpunit/Event/Exception/NoDataSetFromDataProviderException.php'  EN„i'  @~à¤      8   phpunit/Event/Exception/NoPreviousThrowableException.php
-  EN„i
-  Ùú¦~¤      @   phpunit/Event/Exception/NoTestCaseObjectOnCallStackException.phpù  EN„iù  xs§Ù¤      ,   phpunit/Event/Exception/RuntimeException.phpé  EN„ié  LÆ¤      D   phpunit/Event/Exception/SubscriberTypeAlreadyRegisteredException.php  EN„i  Ä¯¨K¤      1   phpunit/Event/Exception/UnknownEventException.php  EN„i  šÜ}ê¤      5   phpunit/Event/Exception/UnknownEventTypeException.php  EN„i  /<ˆ¡¤      6   phpunit/Event/Exception/UnknownSubscriberException.php  EN„i  ²ÉË¤      :   phpunit/Event/Exception/UnknownSubscriberTypeException.php  EN„i  &'ı*¤         phpunit/Event/Facade.php$  EN„i$  âıú¤         phpunit/Event/Subscriber.php£  EN„i£  dlkû¤         phpunit/Event/Tracer.phpî  EN„iî  €Úm¤         phpunit/Event/TypeMap.php[  EN„i[  %À;|¤      #   phpunit/Event/Value/ClassMethod.phpj  EN„ij  ı¢—¤      )   phpunit/Event/Value/ComparisonFailure.phpË  EN„iË  Š6IQ¤      0   phpunit/Event/Value/ComparisonFailureBuilder.php^  EN„i^  Õ?`Ÿ¤      /   phpunit/Event/Value/Runtime/OperatingSystem.php¢  EN„i¢  Âá—÷¤      #   phpunit/Event/Value/Runtime/PHP.phpÄ  EN„iÄ  †ƒÖ½¤      '   phpunit/Event/Value/Runtime/PHPUnit.php^  EN„i^   7:á¤      '   phpunit/Event/Value/Runtime/Runtime.php´  EN„i´  Ë&TŒ¤      *   phpunit/Event/Value/Telemetry/Duration.phpÑ  EN„iÑ  ëØ`†¤      8   phpunit/Event/Value/Telemetry/GarbageCollectorStatus.phpŞ	  EN„iŞ	  Ó5ƒ¤      @   phpunit/Event/Value/Telemetry/GarbageCollectorStatusProvider.phpp  EN„ip  rÙ¤      (   phpunit/Event/Value/Telemetry/HRTime.php	  EN„i	  mÖ¥¤      &   phpunit/Event/Value/Telemetry/Info.php
-  EN„i
-  fÔ‹¤      -   phpunit/Event/Value/Telemetry/MemoryMeter.php¤  EN„i¤  'ìä}¤      -   phpunit/Event/Value/Telemetry/MemoryUsage.php^  EN„i^  Übi¤      *   phpunit/Event/Value/Telemetry/Snapshot.php…  EN„i…  âš‹ø¤      +   phpunit/Event/Value/Telemetry/StopWatch.phpL  EN„iL  QØ¡6¤      (   phpunit/Event/Value/Telemetry/System.php•  EN„i•  öÈˆÉ¤      F   phpunit/Event/Value/Telemetry/SystemGarbageCollectorStatusProvider.phpR  EN„iR  ÃRH¤      3   phpunit/Event/Value/Telemetry/SystemMemoryMeter.phpç  EN„iç  >ÿ¤      1   phpunit/Event/Value/Telemetry/SystemStopWatch.phpc  EN„ic  ı‚÷H¤      ;   phpunit/Event/Value/Telemetry/SystemStopWatchWithOffset.php½  EN„i½  ‹'^L¤      0   phpunit/Event/Value/Test/Issue/DirectTrigger.php  EN„i  ¦†±.¤      2   phpunit/Event/Value/Test/Issue/IndirectTrigger.php  EN„i  h[ÊŸ¤      /   phpunit/Event/Value/Test/Issue/IssueTrigger.php2	  EN„i2	  *íÚ ¤      .   phpunit/Event/Value/Test/Issue/SelfTrigger.php  EN„i  #êaá¤      .   phpunit/Event/Value/Test/Issue/TestTrigger.phpß  EN„iß  hq-µ¤      1   phpunit/Event/Value/Test/Issue/UnknownTrigger.phpÖ  EN„iÖ  ³y¤      !   phpunit/Event/Value/Test/Phpt.php  EN„i  3{ŞY¤      !   phpunit/Event/Value/Test/Test.phpÓ  EN„iÓ  Ù[U¼¤      +   phpunit/Event/Value/Test/TestCollection.php"  EN„i"  ¨>Æ¤      3   phpunit/Event/Value/Test/TestCollectionIterator.php$  EN„i$   ‡ˆS¤      :   phpunit/Event/Value/Test/TestData/DataFromDataProvider.phpÅ  EN„iÅ  öÆ¥¤      <   phpunit/Event/Value/Test/TestData/DataFromTestDependency.php°  EN„i°  8åçË¤      .   phpunit/Event/Value/Test/TestData/TestData.phpÄ  EN„iÄ   æ·¤      8   phpunit/Event/Value/Test/TestData/TestDataCollection.php  EN„i  '¬¤      @   phpunit/Event/Value/Test/TestData/TestDataCollectionIterator.php>  EN„i>  SSÔØ¤      $   phpunit/Event/Value/Test/TestDox.phpò  EN„iò  b°oŠ¤      +   phpunit/Event/Value/Test/TestDoxBuilder.phpÇ  EN„iÇ  Rçò^¤      '   phpunit/Event/Value/Test/TestMethod.php:  EN„i:  Œ&úe¤      .   phpunit/Event/Value/Test/TestMethodBuilder.php4
-  EN„i4
-  1Á¤      +   phpunit/Event/Value/TestSuite/TestSuite.php^  EN„i^  Ó,[Š¤      2   phpunit/Event/Value/TestSuite/TestSuiteBuilder.phpl  EN„il  •š÷¤      7   phpunit/Event/Value/TestSuite/TestSuiteForTestClass.php5  EN„i5  ŞŞmP¤      H   phpunit/Event/Value/TestSuite/TestSuiteForTestMethodWithDataProvider.phpÙ  EN„iÙ  .^¤      3   phpunit/Event/Value/TestSuite/TestSuiteWithName.phpD  EN„iD  jW;¤      !   phpunit/Event/Value/Throwable.php	  EN„i	  W¾¼¤      (   phpunit/Event/Value/ThrowableBuilder.php‹  EN„i‹  CÎ“¤         phpunit/Exception.php½  EN„i½  ĞA-¤         phpunit/Framework/Assert.phpìh EN„iìh  óI_¤      &   phpunit/Framework/Assert/Functions.php"½ EN„i"½ ÖÏì¤      &   phpunit/Framework/Attributes/After.phpÎ  EN„iÎ  w§¤      +   phpunit/Framework/Attributes/AfterClass.phpÓ  EN„iÓ  9Á±¤      D   phpunit/Framework/Attributes/AllowMockObjectsWithoutExpectations.php7  EN„i7  5>%¤      .   phpunit/Framework/Attributes/BackupGlobals.phpé  EN„ié  m4B·¤      7   phpunit/Framework/Attributes/BackupStaticProperties.phpò  EN„iò  y	!„¤      '   phpunit/Framework/Attributes/Before.phpÏ  EN„iÏ  ŠNÌ2¤      ,   phpunit/Framework/Attributes/BeforeClass.phpÔ  EN„iÔ  ·	Gå¤      ,   phpunit/Framework/Attributes/CoversClass.php„  EN„i„  T^ù§¤      =   phpunit/Framework/Attributes/CoversClassesThatExtendClass.php•  EN„i•  Úæš¤      D   phpunit/Framework/Attributes/CoversClassesThatImplementInterface.php¸  EN„i¸  £Ã¤      /   phpunit/Framework/Attributes/CoversFunction.php¨  EN„i¨  u®ôK¤      -   phpunit/Framework/Attributes/CoversMethod.phpÅ  EN„iÅ  ş¨So¤      0   phpunit/Framework/Attributes/CoversNamespace.php”  EN„i”  wQdÊ¤      .   phpunit/Framework/Attributes/CoversNothing.php!  EN„i!  z3Š¤      ,   phpunit/Framework/Attributes/CoversTrait.php„  EN„i„  ã®¶¤      -   phpunit/Framework/Attributes/DataProvider.php‘  EN„i‘  •¾Œ¤      5   phpunit/Framework/Attributes/DataProviderExternal.phpÆ  EN„iÆ  GÓU¤      (   phpunit/Framework/Attributes/Depends.php”  EN„i”  ¶6"¤      0   phpunit/Framework/Attributes/DependsExternal.phpÉ  EN„iÉ  ·¶Q¤      >   phpunit/Framework/Attributes/DependsExternalUsingDeepClone.php×  EN„i×  ŒQU,¤      A   phpunit/Framework/Attributes/DependsExternalUsingShallowClone.phpÚ  EN„iÚ  ÃuI¤      /   phpunit/Framework/Attributes/DependsOnClass.phpˆ  EN„iˆ  £‡Ó¤      =   phpunit/Framework/Attributes/DependsOnClassUsingDeepClone.php–  EN„i–  •#kû¤      @   phpunit/Framework/Attributes/DependsOnClassUsingShallowClone.php™  EN„i™  fùÕ¤      6   phpunit/Framework/Attributes/DependsUsingDeepClone.php¢  EN„i¢  «&…á¤      9   phpunit/Framework/Attributes/DependsUsingShallowClone.php¥  EN„i¥  r@P¤      K   phpunit/Framework/Attributes/DisableReturnValueGenerationForTestDoubles.php#  EN„i#  Y¿tE¤      9   phpunit/Framework/Attributes/DoesNotPerformAssertions.php,  EN„i,   a¡¤      @   phpunit/Framework/Attributes/ExcludeGlobalVariableFromBackup.phpş  EN„iş  ¡ım¤      @   phpunit/Framework/Attributes/ExcludeStaticPropertyFromBackup.php  EN„i  …çğò¤      &   phpunit/Framework/Attributes/Group.php‚  EN„i‚  àãŸ¤      3   phpunit/Framework/Attributes/IgnoreDeprecations.phpË  EN„iË  ç¾Ø¤      :   phpunit/Framework/Attributes/IgnorePhpunitDeprecations.php‰  EN„i‰  Ç}±ı¤      6   phpunit/Framework/Attributes/IgnorePhpunitWarnings.php´  EN„i´  UÜ«Ë¤      &   phpunit/Framework/Attributes/Large.phpş  EN„iş  ¤      '   phpunit/Framework/Attributes/Medium.phpÿ  EN„iÿ  `4à¤      .   phpunit/Framework/Attributes/PostCondition.phpÖ  EN„iÖ  )[.¤      -   phpunit/Framework/Attributes/PreCondition.phpÕ  EN„iÕ  •(y¤      4   phpunit/Framework/Attributes/PreserveGlobalState.phpï  EN„iï  rm¿c¤      <   phpunit/Framework/Attributes/RequiresEnvironmentVariable.php$  EN„i$  fX¤      1   phpunit/Framework/Attributes/RequiresFunction.phpÅ  EN„iÅ  Xê¤      /   phpunit/Framework/Attributes/RequiresMethod.phpâ  EN„iâ  0ĞÏš¤      8   phpunit/Framework/Attributes/RequiresOperatingSystem.phpÔ  EN„iÔ  Ñü’Ö¤      >   phpunit/Framework/Attributes/RequiresOperatingSystemFamily.phpö  EN„iö  ê?Á‡¤      ,   phpunit/Framework/Attributes/RequiresPhp.phpÏ  EN„iÏ  Ç¯o¤      5   phpunit/Framework/Attributes/RequiresPhpExtension.phpF  EN„iF  ;9°£¤      0   phpunit/Framework/Attributes/RequiresPhpunit.phpÓ  EN„iÓ  ãïc“¤      9   phpunit/Framework/Attributes/RequiresPhpunitExtension.php  EN„i  rÙã¤      0   phpunit/Framework/Attributes/RequiresSetting.phpº  EN„iº  ª_p¿¤      :   phpunit/Framework/Attributes/RunClassInSeparateProcess.php]  EN„i]  CÍÕk¤      5   phpunit/Framework/Attributes/RunInSeparateProcess.php  EN„i  Õ}³¤      <   phpunit/Framework/Attributes/RunTestsInSeparateProcesses.php  EN„i  ú£Hz¤      &   phpunit/Framework/Attributes/Small.phpş  EN„iş  ˜
-´w¤      %   phpunit/Framework/Attributes/Test.phpş  EN„iş  77d‹¤      (   phpunit/Framework/Attributes/TestDox.phpi  EN„ii  éXL¤      1   phpunit/Framework/Attributes/TestDoxFormatter.php‚  EN„i‚  axÇÅ¤      9   phpunit/Framework/Attributes/TestDoxFormatterExternal.php·  EN„i·  EîÅ¤      )   phpunit/Framework/Attributes/TestWith.php€  EN„i€  2Míw¤      -   phpunit/Framework/Attributes/TestWithJson.php  EN„i  –	á¤      '   phpunit/Framework/Attributes/Ticket.phpƒ  EN„iƒ  „,D¤      *   phpunit/Framework/Attributes/UsesClass.php‚  EN„i‚  Ä3­¤      ;   phpunit/Framework/Attributes/UsesClassesThatExtendClass.php“  EN„i“  ”<¤      B   phpunit/Framework/Attributes/UsesClassesThatImplementInterface.php¶  EN„i¶  ÿ·¹´¤      -   phpunit/Framework/Attributes/UsesFunction.php¦  EN„i¦  =Yï¤      +   phpunit/Framework/Attributes/UsesMethod.phpÃ  EN„iÃ  ,Ap´¤      .   phpunit/Framework/Attributes/UsesNamespace.php’  EN„i’  Î¾ë¤      *   phpunit/Framework/Attributes/UsesTrait.php‚  EN„i‚  ²4K¼¤      8   phpunit/Framework/Attributes/WithEnvironmentVariable.phpÅ  EN„iÅ  èÇ£e¤      4   phpunit/Framework/Attributes/WithoutErrorHandler.php  EN„i  ñO½¤      0   phpunit/Framework/Constraint/Boolean/IsFalse.php`  EN„i`  , µá¤      /   phpunit/Framework/Constraint/Boolean/IsTrue.php]  EN„i]  ?6şÍ¤      )   phpunit/Framework/Constraint/Callback.phpú  EN„iú  J¢c¤      2   phpunit/Framework/Constraint/Cardinality/Count.phpY  EN„iY  º™/¤      8   phpunit/Framework/Constraint/Cardinality/GreaterThan.php(  EN„i(  ¥¯¤      4   phpunit/Framework/Constraint/Cardinality/IsEmpty.phpŒ  EN„iŒ  [c[¤      5   phpunit/Framework/Constraint/Cardinality/LessThan.php"  EN„i"  ¡°%¤      5   phpunit/Framework/Constraint/Cardinality/SameSize.phpû  EN„iû  
-™08¤      +   phpunit/Framework/Constraint/Constraint.php‘#  EN„i‘#  ãn]¤      1   phpunit/Framework/Constraint/Equality/IsEqual.phpc
-  EN„ic
+ñ¤      5   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Mul.phpH  ©t…iH  	œt¤      :   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/NotEqual.phpS  ©t…iS  ¨½£Í¤      >   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/NotIdentical.php\  ©t…i\  õc_¤      6   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Pipe.phpK  ©t…iK  uõ$¤      6   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Plus.phpJ  ©t…iJ  cmÂ¤      5   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Pow.phpI  ©t…iI  ­Ş,ô¤      ;   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/ShiftLeft.phpU  ©t…iU  C”Xe¤      <   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/ShiftRight.phpW  ©t…iW  ü;‘¤      9   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Smaller.phpP  ©t…iP  T— å¤      @   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/SmallerOrEqual.php_  ©t…i_  èJ³¤      ;   nikic-php-parser/PhpParser/Node/Expr/BinaryOp/Spaceship.phpV  ©t…iV  ã”Ex¤      3   nikic-php-parser/PhpParser/Node/Expr/BitwiseNot.php­  ©t…i­  }lMË¤      3   nikic-php-parser/PhpParser/Node/Expr/BooleanNot.php­  ©t…i­  sÂ7Ş¤      1   nikic-php-parser/PhpParser/Node/Expr/CallLike.php  ©t…i  ö$‘b¤      -   nikic-php-parser/PhpParser/Node/Expr/Cast.phpU  ©t…iU  ¼ö³ğ¤      4   nikic-php-parser/PhpParser/Node/Expr/Cast/Array_.phpî   ©t…iî   È¯¾š¤      3   nikic-php-parser/PhpParser/Node/Expr/Cast/Bool_.php  ©t…i  uxå¤      4   nikic-php-parser/PhpParser/Node/Expr/Cast/Double.php·  ©t…i·  S(Û¤      2   nikic-php-parser/PhpParser/Node/Expr/Cast/Int_.php{  ©t…i{  ú{¤      5   nikic-php-parser/PhpParser/Node/Expr/Cast/Object_.phpğ   ©t…iğ   \­‘°¤      5   nikic-php-parser/PhpParser/Node/Expr/Cast/String_.php…  ©t…i…  Øú{Æ¤      4   nikic-php-parser/PhpParser/Node/Expr/Cast/Unset_.phpî   ©t…iî   É”™Ô¤      3   nikic-php-parser/PhpParser/Node/Expr/Cast/Void_.phpì   ©t…iì   šõ±d¤      8   nikic-php-parser/PhpParser/Node/Expr/ClassConstFetch.php  ©t…i  2å¤      /   nikic-php-parser/PhpParser/Node/Expr/Clone_.php  ©t…i  ™×¤      0   nikic-php-parser/PhpParser/Node/Expr/Closure.phpj  ©t…ij  òI¶¤      3   nikic-php-parser/PhpParser/Node/Expr/ConstFetch.phpØ  ©t…iØ  s>6¤      /   nikic-php-parser/PhpParser/Node/Expr/Empty_.php¡  ©t…i¡  ¸¨İ¤      .   nikic-php-parser/PhpParser/Node/Expr/Error.php  ©t…i  $ŸLŒ¤      6   nikic-php-parser/PhpParser/Node/Expr/ErrorSuppress.php·  ©t…i·  Î	&¤      .   nikic-php-parser/PhpParser/Node/Expr/Eval_.php  ©t…i  A[¤      .   nikic-php-parser/PhpParser/Node/Expr/Exit_.php  ©t…i  gİí¼¤      1   nikic-php-parser/PhpParser/Node/Expr/FuncCall.php  ©t…i  @"]¤      1   nikic-php-parser/PhpParser/Node/Expr/Include_.phpÍ  ©t…iÍ  —ÀÊ¤      4   nikic-php-parser/PhpParser/Node/Expr/Instanceof_.php•  ©t…i•  .§B ¤      /   nikic-php-parser/PhpParser/Node/Expr/Isset_.php£  ©t…i£  ò>:¤      .   nikic-php-parser/PhpParser/Node/Expr/List_.php£  ©t…i£  2ò¿)¤      /   nikic-php-parser/PhpParser/Node/Expr/Match_.php;  ©t…i;  hü¤      3   nikic-php-parser/PhpParser/Node/Expr/MethodCall.phpQ  ©t…iQ  OD¥å¤      -   nikic-php-parser/PhpParser/Node/Expr/New_.php•  ©t…i•  <~h¤      ;   nikic-php-parser/PhpParser/Node/Expr/NullsafeMethodCall.phph  ©t…ih  k[˜S¤      >   nikic-php-parser/PhpParser/Node/Expr/NullsafePropertyFetch.php  ©t…i  k*¢¤      0   nikic-php-parser/PhpParser/Node/Expr/PostDec.php   ©t…i   Ph@¤      0   nikic-php-parser/PhpParser/Node/Expr/PostInc.php   ©t…i   dŞ‡¤      /   nikic-php-parser/PhpParser/Node/Expr/PreDec.php  ©t…i  ÍmB'¤      /   nikic-php-parser/PhpParser/Node/Expr/PreInc.php  ©t…i  Ô·$x¤      /   nikic-php-parser/PhpParser/Node/Expr/Print_.php¡  ©t…i¡  U¤óô¤      6   nikic-php-parser/PhpParser/Node/Expr/PropertyFetch.phpê  ©t…iê  :%g¤      2   nikic-php-parser/PhpParser/Node/Expr/ShellExec.phpH  ©t…iH  edü¤      3   nikic-php-parser/PhpParser/Node/Expr/StaticCall.php\  ©t…i\  ©ÁP¼¤      <   nikic-php-parser/PhpParser/Node/Expr/StaticPropertyFetch.php;  ©t…i;  ç.½ ¤      0   nikic-php-parser/PhpParser/Node/Expr/Ternary.phpè  ©t…iè  :X(¤      /   nikic-php-parser/PhpParser/Node/Expr/Throw_.php½  ©t…i½  #‚6¢¤      3   nikic-php-parser/PhpParser/Node/Expr/UnaryMinus.php­  ©t…i­  ¾*C‰¤      2   nikic-php-parser/PhpParser/Node/Expr/UnaryPlus.phpª  ©t…iª  F!Ä¤      1   nikic-php-parser/PhpParser/Node/Expr/Variable.php  ©t…i  ìEk¤      2   nikic-php-parser/PhpParser/Node/Expr/YieldFrom.php»  ©t…i»  ôBß¤      /   nikic-php-parser/PhpParser/Node/Expr/Yield_.phpo  ©t…io  ‘Æ´¤      0   nikic-php-parser/PhpParser/Node/FunctionLike.phpï  ©t…iï  Êj¸¤      .   nikic-php-parser/PhpParser/Node/Identifier.phpR  ©t…iR  ¦œú¤      :   nikic-php-parser/PhpParser/Node/InterpolatedStringPart.phpr  ©t…ir  kGşn¤      4   nikic-php-parser/PhpParser/Node/IntersectionType.php¯  ©t…i¯  €”u«¤      ,   nikic-php-parser/PhpParser/Node/MatchArm.php¹  ©t…i¹  ›Q\¤¤      (   nikic-php-parser/PhpParser/Node/Name.phpÙ!  ©t…iÙ!  ÿ6VË¤      7   nikic-php-parser/PhpParser/Node/Name/FullyQualified.phpÂ  ©t…iÂ  ø 2¤      1   nikic-php-parser/PhpParser/Node/Name/Relative.php¿  ©t…i¿  ‰8½V¤      0   nikic-php-parser/PhpParser/Node/NullableType.phpÈ  ©t…iÈ  Õä¤      )   nikic-php-parser/PhpParser/Node/Param.phpë  ©t…ië  r
+@¤      0   nikic-php-parser/PhpParser/Node/PropertyHook.phpÉ  ©t…iÉ  \üBA¤      0   nikic-php-parser/PhpParser/Node/PropertyItem.php\  ©t…i\  ¦`º¤      *   nikic-php-parser/PhpParser/Node/Scalar.phpo   ©t…io   ­¦ş=¤      1   nikic-php-parser/PhpParser/Node/Scalar/Float_.phpW  ©t…iW  j©Æ¤      /   nikic-php-parser/PhpParser/Node/Scalar/Int_.phpø	  ©t…iø	  Ÿ‘¤      =   nikic-php-parser/PhpParser/Node/Scalar/InterpolatedString.phpİ  ©t…iİ  ?Ã	Z¤      5   nikic-php-parser/PhpParser/Node/Scalar/MagicConst.phpx  ©t…ix  ÷Ï®÷¤      <   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Class_.phpZ  ©t…iZ  ÁÆÓ5¤      9   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Dir.phpS  ©t…iS  rÙfÉ¤      :   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/File.phpV  ©t…iV  6›Q¤      ?   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Function_.phpc  ©t…ic  —5¤¤      :   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Line.phpV  ©t…iV  èDEš¤      <   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Method.php\  ©t…i\  Ë2N¤      @   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Namespace_.phpf  ©t…if  ‹Ãq¤      >   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Property.phpb  ©t…ib  0º«¤      <   nikic-php-parser/PhpParser/Node/Scalar/MagicConst/Trait_.phpZ  ©t…iZ  Ëµİ¤      2   nikic-php-parser/PhpParser/Node/Scalar/String_.phpÀ  ©t…iÀ  ‰–ƒË¤      -   nikic-php-parser/PhpParser/Node/StaticVar.php  ©t…i  ñT>¤      (   nikic-php-parser/PhpParser/Node/Stmt.php   ©t…i   «yş¤      .   nikic-php-parser/PhpParser/Node/Stmt/Block.php§  ©t…i§  ×j¤      /   nikic-php-parser/PhpParser/Node/Stmt/Break_.phpÛ  ©t…iÛ  mj–¤      .   nikic-php-parser/PhpParser/Node/Stmt/Case_.php†  ©t…i†  İ¸O/¤      /   nikic-php-parser/PhpParser/Node/Stmt/Catch_.phpy  ©t…iy  {é^}¤      3   nikic-php-parser/PhpParser/Node/Stmt/ClassConst.phpS  ©t…iS  /ê¾¬¤      2   nikic-php-parser/PhpParser/Node/Stmt/ClassLike.php  ©t…i  üÄsİ¤      4   nikic-php-parser/PhpParser/Node/Stmt/ClassMethod.php÷  ©t…i÷  #c¤      /   nikic-php-parser/PhpParser/Node/Stmt/Class_.php¸  ©t…i¸  Æ1è?¤      /   nikic-php-parser/PhpParser/Node/Stmt/Const_.phpÊ  ©t…iÊ  ¤      2   nikic-php-parser/PhpParser/Node/Stmt/Continue_.phpê  ©t…iê  Çò¥€¤      1   nikic-php-parser/PhpParser/Node/Stmt/Declare_.php½  ©t…i½  5‹`ä¤      ,   nikic-php-parser/PhpParser/Node/Stmt/Do_.phpT  ©t…iT  %ú0¤      .   nikic-php-parser/PhpParser/Node/Stmt/Echo_.php´  ©t…i´  ±°`)¤      0   nikic-php-parser/PhpParser/Node/Stmt/ElseIf_.php[  ©t…i[  bE·Ñ¤      .   nikic-php-parser/PhpParser/Node/Stmt/Else_.php·  ©t…i·  &ô¡Á¤      1   nikic-php-parser/PhpParser/Node/Stmt/EnumCase.php»  ©t…i»  w4m¤      .   nikic-php-parser/PhpParser/Node/Stmt/Enum_.phpJ  ©t…iJ  ›Œï?¤      3   nikic-php-parser/PhpParser/Node/Stmt/Expression.php÷  ©t…i÷  À¤      1   nikic-php-parser/PhpParser/Node/Stmt/Finally_.php¿  ©t…i¿  8ååå¤      -   nikic-php-parser/PhpParser/Node/Stmt/For_.php¼  ©t…i¼  €‚½+¤      1   nikic-php-parser/PhpParser/Node/Stmt/Foreach_.phpĞ  ©t…iĞ  µ0–×¤      2   nikic-php-parser/PhpParser/Node/Stmt/Function_.php¬
+  ©t…i¬
+  f*í‚¤      0   nikic-php-parser/PhpParser/Node/Stmt/Global_.phpÇ  ©t…iÇ  Po6¤      .   nikic-php-parser/PhpParser/Node/Stmt/Goto_.php"  ©t…i"  ĞX–¤      1   nikic-php-parser/PhpParser/Node/Stmt/GroupUse.php^  ©t…i^  €¦7Ñ¤      5   nikic-php-parser/PhpParser/Node/Stmt/HaltCompiler.php!  ©t…i!  ˜×y¤      ,   nikic-php-parser/PhpParser/Node/Stmt/If_.php‘  ©t…i‘  4‡o¤      3   nikic-php-parser/PhpParser/Node/Stmt/InlineHTML.php´  ©t…i´  oûÈ‡¤      3   nikic-php-parser/PhpParser/Node/Stmt/Interface_.phpN  ©t…iN  ™yáÆ¤      .   nikic-php-parser/PhpParser/Node/Stmt/Label.phpü  ©t…iü  ŸäJ¤      3   nikic-php-parser/PhpParser/Node/Stmt/Namespace_.phpİ  ©t…iİ  SvEj¤      ,   nikic-php-parser/PhpParser/Node/Stmt/Nop.phpF  ©t…iF  $6¿Ø¤      1   nikic-php-parser/PhpParser/Node/Stmt/Property.phpÑ  ©t…iÑ  rİ¦¥¤      0   nikic-php-parser/PhpParser/Node/Stmt/Return_.phpÈ  ©t…iÈ  |M¤      0   nikic-php-parser/PhpParser/Node/Stmt/Static_.phpş  ©t…iş  ’ÙœŞ¤      0   nikic-php-parser/PhpParser/Node/Stmt/Switch_.phpI  ©t…iI  iËÇü¤      1   nikic-php-parser/PhpParser/Node/Stmt/TraitUse.phpš  ©t…iš  ?óô\¤      ;   nikic-php-parser/PhpParser/Node/Stmt/TraitUseAdaptation.php=  ©t…i=  {:Š¤      A   nikic-php-parser/PhpParser/Node/Stmt/TraitUseAdaptation/Alias.php1  ©t…i1  b Ö¤      F   nikic-php-parser/PhpParser/Node/Stmt/TraitUseAdaptation/Precedence.php>  ©t…i>  ¶Ñÿ ¤      /   nikic-php-parser/PhpParser/Node/Stmt/Trait_.phpQ  ©t…iQ  ËEøQ¤      1   nikic-php-parser/PhpParser/Node/Stmt/TryCatch.php6  ©t…i6  ‚ã2.¤      /   nikic-php-parser/PhpParser/Node/Stmt/Unset_.php¿  ©t…i¿  :VÉÉ¤      -   nikic-php-parser/PhpParser/Node/Stmt/Use_.phpÔ  ©t…iÔ  Ç|¤      /   nikic-php-parser/PhpParser/Node/Stmt/While_.phpW  ©t…iW  Q/£×¤      -   nikic-php-parser/PhpParser/Node/UnionType.php»  ©t…i»  ’Hš­¤      +   nikic-php-parser/PhpParser/Node/UseItem.phpÇ  ©t…iÇ  73Uƒ¤      5   nikic-php-parser/PhpParser/Node/VarLikeIdentifier.php  ©t…i  y .¤      7   nikic-php-parser/PhpParser/Node/VariadicPlaceholder.php¯  ©t…i¯  mäWè¤      +   nikic-php-parser/PhpParser/NodeAbstract.php7  ©t…i7  ë¾i‚¤      )   nikic-php-parser/PhpParser/NodeDumper.phpû'  ©t…iû'  ŒÍO ¤      )   nikic-php-parser/PhpParser/NodeFinder.phpW
+  ©t…iW
+  ¥¹^‘¤      ,   nikic-php-parser/PhpParser/NodeTraverser.php«&  ©t…i«&  ñ†øm¤      5   nikic-php-parser/PhpParser/NodeTraverserInterface.phpa  ©t…ia  ½©ìğ¤      *   nikic-php-parser/PhpParser/NodeVisitor.phpX  ©t…iX  İp}ª¤      9   nikic-php-parser/PhpParser/NodeVisitor/CloningVisitor.php  ©t…i  î"Û¤      C   nikic-php-parser/PhpParser/NodeVisitor/CommentAnnotatingVisitor.php¶
+  ©t…i¶
+  ªÉ^µ¤      9   nikic-php-parser/PhpParser/NodeVisitor/FindingVisitor.php¥  ©t…i¥  í1A¤      >   nikic-php-parser/PhpParser/NodeVisitor/FirstFindingVisitor.php  ©t…i  ~Ä¬*¤      7   nikic-php-parser/PhpParser/NodeVisitor/NameResolver.phpA(  ©t…iA(  x_Á¤      @   nikic-php-parser/PhpParser/NodeVisitor/NodeConnectingVisitor.php$	  ©t…i$	  Vü ¤      B   nikic-php-parser/PhpParser/NodeVisitor/ParentConnectingVisitor.phpk  ©t…ik  [>¤      2   nikic-php-parser/PhpParser/NodeVisitorAbstract.phpÙ  ©t…iÙ  ¡¿é~¤      %   nikic-php-parser/PhpParser/Parser.php	  ©t…i	  œ0@¤      *   nikic-php-parser/PhpParser/Parser/Php7.phpå ©t…iå ©?/}¤      *   nikic-php-parser/PhpParser/Parser/Php8.phpm ©t…im Á†DÊ¤      -   nikic-php-parser/PhpParser/ParserAbstract.phpÇ  ©t…iÇ  .€m©¤      ,   nikic-php-parser/PhpParser/ParserFactory.phpÖ  ©t…iÖ  (ŸÉc¤      )   nikic-php-parser/PhpParser/PhpVersion.php—  ©t…i—  ªşßj¤      ,   nikic-php-parser/PhpParser/PrettyPrinter.php¸  ©t…i¸  >¹—´¤      5   nikic-php-parser/PhpParser/PrettyPrinter/Standard.phpÏ  ©t…iÏ  ­Û'{¤      4   nikic-php-parser/PhpParser/PrettyPrinterAbstract.php
+ ©t…i
+ 8f(¤      $   nikic-php-parser/PhpParser/Token.phpû  ©t…iû  ÇãÌ¤      3   nikic-php-parser/PhpParser/compatibility_tokens.php1	  ©t…i1	  ¬”‚É¤         object-enumerator/LICENSEû  ©t…iû  ÏÜpŸ¤         object-reflector/LICENSEû  ©t…iû  ûO«¤         phar-io-manifest/LICENSE`  ©t…i`  ÷şp¤      +   phar-io-manifest/ManifestDocumentMapper.phpë  ©t…ië  ^DŒï¤      #   phar-io-manifest/ManifestLoader.phpÿ  ©t…iÿ  ÙX©j¤      '   phar-io-manifest/ManifestSerializer.phpÏ  ©t…iÏ  ?jª'¤      :   phar-io-manifest/exceptions/ElementCollectionException.php  ©t…i  In‡¤      )   phar-io-manifest/exceptions/Exception.phpÓ  ©t…iÓ  Ö½Ğ¤      ?   phar-io-manifest/exceptions/InvalidApplicationNameException.php<  ©t…i<  °°¯W¤      5   phar-io-manifest/exceptions/InvalidEmailException.php  ©t…i  )Ïª}¤      3   phar-io-manifest/exceptions/InvalidUrlException.php  ©t…i  xá³¤      9   phar-io-manifest/exceptions/ManifestDocumentException.php  ©t…i  /úï"¤      @   phar-io-manifest/exceptions/ManifestDocumentLoadingException.php~  ©t…i~  H}»¤      ?   phar-io-manifest/exceptions/ManifestDocumentMapperException.php  ©t…i  J¯R1¤      8   phar-io-manifest/exceptions/ManifestElementException.php  ©t…i  Ìæ¤      7   phar-io-manifest/exceptions/ManifestLoaderException.phpä  ©t…iä  Íl
+½¤      7   phar-io-manifest/exceptions/NoEmailAddressException.php  ©t…i  áÁü¤      '   phar-io-manifest/values/Application.php	  ©t…i	  ;Äk¤      +   phar-io-manifest/values/ApplicationName.php…  ©t…i…  á”ù¤      "   phar-io-manifest/values/Author.php   ©t…i   ÷x•ü¤      ,   phar-io-manifest/values/AuthorCollection.php-  ©t…i-  àÍá¤      4   phar-io-manifest/values/AuthorCollectionIterator.php¡  ©t…i¡  ¨Ğªe¤      ,   phar-io-manifest/values/BundledComponent.phpd  ©t…id  7õõ¤      6   phar-io-manifest/values/BundledComponentCollection.php¹  ©t…i¹  ·æß¤      >   phar-io-manifest/values/BundledComponentCollectionIterator.php  ©t…i   _»¤      0   phar-io-manifest/values/CopyrightInformation.phpp  ©t…ip  ‚“æP¤      !   phar-io-manifest/values/Email.php¦  ©t…i¦  «S·¤      %   phar-io-manifest/values/Extension.phpÅ  ©t…iÅ  F {¤      #   phar-io-manifest/values/Library.php  ©t…i  ±ıv¤      #   phar-io-manifest/values/License.php  ©t…i  4Êıç¤      $   phar-io-manifest/values/Manifest.php&
+  ©t…i&
+  ¾øüú¤      3   phar-io-manifest/values/PhpExtensionRequirement.php¼  ©t…i¼  ²PÎ·¤      1   phar-io-manifest/values/PhpVersionRequirement.phpA  ©t…iA  Äñi‰¤      '   phar-io-manifest/values/Requirement.php´  ©t…i´  ŸïU¤      1   phar-io-manifest/values/RequirementCollection.phps  ©t…is  6ı•M¤      9   phar-io-manifest/values/RequirementCollectionIterator.phpİ  ©t…iİ  U¤          phar-io-manifest/values/Type.phpÔ  ©t…iÔ  Ü²3«¤         phar-io-manifest/values/Url.phpÁ  ©t…iÁ  ëO©ƒ¤      &   phar-io-manifest/xml/AuthorElement.phpğ  ©t…iğ  ÎÊÂÚ¤      0   phar-io-manifest/xml/AuthorElementCollection.phpM  ©t…iM  j£·¤      '   phar-io-manifest/xml/BundlesElement.phpt  ©t…it  ]Y´‹¤      )   phar-io-manifest/xml/ComponentElement.php™  ©t…i™  ”na¤      3   phar-io-manifest/xml/ComponentElementCollection.phpV  ©t…iV  ú¥?¤      (   phar-io-manifest/xml/ContainsElement.phpŒ  ©t…iŒ  l8è¤      )   phar-io-manifest/xml/CopyrightElement.phpó  ©t…ió  ¹hDp¤      *   phar-io-manifest/xml/ElementCollection.phpÂ  ©t…iÂ  <^ÉŞ¤      #   phar-io-manifest/xml/ExtElement.php*  ©t…i*  ^º×¤      -   phar-io-manifest/xml/ExtElementCollection.phpD  ©t…iD  Î²Só¤      )   phar-io-manifest/xml/ExtensionElement.php  ©t…i  €JŒ¤      '   phar-io-manifest/xml/LicenseElement.php  ©t…i  vâ/!¤      )   phar-io-manifest/xml/ManifestDocument.phpƒ  ©t…iƒ  ™Åi_¤      (   phar-io-manifest/xml/ManifestElement.phpİ  ©t…iİ  #¨=¤      #   phar-io-manifest/xml/PhpElement.php  ©t…i  YÊ¤      (   phar-io-manifest/xml/RequiresElement.phpE  ©t…iE  dwÊ¤      !   phar-io-version/BuildMetaData.phpã  ©t…iã  3A(*¤         phar-io-version/LICENSE&  ©t…i&  Òª	¤      $   phar-io-version/PreReleaseSuffix.php  ©t…i  8^æ¤         phar-io-version/Version.phpñ  ©t…iñ  ‘¬¤      +   phar-io-version/VersionConstraintParser.phpN  ©t…iN  n­%Ë¤      *   phar-io-version/VersionConstraintValue.phpA
+  ©t…iA
+  ²fi™¤      !   phar-io-version/VersionNumber.phpµ  ©t…iµ  Kp‘_¤      9   phar-io-version/constraints/AbstractVersionConstraint.phpÁ  ©t…iÁ  42ƒo¤      9   phar-io-version/constraints/AndVersionConstraintGroup.phpé  ©t…ié  k O•¤      4   phar-io-version/constraints/AnyVersionConstraint.phpT  ©t…iT  ¸v¤      6   phar-io-version/constraints/ExactVersionConstraint.phpÖ  ©t…iÖ  gÉĞq¤      E   phar-io-version/constraints/GreaterThanOrEqualToVersionConstraint.php‰  ©t…i‰  ©ŞÚ_¤      8   phar-io-version/constraints/OrVersionConstraintGroup.php  ©t…i  £¥ƒ6¤      F   phar-io-version/constraints/SpecificMajorAndMinorVersionConstraint.phpÌ  ©t…iÌ  Bº”,¤      >   phar-io-version/constraints/SpecificMajorVersionConstraint.php  ©t…i  êÒé¤      1   phar-io-version/constraints/VersionConstraint.phpø  ©t…iø  ï¾dã¤      (   phar-io-version/exceptions/Exception.php³  ©t…i³  ôÓ<²¤      ?   phar-io-version/exceptions/InvalidPreReleaseSuffixException.php›   ©t…i›   Ë[–¤      6   phar-io-version/exceptions/InvalidVersionException.php¡   ©t…i¡   ·ğy¤      7   phar-io-version/exceptions/NoBuildMetaDataException.php“   ©t…i“   +${¡¤      :   phar-io-version/exceptions/NoPreReleaseSuffixException.php–   ©t…i–   º"Ï÷¤      D   phar-io-version/exceptions/UnsupportedVersionConstraintException.phpß  ©t…iß  ¤´æ¨¤      "   php-code-coverage/CodeCoverage.phpHI  ©t…iHI  bWœ±¤      6   php-code-coverage/Data/ProcessedBranchCoverageData.php§	  ©t…i§	  ”qô–¤      -   php-code-coverage/Data/ProcessedClassType.php#  ©t…i#  £M~k¤      4   php-code-coverage/Data/ProcessedCodeCoverageData.php—"  ©t…i—"  Ğ‹¤      8   php-code-coverage/Data/ProcessedFunctionCoverageData.php¨  ©t…i¨  ßp¤      0   php-code-coverage/Data/ProcessedFunctionType.php˜  ©t…i˜  MvÕ·¤      .   php-code-coverage/Data/ProcessedMethodType.php’  ©t…i’  ö3c—¤      4   php-code-coverage/Data/ProcessedPathCoverageData.phpµ  ©t…iµ  i*€¤      -   php-code-coverage/Data/ProcessedTraitType.php#  ©t…i#  ³í-1¤      .   php-code-coverage/Data/RawCodeCoverageData.php‰#  ©t…i‰#  kºk¤      #   php-code-coverage/Driver/Driver.phpÿ  ©t…iÿ  “j	£¤      '   php-code-coverage/Driver/PcovDriver.php¢  ©t…i¢  X^‰¹¤      %   php-code-coverage/Driver/Selector.php(  ©t…i(  ƒ¹Ú¤      )   php-code-coverage/Driver/XdebugDriver.php/  ©t…i/  0|:¤      J   php-code-coverage/Exception/BranchAndPathCoverageNotSupportedException.phpÇ  ©t…iÇ  z¤      C   php-code-coverage/Exception/DirectoryCouldNotBeCreatedException.phpÿ  ©t…iÿ  <î6'¤      )   php-code-coverage/Exception/Exception.php  ©t…i  +’ËQ¤      >   php-code-coverage/Exception/FileCouldNotBeWrittenException.php»  ©t…i»  £ó’¤      8   php-code-coverage/Exception/InvalidArgumentException.php¨  ©t…i¨  lÕ~Ğ¤      B   php-code-coverage/Exception/InvalidCodeCoverageTargetException.phpÃ  ©t…iÃ  yØ¯¤      F   php-code-coverage/Exception/NoCodeCoverageDriverAvailableException.php3  ©t…i3  5oYC¤      ]   php-code-coverage/Exception/NoCodeCoverageDriverWithPathCoverageSupportAvailableException.phpe  ©t…ie  ®X3Ÿ¤      /   php-code-coverage/Exception/ParserException.php¬  ©t…i¬  pÏêÚ¤      D   php-code-coverage/Exception/PathExistsButIsNotDirectoryException.phpd  ©t…id  ±@¿¤      9   php-code-coverage/Exception/PcovNotAvailableException.phpi  ©t…ii  Áq¤      3   php-code-coverage/Exception/ReflectionException.php°  ©t…i°  ö`¤      ?   php-code-coverage/Exception/ReportAlreadyFinalizedException.php>  ©t…i>  ÒmU=¤      I   php-code-coverage/Exception/StaticAnalysisCacheNotConfiguredException.phpÆ  ©t…iÆ  Ûpé¤      6   php-code-coverage/Exception/TestIdMissingException.php  ©t…i  3ÄOê¤      C   php-code-coverage/Exception/UnintentionallyCoveredCodeException.phpÒ  ©t…iÒ  [‹ã¤      =   php-code-coverage/Exception/WriteOperationFailedException.phpO  ©t…iO  Hç‰"¤      ;   php-code-coverage/Exception/XdebugNotAvailableException.phpm  ©t…im  í{F¤      9   php-code-coverage/Exception/XdebugNotEnabledException.php³  ©t…i³  J]0¤      B   php-code-coverage/Exception/XdebugVersionNotSupportedException.phpò  ©t…iò  Øİ2¤      ,   php-code-coverage/Exception/XmlException.php©  ©t…i©  0)ƒR¤         php-code-coverage/Filter.phpˆ  ©t…iˆ  SÿÑ¤         php-code-coverage/LICENSEû  ©t…iû  „+•K¤      '   php-code-coverage/Node/AbstractNode.php   ©t…i   -nP‡¤      "   php-code-coverage/Node/Builder.phpâ  ©t…iâ  ½à¢8¤      $   php-code-coverage/Node/CrapIndex.phpÂ  ©t…iÂ  Wx\´¤      $   php-code-coverage/Node/Directory.php'  ©t…i'  Y¤>ù¤         php-code-coverage/Node/File.php«P  ©t…i«P  ü„Ù»¤      #   php-code-coverage/Node/Iterator.php3  ©t…i3  lÎ¤      #   php-code-coverage/Report/Clover.phpK%  ©t…iK%  äI¸¤      &   php-code-coverage/Report/Cobertura.phpo/  ©t…io/  ŠT·|¤      #   php-code-coverage/Report/Crap4j.phpY  ©t…iY  ÊáÊ¤      (   php-code-coverage/Report/Html/Colors.phpš  ©t…iš  Ö]­ÿ¤      /   php-code-coverage/Report/Html/CustomCssFile.php5  ©t…i5  ©ZÇ0¤      (   php-code-coverage/Report/Html/Facade.php{  ©t…i{  †Ş~¤      *   php-code-coverage/Report/Html/Renderer.php%!  ©t…i%!  É°~9¤      4   php-code-coverage/Report/Html/Renderer/Dashboard.php'  ©t…i'  
+ÃÔ¤      4   php-code-coverage/Report/Html/Renderer/Directory.phpK  ©t…iK  ¹88a¤      /   php-code-coverage/Report/Html/Renderer/File.php‰  ©t…i‰  <îv¤      B   php-code-coverage/Report/Html/Renderer/Template/branches.html.distô  ©t…iô  h2+¤      F   php-code-coverage/Report/Html/Renderer/Template/coverage_bar.html.dist/  ©t…i/  ÕchÁ¤      M   php-code-coverage/Report/Html/Renderer/Template/coverage_bar_branch.html.dist/  ©t…i/  ÕchÁ¤      E   php-code-coverage/Report/Html/Renderer/Template/css/billboard.min.cssu  ©t…iu  Ã(Zœ¤      E   php-code-coverage/Report/Html/Renderer/Template/css/bootstrap.min.cssRŠ ©t…iRŠ 	Ìı¤      >   php-code-coverage/Report/Html/Renderer/Template/css/custom.css    ©t…i        ¤      @   php-code-coverage/Report/Html/Renderer/Template/css/octicons.cssX   ©t…iX   '#ï¤      =   php-code-coverage/Report/Html/Renderer/Template/css/style.css   ©t…i   ¦{n§¤      C   php-code-coverage/Report/Html/Renderer/Template/dashboard.html.distv  ©t…iv  ,©Rt¤      J   php-code-coverage/Report/Html/Renderer/Template/dashboard_branch.html.dist  ©t…i  «ŒÅÏ¤      C   php-code-coverage/Report/Html/Renderer/Template/directory.html.distö  ©t…iö  ÎÕ†á¤      J   php-code-coverage/Report/Html/Renderer/Template/directory_branch.html.dist”  ©t…i”  n2]¤      H   php-code-coverage/Report/Html/Renderer/Template/directory_item.html.distA  ©t…iA  ds¤      O   php-code-coverage/Report/Html/Renderer/Template/directory_item_branch.html.dist;  ©t…i;  ªm½Û¤      >   php-code-coverage/Report/Html/Renderer/Template/file.html.distö  ©t…iö  9Á¤      E   php-code-coverage/Report/Html/Renderer/Template/file_branch.html.dist“	  ©t…i“	  ûu ¤      C   php-code-coverage/Report/Html/Renderer/Template/file_item.html.distr  ©t…ir  éğ/y¤      J   php-code-coverage/Report/Html/Renderer/Template/file_item_branch.html.distl  ©t…il  ¡-°÷¤      C   php-code-coverage/Report/Html/Renderer/Template/icons/file-code.svg0  ©t…i0  ÙQUU¤      H   php-code-coverage/Report/Html/Renderer/Template/icons/file-directory.svgê   ©t…iê   ıÚZÿ¤      H   php-code-coverage/Report/Html/Renderer/Template/js/billboard.pkgd.min.jsÂ· ©t…iÂ· ‰4E”¤      J   php-code-coverage/Report/Html/Renderer/Template/js/bootstrap.bundle.min.jsg; ©t…ig; âOê$¤      :   php-code-coverage/Report/Html/Renderer/Template/js/file.jsÈ  ©t…iÈ  5-¤      @   php-code-coverage/Report/Html/Renderer/Template/js/jquery.min.jsìU ©t…iìU ¥ŸGœ¤      >   php-code-coverage/Report/Html/Renderer/Template/line.html.distÃ   ©t…iÃ   ·ä´_¤      ?   php-code-coverage/Report/Html/Renderer/Template/lines.html.diste   ©t…ie   df¤      E   php-code-coverage/Report/Html/Renderer/Template/method_item.html.dist«  ©t…i«  ‹j×¤      L   php-code-coverage/Report/Html/Renderer/Template/method_item_branch.html.dist¥  ©t…i¥  yÄk¤      ?   php-code-coverage/Report/Html/Renderer/Template/paths.html.distò  ©t…iò  ã*'İ¤      '   php-code-coverage/Report/OpenClover.phpı/  ©t…iı/  Oó©¦¤          php-code-coverage/Report/PHP.phpo  ©t…io  Ê4n’¤      !   php-code-coverage/Report/Text.phpÊ&  ©t…iÊ&  BjL¤      '   php-code-coverage/Report/Thresholds.phpH  ©t…iH  ™¡^}¤      1   php-code-coverage/Report/Xml/BuildInformation.phpC  ©t…iC  Í—½¤      )   php-code-coverage/Report/Xml/Coverage.phpS  ©t…iS  `à[¤      *   php-code-coverage/Report/Xml/Directory.phpí  ©t…ií  ôFn¤      '   php-code-coverage/Report/Xml/Facade.phpp&  ©t…ip&  p§?q¤      %   php-code-coverage/Report/Xml/File.php¢  ©t…i¢  ü³8 ¤      '   php-code-coverage/Report/Xml/Method.php  ©t…i  c‚¾á¤      %   php-code-coverage/Report/Xml/Node.phpş  ©t…iş  ¢[3é¤      (   php-code-coverage/Report/Xml/Project.php’  ©t…i’  ±J¬¤      '   php-code-coverage/Report/Xml/Report.php]
+  ©t…i]
+  6½â1¤      '   php-code-coverage/Report/Xml/Source.phpø  ©t…iø  ò]‚¤      &   php-code-coverage/Report/Xml/Tests.phpø  ©t…iø  pt
+!¤      '   php-code-coverage/Report/Xml/Totals.php:  ©t…i:  ìx8w¤      %   php-code-coverage/Report/Xml/Unit.phpï  ©t…iï  ­££J¤      0   php-code-coverage/StaticAnalysis/CacheWarmer.php±  ©t…i±  PZu$¤      :   php-code-coverage/StaticAnalysis/CachingSourceAnalyser.php5  ©t…i5  T—ó.¤      1   php-code-coverage/StaticAnalysis/FileAnalyser.phpA  ©t…iA  á7Ü¤      :   php-code-coverage/StaticAnalysis/ParsingSourceAnalyser.phpâ  ©t…iâ  F¹_Y¤      3   php-code-coverage/StaticAnalysis/SourceAnalyser.phpÄ  ©t…iÄ  _›n¤      9   php-code-coverage/StaticAnalysis/Value/AnalysisResult.phpÄ
+  ©t…iÄ
+  P»‚’¤      1   php-code-coverage/StaticAnalysis/Value/Class_.phpÔ  ©t…iÔ  }×¼`¤      4   php-code-coverage/StaticAnalysis/Value/Function_.php
+  ©t…i
+  fw¨¤      5   php-code-coverage/StaticAnalysis/Value/Interface_.phpv	  ©t…iv	  ™6=¤      6   php-code-coverage/StaticAnalysis/Value/LinesOfCode.phpP  ©t…iP  é8,|¤      1   php-code-coverage/StaticAnalysis/Value/Method.phpè  ©t…iè  (¤      1   php-code-coverage/StaticAnalysis/Value/Trait_.phpË  ©t…iË  ÕÂ;¤      5   php-code-coverage/StaticAnalysis/Value/Visibility.phpI  ©t…iI  Ì**¤      M   php-code-coverage/StaticAnalysis/Visitor/AttributeParentConnectingVisitor.php  ©t…i  Dùö»¤      C   php-code-coverage/StaticAnalysis/Visitor/CodeUnitFindingVisitor.phpZ,  ©t…iZ,  Ÿ“Á¤      J   php-code-coverage/StaticAnalysis/Visitor/ExecutableLinesFindingVisitor.php +  ©t…i +  ±‹Z¤      G   php-code-coverage/StaticAnalysis/Visitor/IgnoredLinesFindingVisitor.php[  ©t…i[  ¢ájş¤      #   php-code-coverage/Target/Class_.phpG  ©t…iG  æLÁå¤      3   php-code-coverage/Target/ClassesThatExtendClass.php‹  ©t…i‹  “!x¤      :   php-code-coverage/Target/ClassesThatImplementInterface.phpÇ  ©t…iÇ  \<x¤      &   php-code-coverage/Target/Function_.phpv  ©t…iv  ”½'¤      '   php-code-coverage/Target/MapBuilder.php$  ©t…i$  ©ñá¤      #   php-code-coverage/Target/Mapper.phpd  ©t…id  d#ø¤      #   php-code-coverage/Target/Method.php¤  ©t…i¤  îf£¤      '   php-code-coverage/Target/Namespace_.phpb  ©t…ib  Ê¾!¤      #   php-code-coverage/Target/Target.phpÕ
+  ©t…iÕ
+  EÂÌ¤      -   php-code-coverage/Target/TargetCollection.phpî  ©t…iî  3aª?¤      5   php-code-coverage/Target/TargetCollectionIterator.phpò  ©t…iò  Û÷M¤      6   php-code-coverage/Target/TargetCollectionValidator.php  ©t…i  Š>Sy¤      #   php-code-coverage/Target/Trait_.phpF  ©t…iF  üWÃ
+¤      .   php-code-coverage/Target/ValidationFailure.php  ©t…i  ™¬md¤      -   php-code-coverage/Target/ValidationResult.php\  ©t…i\  T¼¤      .   php-code-coverage/Target/ValidationSuccess.phpt  ©t…it  !Ãb¤      $   php-code-coverage/TestSize/Known.php  ©t…i  ”ñQ¤      $   php-code-coverage/TestSize/Large.php‰  ©t…i‰  88çq¤      %   php-code-coverage/TestSize/Medium.php‹  ©t…i‹  û›¤      $   php-code-coverage/TestSize/Small.php}  ©t…i}  O¾Dä¤      '   php-code-coverage/TestSize/TestSize.phpš  ©t…iš  fSúv¤      &   php-code-coverage/TestSize/Unknown.php*  ©t…i*  T4Uv¤      (   php-code-coverage/TestStatus/Failure.php)  ©t…i)  %$¤      &   php-code-coverage/TestStatus/Known.phpà  ©t…ià  sŒ¤      (   php-code-coverage/TestStatus/Success.php)  ©t…i)  ë²!¤      +   php-code-coverage/TestStatus/TestStatus.phpĞ  ©t…iĞ  Äñyå¤      (   php-code-coverage/TestStatus/Unknown.php.  ©t…i.  Xæl¤      %   php-code-coverage/Util/Filesystem.phpı  ©t…iı  d2A¤      %   php-code-coverage/Util/Percentage.phpU  ©t…iU  wªfÀ¤         php-code-coverage/Util/Xml.php•  ©t…i•  W‹¨¤         php-code-coverage/Version.php¯  ©t…i¯  å'­¤      %   php-file-iterator/ExcludeIterator.phpõ  ©t…iõ  C 5ë¤         php-file-iterator/Facade.php•  ©t…i•  Í…!Z¤         php-file-iterator/Factory.phps  ©t…is  3áø¤         php-file-iterator/Iterator.php8  ©t…i8  °*çó¤         php-file-iterator/LICENSEû  ©t…iû  „+•K¤         php-invoker/Invoker.php7  ©t…i7  >(6Ê¤      $   php-invoker/exceptions/Exception.phpv  ©t…iv  'P=¤      D   php-invoker/exceptions/ProcessControlExtensionNotLoadedException.phpÑ  ©t…iÑ  ed e¤      +   php-invoker/exceptions/TimeoutException.php¢  ©t…i¢  —tJï¤         php-text-template/LICENSEû  ©t…iû  „+•K¤         php-text-template/Template.phpÃ  ©t…iÃ  iªÕ–¤      *   php-text-template/exceptions/Exception.php}  ©t…i}  Áã`"¤      9   php-text-template/exceptions/InvalidArgumentException.php¤  ©t…i¤  ô¼¸Â¤      1   php-text-template/exceptions/RuntimeException.php¹  ©t…i¹  Ö]Mp¤         php-timer/Duration.php	  ©t…i	  }h#¤         php-timer/LICENSEû  ©t…iû  w¶-&¤      $   php-timer/ResourceUsageFormatter.php  ©t…i  °”vø¤         php-timer/Timer.phpŠ  ©t…iŠ  CHì¤      "   php-timer/exceptions/Exception.phpr  ©t…ir  ˜›<¤      /   php-timer/exceptions/NoActiveTimerException.php   ©t…i   *®õ¤      E   php-timer/exceptions/TimeSinceStartOfRequestNotAvailableException.phpº  ©t…iº  Ğ.ñ¤         phpunit.xsd²N  ©t…i²N  ßÑ­R¤      1   phpunit/Event/Dispatcher/CollectingDispatcher.php  ©t…i  Ø­:¤      0   phpunit/Event/Dispatcher/DeferringDispatcher.php¢  ©t…i¢  MW°‰¤      -   phpunit/Event/Dispatcher/DirectDispatcher.php  ©t…i  Ğ$"e¤      '   phpunit/Event/Dispatcher/Dispatcher.php}  ©t…i}  ;G`œ¤      3   phpunit/Event/Dispatcher/SubscribableDispatcher.php  ©t…i  »>òL¤      ,   phpunit/Event/Emitter/DispatchingEmitter.php‰  ©t…i‰  5yÜ¤      !   phpunit/Event/Emitter/Emitter.php0  ©t…i0  µ‡¾¤      -   phpunit/Event/Events/Application/Finished.php¨  ©t…i¨  9ÒsS¤      7   phpunit/Event/Events/Application/FinishedSubscriber.php6  ©t…i6  Íş)÷¤      ,   phpunit/Event/Events/Application/Started.php¦  ©t…i¦  ëó0Á¤      6   phpunit/Event/Events/Application/StartedSubscriber.php4  ©t…i4  JÜ'¤         phpunit/Event/Events/Event.php:  ©t…i:  ¾ûké¤      (   phpunit/Event/Events/EventCollection.phpJ  ©t…iJ  ·æI¤      0   phpunit/Event/Events/EventCollectionIterator.php  ©t…i  Rn¤      ;   phpunit/Event/Events/Test/AdditionalInformationProvided.phpw  ©t…iw  †—x†¤      E   phpunit/Event/Events/Test/AdditionalInformationProvidedSubscriber.phpR  ©t…iR  j6ü¤      2   phpunit/Event/Events/Test/ComparatorRegistered.phpv  ©t…iv  Eø¤      <   phpunit/Event/Events/Test/ComparatorRegisteredSubscriber.php@  ©t…i@  Ú­êö¤      <   phpunit/Event/Events/Test/CustomTestMethodInvocationUsed.php?  ©t…i?  ¯È¤      F   phpunit/Event/Events/Test/CustomTestMethodInvocationUsedSubscriber.phpT  ©t…iT  ~'¤      B   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodCalled.php­  ©t…i­  q€+0¤      L   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodCalledSubscriber.phpJ  ©t…iJ  ‘Éü ¤      C   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodErrored.php+  ©t…i+  Ã¦P¤      M   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodErroredSubscriber.phpL  ©t…iL  ø¿¤      B   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodFailed.php)  ©t…i)  ujµ‘¤      L   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodFailedSubscriber.phpJ  ©t…iJ   ¶0¤      D   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodFinished.php˜  ©t…i˜  ëª ¤      N   phpunit/Event/Events/Test/HookMethod/AfterLastTestMethodFinishedSubscriber.phpN  ©t…iN  wœàK¤      >   phpunit/Event/Events/Test/HookMethod/AfterTestMethodCalled.php¼  ©t…i¼  ?±ï¤      H   phpunit/Event/Events/Test/HookMethod/AfterTestMethodCalledSubscriber.phpB  ©t…iB  £R‘ÿ¤      ?   phpunit/Event/Events/Test/HookMethod/AfterTestMethodErrored.php:  ©t…i:  '<ß¤      I   phpunit/Event/Events/Test/HookMethod/AfterTestMethodErroredSubscriber.phpD  ©t…iD  %?±ò¤      >   phpunit/Event/Events/Test/HookMethod/AfterTestMethodFailed.php8  ©t…i8  ”(%h¤      H   phpunit/Event/Events/Test/HookMethod/AfterTestMethodFailedSubscriber.phpB  ©t…iB  ŞÙ¤      @   phpunit/Event/Events/Test/HookMethod/AfterTestMethodFinished.php§  ©t…i§  &1·¤      J   phpunit/Event/Events/Test/HookMethod/AfterTestMethodFinishedSubscriber.phpF  ©t…iF  –^‰_¤      D   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodCalled.php±  ©t…i±  ë@½¤      N   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodCalledSubscriber.phpN  ©t…iN  eÚäu¤      E   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodErrored.php/  ©t…i/  «ÍÖÚ¤      O   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodErroredSubscriber.phpP  ©t…iP  ñ¨¥²¤      D   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodFailed.php-  ©t…i-  Ú1ÇÛ¤      N   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodFailedSubscriber.phpN  ©t…iN  æõ¤      F   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodFinished.phpœ  ©t…iœ  æå3¼¤      P   phpunit/Event/Events/Test/HookMethod/BeforeFirstTestMethodFinishedSubscriber.phpR  ©t…iR  ½Á“\¤      ?   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodCalled.php¾  ©t…i¾  î
+€¦¤      I   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodCalledSubscriber.phpD  ©t…iD  ¿şÆ¾¤      @   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodErrored.php<  ©t…i<  ‘O¤      J   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodErroredSubscriber.phpF  ©t…iF  ¦ó„0¤      ?   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodFailed.php:  ©t…i:  ½Âça¤      I   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodFailedSubscriber.phpD  ©t…iD  }&°ö¤      A   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodFinished.php©  ©t…i©  ÕéÄj¤      K   phpunit/Event/Events/Test/HookMethod/BeforeTestMethodFinishedSubscriber.phpH  ©t…iH  x—ŠS¤      <   phpunit/Event/Events/Test/HookMethod/PostConditionCalled.php¾  ©t…i¾  â~*û¤      F   phpunit/Event/Events/Test/HookMethod/PostConditionCalledSubscriber.php>  ©t…i>  b*¤      =   phpunit/Event/Events/Test/HookMethod/PostConditionErrored.php<  ©t…i<  ²ç¤      G   phpunit/Event/Events/Test/HookMethod/PostConditionErroredSubscriber.php@  ©t…i@  qhÀ÷¤      <   phpunit/Event/Events/Test/HookMethod/PostConditionFailed.php:  ©t…i:  Î‰¥L¤      F   phpunit/Event/Events/Test/HookMethod/PostConditionFailedSubscriber.php>  ©t…i>  åàœ¤      >   phpunit/Event/Events/Test/HookMethod/PostConditionFinished.php©  ©t…i©  Te_¤      H   phpunit/Event/Events/Test/HookMethod/PostConditionFinishedSubscriber.phpB  ©t…iB  WXF“¤      ;   phpunit/Event/Events/Test/HookMethod/PreConditionCalled.php¼  ©t…i¼  [š7<¤      E   phpunit/Event/Events/Test/HookMethod/PreConditionCalledSubscriber.php<  ©t…i<  u8O&¤      <   phpunit/Event/Events/Test/HookMethod/PreConditionErrored.php:  ©t…i:  ³wÉa¤      F   phpunit/Event/Events/Test/HookMethod/PreConditionErroredSubscriber.php>  ©t…i>  ‘§¤      ;   phpunit/Event/Events/Test/HookMethod/PreConditionFailed.php8  ©t…i8  òÈsƒ¤      E   phpunit/Event/Events/Test/HookMethod/PreConditionFailedSubscriber.php<  ©t…i<  >Äw¤      =   phpunit/Event/Events/Test/HookMethod/PreConditionFinished.php§  ©t…i§  ”¤      G   phpunit/Event/Events/Test/HookMethod/PreConditionFinishedSubscriber.php@  ©t…i@  ¡µX¤      3   phpunit/Event/Events/Test/Issue/ConsideredRisky.phpô  ©t…iô  ë1Ÿ ¤      =   phpunit/Event/Events/Test/Issue/ConsideredRiskySubscriber.php6  ©t…i6  S%LT¤      8   phpunit/Event/Events/Test/Issue/DeprecationTriggered.phpx  ©t…ix  ¼ÿö¤      B   phpunit/Event/Events/Test/Issue/DeprecationTriggeredSubscriber.php@  ©t…i@  ö†“¤      2   phpunit/Event/Events/Test/Issue/ErrorTriggered.phpÚ	  ©t…iÚ	  ¼W”¤      <   phpunit/Event/Events/Test/Issue/ErrorTriggeredSubscriber.php4  ©t…i4  R¹Â5¤      3   phpunit/Event/Events/Test/Issue/NoticeTriggered.php  ©t…i  m©ÓX¤      =   phpunit/Event/Events/Test/Issue/NoticeTriggeredSubscriber.php6  ©t…i6  'T$¤      ;   phpunit/Event/Events/Test/Issue/PhpDeprecationTriggered.phpC  ©t…iC  Šr„¤      E   phpunit/Event/Events/Test/Issue/PhpDeprecationTriggeredSubscriber.phpF  ©t…iF  ˆs†¤      6   phpunit/Event/Events/Test/Issue/PhpNoticeTriggered.php  ©t…i  Í-+¤      @   phpunit/Event/Events/Test/Issue/PhpNoticeTriggeredSubscriber.php<  ©t…i<   M¥s¤      7   phpunit/Event/Events/Test/Issue/PhpWarningTriggered.php  ©t…i  fğ2û¤      A   phpunit/Event/Events/Test/Issue/PhpWarningTriggeredSubscriber.php>  ©t…i>  «
+d¤      ?   phpunit/Event/Events/Test/Issue/PhpunitDeprecationTriggered.phpi  ©t…ii  ¨ªa/¤      I   phpunit/Event/Events/Test/Issue/PhpunitDeprecationTriggeredSubscriber.phpN  ©t…iN  lp®¤      9   phpunit/Event/Events/Test/Issue/PhpunitErrorTriggered.phpv  ©t…iv  iÎÙ¤      C   phpunit/Event/Events/Test/Issue/PhpunitErrorTriggeredSubscriber.phpB  ©t…iB  °Ÿ³;¤      :   phpunit/Event/Events/Test/Issue/PhpunitNoticeTriggered.phpx  ©t…ix  dSS8¤      D   phpunit/Event/Events/Test/Issue/PhpunitNoticeTriggeredSubscriber.phpD  ©t…iD  
+—¤      ;   phpunit/Event/Events/Test/Issue/PhpunitWarningTriggered.php¿  ©t…i¿  )ß¤      E   phpunit/Event/Events/Test/Issue/PhpunitWarningTriggeredSubscriber.phpF  ©t…iF  ¶²â¤      4   phpunit/Event/Events/Test/Issue/WarningTriggered.php  ©t…i  üæĞ¤      >   phpunit/Event/Events/Test/Issue/WarningTriggeredSubscriber.php8  ©t…i8  £®Z{¤      @   phpunit/Event/Events/Test/Lifecycle/DataProviderMethodCalled.phpF  ©t…iF  Ÿ?åR¤      J   phpunit/Event/Events/Test/Lifecycle/DataProviderMethodCalledSubscriber.phpH  ©t…iH  ë~-r¤      B   phpunit/Event/Events/Test/Lifecycle/DataProviderMethodFinished.php  ©t…i  ¯(ín¤      L   phpunit/Event/Events/Test/Lifecycle/DataProviderMethodFinishedSubscriber.phpL  ©t…iL  Ç?¤      0   phpunit/Event/Events/Test/Lifecycle/Finished.php8  ©t…i8  <ï4¤      :   phpunit/Event/Events/Test/Lifecycle/FinishedSubscriber.php(  ©t…i(  .ÍµP¤      :   phpunit/Event/Events/Test/Lifecycle/PreparationErrored.php  ©t…i  ’ĞÍ¤      D   phpunit/Event/Events/Test/Lifecycle/PreparationErroredSubscriber.php<  ©t…i<  ‰ê¯€¤      9   phpunit/Event/Events/Test/Lifecycle/PreparationFailed.php  ©t…i  7+%¤      C   phpunit/Event/Events/Test/Lifecycle/PreparationFailedSubscriber.php:  ©t…i:  ØÌ"»¤      :   phpunit/Event/Events/Test/Lifecycle/PreparationStarted.php“  ©t…i“  k¹İ¤      D   phpunit/Event/Events/Test/Lifecycle/PreparationStartedSubscriber.php<  ©t…i<  &Uep¤      0   phpunit/Event/Events/Test/Lifecycle/Prepared.php~  ©t…i~  Öîj¤      :   phpunit/Event/Events/Test/Lifecycle/PreparedSubscriber.php(  ©t…i(  Ä§K”¤      -   phpunit/Event/Events/Test/Outcome/Errored.php  ©t…i  Èx8¤      7   phpunit/Event/Events/Test/Outcome/ErroredSubscriber.php&  ©t…i&  èd3¤      ,   phpunit/Event/Events/Test/Outcome/Failed.php¸  ©t…i¸  Ù²!¤      6   phpunit/Event/Events/Test/Outcome/FailedSubscriber.php$  ©t…i$  À\*¤      6   phpunit/Event/Events/Test/Outcome/MarkedIncomplete.php$  ©t…i$  ş^ß¤      @   phpunit/Event/Events/Test/Outcome/MarkedIncompleteSubscriber.php8  ©t…i8  
+6‹¤      ,   phpunit/Event/Events/Test/Outcome/Passed.phpz  ©t…iz  Òü—¤      6   phpunit/Event/Events/Test/Outcome/PassedSubscriber.php$  ©t…i$  ÂĞ:y¤      -   phpunit/Event/Events/Test/Outcome/Skipped.php´  ©t…i´  ŞÔ-¤      7   phpunit/Event/Events/Test/Outcome/SkippedSubscriber.php&  ©t…i&  {ªdz¤      5   phpunit/Event/Events/Test/PrintedUnexpectedOutput.php4  ©t…i4  D ¤      ?   phpunit/Event/Events/Test/PrintedUnexpectedOutputSubscriber.phpF  ©t…iF  ¾4¾­¤      :   phpunit/Event/Events/Test/TestDouble/MockObjectCreated.php  ©t…i  ì[~¤      D   phpunit/Event/Events/Test/TestDouble/MockObjectCreatedSubscriber.php:  ©t…i:  E¨'á¤      U   phpunit/Event/Events/Test/TestDouble/MockObjectForIntersectionOfInterfacesCreated.phpj  ©t…ij  ’Œ¤      _   phpunit/Event/Events/Test/TestDouble/MockObjectForIntersectionOfInterfacesCreatedSubscriber.phpp  ©t…ip  -¤      A   phpunit/Event/Events/Test/TestDouble/PartialMockObjectCreated.php3  ©t…i3  ÓE„¤      K   phpunit/Event/Events/Test/TestDouble/PartialMockObjectCreatedSubscriber.phpH  ©t…iH  øş¡£¤      8   phpunit/Event/Events/Test/TestDouble/TestStubCreated.php  ©t…i  ·ÚÅû¤      B   phpunit/Event/Events/Test/TestDouble/TestStubCreatedSubscriber.php6  ©t…i6  íà¤      S   phpunit/Event/Events/Test/TestDouble/TestStubForIntersectionOfInterfacesCreated.phpf  ©t…if  ¥“Æ‡¤      ]   phpunit/Event/Events/Test/TestDouble/TestStubForIntersectionOfInterfacesCreatedSubscriber.phpl  ©t…il  ŠªR¤      5   phpunit/Event/Events/TestRunner/BootstrapFinished.php  ©t…i  ySó¤      ?   phpunit/Event/Events/TestRunner/BootstrapFinishedSubscriber.phpF  ©t…iF  €2¸=¤      7   phpunit/Event/Events/TestRunner/ChildProcessErrored.php¯  ©t…i¯  œR[ª¤      A   phpunit/Event/Events/TestRunner/ChildProcessErroredSubscriber.phpJ  ©t…iJ  @$$¤      8   phpunit/Event/Events/TestRunner/ChildProcessFinished.phpé  ©t…ié  O†º¤      B   phpunit/Event/Events/TestRunner/ChildProcessFinishedSubscriber.phpL  ©t…iL  `¨&¤      7   phpunit/Event/Events/TestRunner/ChildProcessStarted.php¯  ©t…i¯  °ıÙg¤      A   phpunit/Event/Events/TestRunner/ChildProcessStartedSubscriber.phpJ  ©t…iJ  "4¤      .   phpunit/Event/Events/TestRunner/Configured.php¡  ©t…i¡  nTúĞ¤      8   phpunit/Event/Events/TestRunner/ConfiguredSubscriber.php8  ©t…i8  ÍL¿Ï¤      8   phpunit/Event/Events/TestRunner/DeprecationTriggered.php'  ©t…i'  Ù¾ˆ¤      B   phpunit/Event/Events/TestRunner/DeprecationTriggeredSubscriber.phpL  ©t…iL  öñ`2¤      5   phpunit/Event/Events/TestRunner/EventFacadeSealed.php«  ©t…i«  jÌ¾¤      ?   phpunit/Event/Events/TestRunner/EventFacadeSealedSubscriber.phpF  ©t…iF  $¬v^¤      4   phpunit/Event/Events/TestRunner/ExecutionAborted.php´  ©t…i´  uÓ-¤      >   phpunit/Event/Events/TestRunner/ExecutionAbortedSubscriber.phpD  ©t…iD  ²sl|¤      5   phpunit/Event/Events/TestRunner/ExecutionFinished.php¶  ©t…i¶  ¶"Àq¤      ?   phpunit/Event/Events/TestRunner/ExecutionFinishedSubscriber.phpF  ©t…iF  Ó¾ñ¤      4   phpunit/Event/Events/TestRunner/ExecutionStarted.php  ©t…i  Ş#<ü¤      >   phpunit/Event/Events/TestRunner/ExecutionStartedSubscriber.phpD  ©t…iD  ÿ.¤      9   phpunit/Event/Events/TestRunner/ExtensionBootstrapped.phpr  ©t…ir   ½)¼¤      C   phpunit/Event/Events/TestRunner/ExtensionBootstrappedSubscriber.phpN  ©t…iN  Ã¥³¤      ;   phpunit/Event/Events/TestRunner/ExtensionLoadedFromPhar.phps  ©t…is  Rë¡¤      E   phpunit/Event/Events/TestRunner/ExtensionLoadedFromPharSubscriber.phpR  ©t…iR  A‹Æ¾¤      ,   phpunit/Event/Events/TestRunner/Finished.php£  ©t…i£  p™¤      6   phpunit/Event/Events/TestRunner/FinishedSubscriber.php4  ©t…i4  [Ixé¤      =   phpunit/Event/Events/TestRunner/GarbageCollectionDisabled.phpÇ  ©t…iÇ  A\¤      G   phpunit/Event/Events/TestRunner/GarbageCollectionDisabledSubscriber.phpV  ©t…iV  yÃW¤      <   phpunit/Event/Events/TestRunner/GarbageCollectionEnabled.phpÅ  ©t…iÅ  ‡­M«¤      F   phpunit/Event/Events/TestRunner/GarbageCollectionEnabledSubscriber.phpT  ©t…iT  yÄ
+¤      >   phpunit/Event/Events/TestRunner/GarbageCollectionTriggered.phpÉ  ©t…iÉ  4†”d¤      H   phpunit/Event/Events/TestRunner/GarbageCollectionTriggeredSubscriber.phpX  ©t…iX  €Jz¤      3   phpunit/Event/Events/TestRunner/NoticeTriggered.phpˆ  ©t…iˆ  ğ¤      =   phpunit/Event/Events/TestRunner/NoticeTriggeredSubscriber.phpB  ©t…iB  ¾ĞòÂ¤      +   phpunit/Event/Events/TestRunner/Started.php¡  ©t…i¡  [i¶W¤      5   phpunit/Event/Events/TestRunner/StartedSubscriber.php2  ©t…i2  }ÃRp¤      I   phpunit/Event/Events/TestRunner/StaticAnalysisForCodeCoverageFinished.php²  ©t…i²  €œRÖ¤      S   phpunit/Event/Events/TestRunner/StaticAnalysisForCodeCoverageFinishedSubscriber.phpn  ©t…in  öÏLû¤      H   phpunit/Event/Events/TestRunner/StaticAnalysisForCodeCoverageStarted.phpÔ  ©t…iÔ  FCàò¤      R   phpunit/Event/Events/TestRunner/StaticAnalysisForCodeCoverageStartedSubscriber.phpl  ©t…il  êÙ§Ó¤      4   phpunit/Event/Events/TestRunner/WarningTriggered.php  ©t…i  _Ìò¤      >   phpunit/Event/Events/TestRunner/WarningTriggeredSubscriber.phpD  ©t…iD  Ê‰ú±¤      +   phpunit/Event/Events/TestSuite/Filtered.php  ©t…i  ñ˜_Õ¤      5   phpunit/Event/Events/TestSuite/FilteredSubscriber.php2  ©t…i2  ™?¾Ë¤      +   phpunit/Event/Events/TestSuite/Finished.php3  ©t…i3  8›ó¤      5   phpunit/Event/Events/TestSuite/FinishedSubscriber.php2  ©t…i2  JVˆ8¤      )   phpunit/Event/Events/TestSuite/Loaded.php  ©t…i  ¤      3   phpunit/Event/Events/TestSuite/LoadedSubscriber.php.  ©t…i.  ˜š)¤      *   phpunit/Event/Events/TestSuite/Skipped.php•  ©t…i•  ëİL¤      4   phpunit/Event/Events/TestSuite/SkippedSubscriber.php0  ©t…i0  èÇ¤      )   phpunit/Event/Events/TestSuite/Sorted.php1  ©t…i1  úl9´¤      3   phpunit/Event/Events/TestSuite/SortedSubscriber.php.  ©t…i.  İIN"¤      *   phpunit/Event/Events/TestSuite/Started.php1  ©t…i1  9ˆÇ¤      4   phpunit/Event/Events/TestSuite/StartedSubscriber.php0  ©t…i0  ¿İ.¤      9   phpunit/Event/Exception/EventAlreadyAssignedException.php  ©t…i  0•É¤      8   phpunit/Event/Exception/EventFacadeIsSealedException.php
+  ©t…i
+  JÂØ¤      %   phpunit/Event/Exception/Exception.php½  ©t…i½  /7rr¤      4   phpunit/Event/Exception/InvalidArgumentException.phpù  ©t…iù  Ûä€¤      1   phpunit/Event/Exception/InvalidEventException.php  ©t…i  E>¯¤      6   phpunit/Event/Exception/InvalidSubscriberException.php  ©t…i  SÜg¤      $   phpunit/Event/Exception/MapError.phpö  ©t…iö  Õ÷äR¤      8   phpunit/Event/Exception/NoComparisonFailureException.php  ©t…i  â{k ¤      >   phpunit/Event/Exception/NoDataSetFromDataProviderException.php'  ©t…i'  @~à¤      8   phpunit/Event/Exception/NoPreviousThrowableException.php
+  ©t…i
+  Ùú¦~¤      @   phpunit/Event/Exception/NoTestCaseObjectOnCallStackException.phpù  ©t…iù  xs§Ù¤      ,   phpunit/Event/Exception/RuntimeException.phpé  ©t…ié  LÆ¤      D   phpunit/Event/Exception/SubscriberTypeAlreadyRegisteredException.php  ©t…i  Ä¯¨K¤      1   phpunit/Event/Exception/UnknownEventException.php  ©t…i  šÜ}ê¤      5   phpunit/Event/Exception/UnknownEventTypeException.php  ©t…i  /<ˆ¡¤      6   phpunit/Event/Exception/UnknownSubscriberException.php  ©t…i  ²ÉË¤      :   phpunit/Event/Exception/UnknownSubscriberTypeException.php  ©t…i  &'ı*¤         phpunit/Event/Facade.phpO$  ©t…iO$  ¶©°¤         phpunit/Event/Subscriber.php£  ©t…i£  dlkû¤         phpunit/Event/Tracer.phpî  ©t…iî  €Úm¤         phpunit/Event/TypeMap.php&  ©t…i&  j}J¤      #   phpunit/Event/Value/ClassMethod.phpj  ©t…ij  ı¢—¤      )   phpunit/Event/Value/ComparisonFailure.phpË  ©t…iË  Š6IQ¤      0   phpunit/Event/Value/ComparisonFailureBuilder.php^  ©t…i^  Õ?`Ÿ¤      /   phpunit/Event/Value/Runtime/OperatingSystem.php¢  ©t…i¢  Âá—÷¤      #   phpunit/Event/Value/Runtime/PHP.phpÄ  ©t…iÄ  †ƒÖ½¤      '   phpunit/Event/Value/Runtime/PHPUnit.php^  ©t…i^   7:á¤      '   phpunit/Event/Value/Runtime/Runtime.php´  ©t…i´  Ë&TŒ¤      *   phpunit/Event/Value/Telemetry/Duration.phpÑ  ©t…iÑ  ëØ`†¤      8   phpunit/Event/Value/Telemetry/GarbageCollectorStatus.phpŞ	  ©t…iŞ	  Ó5ƒ¤      @   phpunit/Event/Value/Telemetry/GarbageCollectorStatusProvider.phpp  ©t…ip  rÙ¤      (   phpunit/Event/Value/Telemetry/HRTime.php	  ©t…i	  mÖ¥¤      &   phpunit/Event/Value/Telemetry/Info.php
+  ©t…i
+  fÔ‹¤      -   phpunit/Event/Value/Telemetry/MemoryMeter.php¤  ©t…i¤  'ìä}¤      -   phpunit/Event/Value/Telemetry/MemoryUsage.php^  ©t…i^  Übi¤      *   phpunit/Event/Value/Telemetry/Snapshot.php…  ©t…i…  âš‹ø¤      +   phpunit/Event/Value/Telemetry/StopWatch.phpL  ©t…iL  QØ¡6¤      (   phpunit/Event/Value/Telemetry/System.php•  ©t…i•  öÈˆÉ¤      F   phpunit/Event/Value/Telemetry/SystemGarbageCollectorStatusProvider.phpR  ©t…iR  ÃRH¤      3   phpunit/Event/Value/Telemetry/SystemMemoryMeter.phpç  ©t…iç  >ÿ¤      1   phpunit/Event/Value/Telemetry/SystemStopWatch.phpc  ©t…ic  ı‚÷H¤      ;   phpunit/Event/Value/Telemetry/SystemStopWatchWithOffset.php½  ©t…i½  ‹'^L¤      0   phpunit/Event/Value/Test/Issue/DirectTrigger.php  ©t…i  ¦†±.¤      2   phpunit/Event/Value/Test/Issue/IndirectTrigger.php  ©t…i  h[ÊŸ¤      /   phpunit/Event/Value/Test/Issue/IssueTrigger.php2	  ©t…i2	  *íÚ ¤      .   phpunit/Event/Value/Test/Issue/SelfTrigger.php  ©t…i  #êaá¤      .   phpunit/Event/Value/Test/Issue/TestTrigger.phpß  ©t…iß  hq-µ¤      1   phpunit/Event/Value/Test/Issue/UnknownTrigger.phpÖ  ©t…iÖ  ³y¤      !   phpunit/Event/Value/Test/Phpt.php  ©t…i  3{ŞY¤      !   phpunit/Event/Value/Test/Test.phpÓ  ©t…iÓ  Ù[U¼¤      +   phpunit/Event/Value/Test/TestCollection.php"  ©t…i"  ¨>Æ¤      3   phpunit/Event/Value/Test/TestCollectionIterator.php  ©t…i  ‘9•¤      :   phpunit/Event/Value/Test/TestData/DataFromDataProvider.phpÅ  ©t…iÅ  öÆ¥¤      <   phpunit/Event/Value/Test/TestData/DataFromTestDependency.php°  ©t…i°  8åçË¤      .   phpunit/Event/Value/Test/TestData/TestData.phpÄ  ©t…iÄ   æ·¤      8   phpunit/Event/Value/Test/TestData/TestDataCollection.php  ©t…i  '¬¤      @   phpunit/Event/Value/Test/TestData/TestDataCollectionIterator.php)  ©t…i)  £ì˜¤      $   phpunit/Event/Value/Test/TestDox.phpò  ©t…iò  b°oŠ¤      +   phpunit/Event/Value/Test/TestDoxBuilder.phpÇ  ©t…iÇ  Rçò^¤      '   phpunit/Event/Value/Test/TestMethod.php:  ©t…i:  Œ&úe¤      .   phpunit/Event/Value/Test/TestMethodBuilder.php4
+  ©t…i4
+  1Á¤      +   phpunit/Event/Value/TestSuite/TestSuite.php^  ©t…i^  Ó,[Š¤      2   phpunit/Event/Value/TestSuite/TestSuiteBuilder.phpl  ©t…il  •š÷¤      7   phpunit/Event/Value/TestSuite/TestSuiteForTestClass.php5  ©t…i5  ŞŞmP¤      H   phpunit/Event/Value/TestSuite/TestSuiteForTestMethodWithDataProvider.phpÙ  ©t…iÙ  .^¤      3   phpunit/Event/Value/TestSuite/TestSuiteWithName.phpD  ©t…iD  jW;¤      !   phpunit/Event/Value/Throwable.php	  ©t…i	  W¾¼¤      (   phpunit/Event/Value/ThrowableBuilder.php‹  ©t…i‹  CÎ“¤         phpunit/Exception.php½  ©t…i½  ĞA-¤         phpunit/Framework/Assert.php´V ©t…i´V B4½Ê¤      &   phpunit/Framework/Assert/Functions.phpÑÍ ©t…iÑÍ •Ûh ¤      &   phpunit/Framework/Attributes/After.phpÎ  ©t…iÎ  w§¤      +   phpunit/Framework/Attributes/AfterClass.phpÓ  ©t…iÓ  9Á±¤      D   phpunit/Framework/Attributes/AllowMockObjectsWithoutExpectations.php7  ©t…i7  5>%¤      .   phpunit/Framework/Attributes/BackupGlobals.phpé  ©t…ié  m4B·¤      7   phpunit/Framework/Attributes/BackupStaticProperties.phpò  ©t…iò  y	!„¤      '   phpunit/Framework/Attributes/Before.phpÏ  ©t…iÏ  ŠNÌ2¤      ,   phpunit/Framework/Attributes/BeforeClass.phpÔ  ©t…iÔ  ·	Gå¤      ,   phpunit/Framework/Attributes/CoversClass.php„  ©t…i„  T^ù§¤      =   phpunit/Framework/Attributes/CoversClassesThatExtendClass.php•  ©t…i•  Úæš¤      D   phpunit/Framework/Attributes/CoversClassesThatImplementInterface.php¸  ©t…i¸  £Ã¤      /   phpunit/Framework/Attributes/CoversFunction.php¨  ©t…i¨  u®ôK¤      -   phpunit/Framework/Attributes/CoversMethod.phpÅ  ©t…iÅ  ş¨So¤      0   phpunit/Framework/Attributes/CoversNamespace.php”  ©t…i”  wQdÊ¤      .   phpunit/Framework/Attributes/CoversNothing.php!  ©t…i!  z3Š¤      ,   phpunit/Framework/Attributes/CoversTrait.php„  ©t…i„  ã®¶¤      -   phpunit/Framework/Attributes/DataProvider.php‘  ©t…i‘  •¾Œ¤      5   phpunit/Framework/Attributes/DataProviderExternal.phpÆ  ©t…iÆ  GÓU¤      (   phpunit/Framework/Attributes/Depends.php”  ©t…i”  ¶6"¤      0   phpunit/Framework/Attributes/DependsExternal.phpÉ  ©t…iÉ  ·¶Q¤      >   phpunit/Framework/Attributes/DependsExternalUsingDeepClone.php×  ©t…i×  ŒQU,¤      A   phpunit/Framework/Attributes/DependsExternalUsingShallowClone.phpÚ  ©t…iÚ  ÃuI¤      /   phpunit/Framework/Attributes/DependsOnClass.phpˆ  ©t…iˆ  £‡Ó¤      =   phpunit/Framework/Attributes/DependsOnClassUsingDeepClone.php–  ©t…i–  •#kû¤      @   phpunit/Framework/Attributes/DependsOnClassUsingShallowClone.php™  ©t…i™  fùÕ¤      6   phpunit/Framework/Attributes/DependsUsingDeepClone.php¢  ©t…i¢  «&…á¤      9   phpunit/Framework/Attributes/DependsUsingShallowClone.php¥  ©t…i¥  r@P¤      K   phpunit/Framework/Attributes/DisableReturnValueGenerationForTestDoubles.php#  ©t…i#  Y¿tE¤      9   phpunit/Framework/Attributes/DoesNotPerformAssertions.php,  ©t…i,   a¡¤      @   phpunit/Framework/Attributes/ExcludeGlobalVariableFromBackup.phpş  ©t…iş  ¡ım¤      @   phpunit/Framework/Attributes/ExcludeStaticPropertyFromBackup.php  ©t…i  …çğò¤      &   phpunit/Framework/Attributes/Group.php‚  ©t…i‚  àãŸ¤      3   phpunit/Framework/Attributes/IgnoreDeprecations.phpË  ©t…iË  ç¾Ø¤      :   phpunit/Framework/Attributes/IgnorePhpunitDeprecations.php‰  ©t…i‰  Ç}±ı¤      6   phpunit/Framework/Attributes/IgnorePhpunitWarnings.php´  ©t…i´  UÜ«Ë¤      &   phpunit/Framework/Attributes/Large.phpş  ©t…iş  ¤      '   phpunit/Framework/Attributes/Medium.phpÿ  ©t…iÿ  `4à¤      .   phpunit/Framework/Attributes/PostCondition.phpÖ  ©t…iÖ  )[.¤      -   phpunit/Framework/Attributes/PreCondition.phpÕ  ©t…iÕ  •(y¤      4   phpunit/Framework/Attributes/PreserveGlobalState.phpï  ©t…iï  rm¿c¤      <   phpunit/Framework/Attributes/RequiresEnvironmentVariable.php$  ©t…i$  fX¤      1   phpunit/Framework/Attributes/RequiresFunction.phpÅ  ©t…iÅ  Xê¤      /   phpunit/Framework/Attributes/RequiresMethod.phpâ  ©t…iâ  0ĞÏš¤      8   phpunit/Framework/Attributes/RequiresOperatingSystem.phpÔ  ©t…iÔ  Ñü’Ö¤      >   phpunit/Framework/Attributes/RequiresOperatingSystemFamily.phpö  ©t…iö  ê?Á‡¤      ,   phpunit/Framework/Attributes/RequiresPhp.phpÏ  ©t…iÏ  Ç¯o¤      5   phpunit/Framework/Attributes/RequiresPhpExtension.phpF  ©t…iF  ;9°£¤      0   phpunit/Framework/Attributes/RequiresPhpunit.phpÓ  ©t…iÓ  ãïc“¤      9   phpunit/Framework/Attributes/RequiresPhpunitExtension.php  ©t…i  rÙã¤      0   phpunit/Framework/Attributes/RequiresSetting.phpº  ©t…iº  ª_p¿¤      5   phpunit/Framework/Attributes/RunInSeparateProcess.php  ©t…i  Õ}³¤      <   phpunit/Framework/Attributes/RunTestsInSeparateProcesses.php  ©t…i  ú£Hz¤      &   phpunit/Framework/Attributes/Small.phpş  ©t…iş  ˜
+´w¤      %   phpunit/Framework/Attributes/Test.phpş  ©t…iş  77d‹¤      (   phpunit/Framework/Attributes/TestDox.phpi  ©t…ii  éXL¤      1   phpunit/Framework/Attributes/TestDoxFormatter.php‚  ©t…i‚  axÇÅ¤      9   phpunit/Framework/Attributes/TestDoxFormatterExternal.php·  ©t…i·  EîÅ¤      )   phpunit/Framework/Attributes/TestWith.php€  ©t…i€  2Míw¤      -   phpunit/Framework/Attributes/TestWithJson.php  ©t…i  –	á¤      '   phpunit/Framework/Attributes/Ticket.phpƒ  ©t…iƒ  „,D¤      *   phpunit/Framework/Attributes/UsesClass.php‚  ©t…i‚  Ä3­¤      ;   phpunit/Framework/Attributes/UsesClassesThatExtendClass.php“  ©t…i“  ”<¤      B   phpunit/Framework/Attributes/UsesClassesThatImplementInterface.php¶  ©t…i¶  ÿ·¹´¤      -   phpunit/Framework/Attributes/UsesFunction.php¦  ©t…i¦  =Yï¤      +   phpunit/Framework/Attributes/UsesMethod.phpÃ  ©t…iÃ  ,Ap´¤      .   phpunit/Framework/Attributes/UsesNamespace.php’  ©t…i’  Î¾ë¤      *   phpunit/Framework/Attributes/UsesTrait.php‚  ©t…i‚  ²4K¼¤      8   phpunit/Framework/Attributes/WithEnvironmentVariable.phpÅ  ©t…iÅ  èÇ£e¤      4   phpunit/Framework/Attributes/WithoutErrorHandler.php  ©t…i  ñO½¤      6   phpunit/Framework/Constraint/Array/ArrayComparison.phpŠ  ©t…iŠ  r¨L/¤      2   phpunit/Framework/Constraint/Array/ArrayHasKey.phpy  ©t…iy  8ÓÆ£¤      5   phpunit/Framework/Constraint/Array/ArraysAreEqual.php  ©t…i  õë÷¤      9   phpunit/Framework/Constraint/Array/ArraysAreIdentical.phpò  ©t…iò  ßŞM¤      -   phpunit/Framework/Constraint/Array/IsList.phpR  ©t…iR  ì!„=¤      0   phpunit/Framework/Constraint/Boolean/IsFalse.php`  ©t…i`  , µá¤      /   phpunit/Framework/Constraint/Boolean/IsTrue.php]  ©t…i]  ?6şÍ¤      )   phpunit/Framework/Constraint/Callback.phpú  ©t…iú  J¢c¤      2   phpunit/Framework/Constraint/Cardinality/Count.phpY  ©t…iY  º™/¤      8   phpunit/Framework/Constraint/Cardinality/GreaterThan.php(  ©t…i(  ¥¯¤      4   phpunit/Framework/Constraint/Cardinality/IsEmpty.phpŒ  ©t…iŒ  [c[¤      5   phpunit/Framework/Constraint/Cardinality/LessThan.php"  ©t…i"  ¡°%¤      5   phpunit/Framework/Constraint/Cardinality/SameSize.phpû  ©t…iû  
+™08¤      +   phpunit/Framework/Constraint/Constraint.php‘#  ©t…i‘#  ãn]¤      1   phpunit/Framework/Constraint/Equality/IsEqual.phpc
+  ©t…ic
    3ÃÖ¤      ?   phpunit/Framework/Constraint/Equality/IsEqualCanonicalizing.php^
-  EN„i^
+  ©t…i^
   šğY‚¤      =   phpunit/Framework/Constraint/Equality/IsEqualIgnoringCase.phpd
-  EN„id
-  kîÍ¤      :   phpunit/Framework/Constraint/Equality/IsEqualWithDelta.php¸	  EN„i¸	  ;y6ê¤      4   phpunit/Framework/Constraint/Exception/Exception.phpé  EN„ié  X}íÿ¤      8   phpunit/Framework/Constraint/Exception/ExceptionCode.php0  EN„i0  ~Ñ¤      G   phpunit/Framework/Constraint/Exception/ExceptionMessageIsOrContains.php$  EN„i$  x›¤ñ¤      S   phpunit/Framework/Constraint/Exception/ExceptionMessageMatchesRegularExpression.php·  EN„i·  7Ë«F¤      ;   phpunit/Framework/Constraint/Filesystem/DirectoryExists.phpù  EN„iù  -pˆ¤      6   phpunit/Framework/Constraint/Filesystem/FileExists.phpô  EN„iô  ÿ+ğ÷¤      6   phpunit/Framework/Constraint/Filesystem/IsReadable.phpô  EN„iô  “A†¤      6   phpunit/Framework/Constraint/Filesystem/IsWritable.phpô  EN„iô  öÆùB¤      +   phpunit/Framework/Constraint/IsAnything.phpA  EN„iA  kÒš6¤      ,   phpunit/Framework/Constraint/IsIdentical.phpæ  EN„iæ  rÚª¤      ,   phpunit/Framework/Constraint/JsonMatches.php
-  EN„i
-  9~¬8¤      .   phpunit/Framework/Constraint/Math/IsFinite.phpz  EN„iz  ÔŠø¤      0   phpunit/Framework/Constraint/Math/IsInfinite.php‚  EN„i‚  íC²¤      +   phpunit/Framework/Constraint/Math/IsNan.phpn  EN„in  Çx¤      4   phpunit/Framework/Constraint/Object/ObjectEquals.phpü  EN„iü  ÷1¤      9   phpunit/Framework/Constraint/Object/ObjectHasProperty.phpu  EN„iu  ÷e¥¤      8   phpunit/Framework/Constraint/Operator/BinaryOperator.php[  EN„i[  ÕÕW†¤      4   phpunit/Framework/Constraint/Operator/LogicalAnd.phpY  EN„iY  ÿ‡ı¤      4   phpunit/Framework/Constraint/Operator/LogicalNot.php9  EN„i9  Kğí¤      3   phpunit/Framework/Constraint/Operator/LogicalOr.php=  EN„i=  "iN¤      4   phpunit/Framework/Constraint/Operator/LogicalXor.phpš  EN„iš  Kf¤¤      2   phpunit/Framework/Constraint/Operator/Operator.php'  EN„i'  áJÂ%¤      7   phpunit/Framework/Constraint/Operator/UnaryOperator.php  EN„i  5D¤      .   phpunit/Framework/Constraint/String/IsJson.phpò	  EN„iò	  î–±¤      9   phpunit/Framework/Constraint/String/RegularExpression.php^  EN„i^  ŠË¬>¤      6   phpunit/Framework/Constraint/String/StringContains.php?  EN„i?  š¶©¤¤      6   phpunit/Framework/Constraint/String/StringEndsWith.phpğ  EN„iğ  @%õ-¤      M   phpunit/Framework/Constraint/String/StringEqualsStringIgnoringLineEndings.php7  EN„i7  […J¤      F   phpunit/Framework/Constraint/String/StringMatchesFormatDescription.php,  EN„i,  µc¶"¤      8   phpunit/Framework/Constraint/String/StringStartsWith.phpø  EN„iø  ™.ÿ¤      8   phpunit/Framework/Constraint/Traversable/ArrayHasKey.phpy  EN„iy  8ÓÆ£¤      3   phpunit/Framework/Constraint/Traversable/IsList.phpR  EN„iR  ì!„=¤      @   phpunit/Framework/Constraint/Traversable/TraversableContains.phpK  EN„iK  #Ç¦¤      E   phpunit/Framework/Constraint/Traversable/TraversableContainsEqual.php!  EN„i!  ×b/¤      I   phpunit/Framework/Constraint/Traversable/TraversableContainsIdentical.phpò  EN„iò  íµÍ#¤      D   phpunit/Framework/Constraint/Traversable/TraversableContainsOnly.phpH	  EN„iH	  DsÖå¤      2   phpunit/Framework/Constraint/Type/IsInstanceOf.phpÊ  EN„iÊ  9;>¤      ,   phpunit/Framework/Constraint/Type/IsNull.php\  EN„i\  a#‡ ¤      ,   phpunit/Framework/Constraint/Type/IsType.phpâ	  EN„iâ	  ÃÈÚ°¤      +   phpunit/Framework/DataProviderTestSuite.php@	  EN„i@	  E­‹ø¤      4   phpunit/Framework/Exception/AssertionFailedError.phpş  EN„iş  Ï5/¤      4   phpunit/Framework/Exception/EmptyStringException.phpC  EN„iC  ‹ÖšÍ¤      <   phpunit/Framework/Exception/ErrorLogNotWritableException.php¹  EN„i¹  _}¤      )   phpunit/Framework/Exception/Exception.php›
-  EN„i›
-  ²,Õú¤      :   phpunit/Framework/Exception/ExpectationFailedException.phpÎ  EN„iÎ  Ş]û»¤      >   phpunit/Framework/Exception/GeneratorNotSupportedException.php:  EN„i:  ™ j{¤      9   phpunit/Framework/Exception/Incomplete/IncompleteTest.php,  EN„i,  _Kª¤      >   phpunit/Framework/Exception/Incomplete/IncompleteTestError.phpk  EN„ik  ÷›øè¤      8   phpunit/Framework/Exception/InvalidArgumentException.php;  EN„i;  ÷ñ‹)¤      <   phpunit/Framework/Exception/InvalidDataProviderException.phpÉ  EN„iÉ  ¥¾'¤      :   phpunit/Framework/Exception/InvalidDependencyException.phpo  EN„io  i¾Ôí¤      9   phpunit/Framework/Exception/NoChildTestSuiteException.php9  EN„i9  4´İ¤      N   phpunit/Framework/Exception/ObjectEquals/ActualValueIsNotAnObjectException.php­  EN„i­  ·òW÷¤      `   phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotAcceptParameterTypeException.phpW  EN„iW  Œ‹–½¤      b   phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotDeclareBoolReturnTypeException.php>  EN„i>  {ı– ¤      g   phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotDeclareExactlyOneParameterException.phpH  EN„iH  °t ²¤      a   phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotDeclareParameterTypeException.phpF  EN„iF  ñ†9¤      R   phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotExistException.php  EN„i  İ/]¤      8   phpunit/Framework/Exception/PhptAssertionFailedError.phpÃ  EN„iÃ  èèy¤      9   phpunit/Framework/Exception/ProcessIsolationException.php9  EN„i9  ,ÿÃ¤      3   phpunit/Framework/Exception/Skipped/SkippedTest.php)  EN„i)  Àó¤      =   phpunit/Framework/Exception/Skipped/SkippedTestSuiteError.phpj  EN„ij  wÜŠ¤      C   phpunit/Framework/Exception/Skipped/SkippedWithMessageException.phpp  EN„ip  X&º>¤      @   phpunit/Framework/Exception/UnknownClassOrInterfaceException.phpö  EN„iö  Hnw¤      :   phpunit/Framework/Exception/UnknownNativeTypeException.phpç  EN„iç  œ%]¤      .   phpunit/Framework/ExecutionOrderDependency.php  EN„i  ë×œğ¤      3   phpunit/Framework/MockObject/ConfigurableMethod.phpï  EN„iï  Ì^ÉP¤      A   phpunit/Framework/MockObject/Exception/BadMethodCallException.phpo  EN„io  äÛ!¤      H   phpunit/Framework/MockObject/Exception/CannotUseOnlyMethodsException.phpt  EN„it  ™¬
-¤      4   phpunit/Framework/MockObject/Exception/Exception.php,  EN„i,  ÷Rœ?¤      K   phpunit/Framework/MockObject/Exception/IncompatibleReturnValueException.phpå  EN„iå  2íK]¤      H   phpunit/Framework/MockObject/Exception/MatchBuilderNotFoundException.php.  EN„i.  ú¤´a¤      L   phpunit/Framework/MockObject/Exception/MatcherAlreadyRegisteredException.php&  EN„i&  æİîŸ¤      L   phpunit/Framework/MockObject/Exception/MethodCannotBeConfiguredException.phpˆ  EN„iˆ  7À„3¤      O   phpunit/Framework/MockObject/Exception/MethodNameAlreadyConfiguredException.phpò  EN„iò  <Ú¬>¤      K   phpunit/Framework/MockObject/Exception/MethodNameNotConfiguredException.phpê  EN„iê  ªYi¤      U   phpunit/Framework/MockObject/Exception/MethodParametersAlreadyConfiguredException.phpû  EN„iû  ¥s¤      H   phpunit/Framework/MockObject/Exception/NeverReturningMethodException.phpe  EN„ie  ]M6…¤      P   phpunit/Framework/MockObject/Exception/NoMoreReturnValuesConfiguredException.php×  EN„i×  H]²ò¤      L   phpunit/Framework/MockObject/Exception/ReturnValueNotConfiguredException.php¨  EN„i¨  2’×V¤      ;   phpunit/Framework/MockObject/Exception/RuntimeException.phpc  EN„ic  õ€=	¤      7   phpunit/Framework/MockObject/Generator/DoubledClass.php  EN„i  8¢Àó¤      8   phpunit/Framework/MockObject/Generator/DoubledMethod.php~)  EN„i~)  Ò'W±¤      ;   phpunit/Framework/MockObject/Generator/DoubledMethodSet.phpÚ  EN„iÚ  #0¤      P   phpunit/Framework/MockObject/Generator/Exception/ClassIsEnumerationException.phpJ  EN„iJ   `@¤      J   phpunit/Framework/MockObject/Generator/Exception/ClassIsFinalException.phpF  EN„iF  Ôƒ¤      M   phpunit/Framework/MockObject/Generator/Exception/DuplicateMethodException.phpF  EN„iF  ÂAé¤      >   phpunit/Framework/MockObject/Generator/Exception/Exception.phpn  EN„in  ½q~•¤      O   phpunit/Framework/MockObject/Generator/Exception/InvalidMethodNameException.php<  EN„i<  ×ÓªÙ¤      O   phpunit/Framework/MockObject/Generator/Exception/MethodNamedMethodException.phpÃ  EN„iÃ  W²6¶¤      N   phpunit/Framework/MockObject/Generator/Exception/NameAlreadyInUseException.phpi  EN„ii  Ø´¤      H   phpunit/Framework/MockObject/Generator/Exception/ReflectionException.php…  EN„i…  "è¤      E   phpunit/Framework/MockObject/Generator/Exception/RuntimeException.php‚  EN„i‚  „Ãø¤      N   phpunit/Framework/MockObject/Generator/Exception/UnknownInterfaceException.php;  EN„i;  ¹:yá¤      I   phpunit/Framework/MockObject/Generator/Exception/UnknownTypeException.php-  EN„i-  ¨‰V¤      4   phpunit/Framework/MockObject/Generator/Generator.phpc  EN„ic  S5f¤      9   phpunit/Framework/MockObject/Generator/HookedProperty.phpê  EN„iê  -—ˆ¤      B   phpunit/Framework/MockObject/Generator/HookedPropertyGenerator.phpI  EN„iI  Ïƒt¤      9   phpunit/Framework/MockObject/Generator/TemplateLoader.phpÙ  EN„iÙ  ˆHU!¤      @   phpunit/Framework/MockObject/Generator/templates/deprecation.tpl;   EN„i;   O5øs¤      C   phpunit/Framework/MockObject/Generator/templates/doubled_method.tplC  EN„iC  ¡÷Mé¤      J   phpunit/Framework/MockObject/Generator/templates/doubled_static_method.tplî   EN„iî    4éR¤      A   phpunit/Framework/MockObject/Generator/templates/intersection.tplL   EN„iL   ®-X¤      F   phpunit/Framework/MockObject/Generator/templates/test_double_class.tpl[   EN„i[   üj½Ğ¤      ,   phpunit/Framework/MockObject/MockBuilder.php"
-  EN„i"
-  (Ê³¤      ?   phpunit/Framework/MockObject/Runtime/Api/DoubledCloneMethod.php  EN„i  ¥•J%¤      3   phpunit/Framework/MockObject/Runtime/Api/Method.php  EN„i  ¡£)²¤      :   phpunit/Framework/MockObject/Runtime/Api/MockObjectApi.php	  EN„i	  ÏYïz¤      ?   phpunit/Framework/MockObject/Runtime/Api/ProxiedCloneMethod.php7  EN„i7  ‰˜Â˜¤      4   phpunit/Framework/MockObject/Runtime/Api/StubApi.phpĞ  EN„iĞ  $ÊFñ¤      <   phpunit/Framework/MockObject/Runtime/Api/TestDoubleState.phpõ  EN„iõ  |†$•¤      D   phpunit/Framework/MockObject/Runtime/Interface/InvocationStubber.phpå  EN„iå  zå˜¤      =   phpunit/Framework/MockObject/Runtime/Interface/MockObject.phpƒ  EN„iƒ  ½Tß»¤      E   phpunit/Framework/MockObject/Runtime/Interface/MockObjectInternal.phpû  EN„iû  êúı“¤      7   phpunit/Framework/MockObject/Runtime/Interface/Stub.php‰  EN„i‰  cvã¤      ?   phpunit/Framework/MockObject/Runtime/Interface/StubInternal.php9  EN„i9   {Æå¤      3   phpunit/Framework/MockObject/Runtime/Invocation.phpW  EN„iW  É¿{2¤      :   phpunit/Framework/MockObject/Runtime/InvocationHandler.phpq  EN„iq  ­%Ã3¤      H   phpunit/Framework/MockObject/Runtime/InvocationStubberImplementation.php[&  EN„i[&  öÀzØ¤      0   phpunit/Framework/MockObject/Runtime/Matcher.php‘  EN„i‘  •?¢t¤      =   phpunit/Framework/MockObject/Runtime/MethodNameConstraint.php  EN„i  ı/ƒ¤      E   phpunit/Framework/MockObject/Runtime/PropertyHook/PropertyGetHook.php  EN„i  »Æ6Ì¤      B   phpunit/Framework/MockObject/Runtime/PropertyHook/PropertyHook.php5  EN„i5  NE5Ò¤      E   phpunit/Framework/MockObject/Runtime/PropertyHook/PropertySetHook.php  EN„i  `²>n¤      =   phpunit/Framework/MockObject/Runtime/ReturnValueGenerator.phpû  EN„iû  emĞb¤      =   phpunit/Framework/MockObject/Runtime/Rule/AnyInvokedCount.phpƒ  EN„iƒ  /d²k¤      ;   phpunit/Framework/MockObject/Runtime/Rule/AnyParameters.php/  EN„i/  ÿpv¤      =   phpunit/Framework/MockObject/Runtime/Rule/InvocationOrder.php7  EN„i7  =€Ä˜¤      A   phpunit/Framework/MockObject/Runtime/Rule/InvokedAtLeastCount.php*  EN„i*  ä™†³¤      @   phpunit/Framework/MockObject/Runtime/Rule/InvokedAtLeastOnce.phpG  EN„iG  ãfËs¤      @   phpunit/Framework/MockObject/Runtime/Rule/InvokedAtMostCount.php  EN„i  yÃI¤      :   phpunit/Framework/MockObject/Runtime/Rule/InvokedCount.phpÁ	  EN„iÁ	   I¤      8   phpunit/Framework/MockObject/Runtime/Rule/MethodName.php{  EN„i{  >Êh¤      8   phpunit/Framework/MockObject/Runtime/Rule/Parameters.php©  EN„i©  ·İB¤      <   phpunit/Framework/MockObject/Runtime/Rule/ParametersRule.phpë  EN„ië  v®Y¤      >   phpunit/Framework/MockObject/Runtime/Stub/ConsecutiveCalls.php   EN„i   ËdRY¤      7   phpunit/Framework/MockObject/Runtime/Stub/Exception.php¦  EN„i¦  áëK¶¤      <   phpunit/Framework/MockObject/Runtime/Stub/ReturnArgument.phpŸ  EN„iŸ  rjc¤      <   phpunit/Framework/MockObject/Runtime/Stub/ReturnCallback.phpÔ  EN„iÔ  2à¶Q¤      =   phpunit/Framework/MockObject/Runtime/Stub/ReturnReference.phpf  EN„if  ¦ÿ¬Ó¤      8   phpunit/Framework/MockObject/Runtime/Stub/ReturnSelf.phpE  EN„iE  “”DÑ¤      8   phpunit/Framework/MockObject/Runtime/Stub/ReturnStub.phpT  EN„iT  å{ÈŠ¤      <   phpunit/Framework/MockObject/Runtime/Stub/ReturnValueMap.phpl  EN„il  $}S¤      2   phpunit/Framework/MockObject/Runtime/Stub/Stub.phpé  EN„ié  Ó±Ê¤      2   phpunit/Framework/MockObject/TestDoubleBuilder.php×  EN„i×  [=“&¤      0   phpunit/Framework/MockObject/TestStubBuilder.phpª  EN„iª  ‚B<\¤          phpunit/Framework/NativeType.php&  EN„i&  |Ñgç¤      !   phpunit/Framework/Reorderable.phpø  EN„iø  €¶çö¤      $   phpunit/Framework/SelfDescribing.phpy  EN„iy  ;Å;¤         phpunit/Framework/Test.phpã  EN„iã  ­ñ9¤      !   phpunit/Framework/TestBuilder.phpè,  EN„iè,  È¯4Ü¤         phpunit/Framework/TestCase.php´" EN„i´" èP¤      <   phpunit/Framework/TestRunner/ChildProcessResultProcessor.php8  EN„i8  =¾;ì¤      3   phpunit/Framework/TestRunner/IsolatedTestRunner.php˜  EN„i˜  H/¥Ş¤      ;   phpunit/Framework/TestRunner/IsolatedTestRunnerRegistry.phpV  EN„iV  €ag¤      :   phpunit/Framework/TestRunner/SeparateProcessTestRunner.php|  EN„i|  Œ¤ò¤      +   phpunit/Framework/TestRunner/TestRunner.phpÔ,  EN„iÔ,  ÎG&¤      0   phpunit/Framework/TestRunner/templates/class.tplÚ  EN„iÚ  ÅïÍ¤      1   phpunit/Framework/TestRunner/templates/method.tplà  EN„ià  U»PÏ¤      $   phpunit/Framework/TestSize/Known.phpØ  EN„iØ  ¯½R¤      $   phpunit/Framework/TestSize/Large.phpb  EN„ib  ;qç¤      %   phpunit/Framework/TestSize/Medium.phpd  EN„id  TA¦Ñ¤      $   phpunit/Framework/TestSize/Small.phpV  EN„iV  XÃ¢™¤      '   phpunit/Framework/TestSize/TestSize.php¤  EN„i¤  ÅìHÑ¤      &   phpunit/Framework/TestSize/Unknown.phpç  EN„iç  fÚœ¤      ,   phpunit/Framework/TestStatus/Deprecation.php3  EN„i3  ‡mĞ|¤      &   phpunit/Framework/TestStatus/Error.php!  EN„i!  ÊXP>¤      (   phpunit/Framework/TestStatus/Failure.php'  EN„i'  µgö%¤      +   phpunit/Framework/TestStatus/Incomplete.php0  EN„i0  Üqöq¤      &   phpunit/Framework/TestStatus/Known.phpŸ  EN„iŸ  ‘Â–¤      '   phpunit/Framework/TestStatus/Notice.php$  EN„i$  «¥!H¤      &   phpunit/Framework/TestStatus/Risky.php!  EN„i!  t E¤      (   phpunit/Framework/TestStatus/Skipped.php'  EN„i'   <¤      (   phpunit/Framework/TestStatus/Success.php'  EN„i'  Şa&¥¤      +   phpunit/Framework/TestStatus/TestStatus.phpÀ  EN„iÀ  +u¤      (   phpunit/Framework/TestStatus/Unknown.php-  EN„i-  FuXN¤      (   phpunit/Framework/TestStatus/Warning.php'  EN„i'  =â¤         phpunit/Framework/TestSuite.phpEK  EN„iEK  Ë‡D¤      '   phpunit/Framework/TestSuiteIterator.phpü  EN„iü  Ä¯Ì6¤         phpunit/Logging/EventLogger.phpI  EN„iI  cïµ¾¤      (   phpunit/Logging/JUnit/JunitXmlLogger.php¹1  EN„i¹1  µÿW¤      /   phpunit/Logging/JUnit/Subscriber/Subscriber.php=  EN„i=  ôıxÛ¤      :   phpunit/Logging/JUnit/Subscriber/TestErroredSubscriber.php}  EN„i}  £Šá¤      9   phpunit/Logging/JUnit/Subscriber/TestFailedSubscriber.phpw  EN„iw  †€¤      ;   phpunit/Logging/JUnit/Subscriber/TestFinishedSubscriber.phpƒ  EN„iƒ  "^—¤      C   phpunit/Logging/JUnit/Subscriber/TestMarkedIncompleteSubscriber.php³  EN„i³  5İTY¤      E   phpunit/Logging/JUnit/Subscriber/TestPreparationErroredSubscriber.php¹  EN„i¹  ñDy‰¤      D   phpunit/Logging/JUnit/Subscriber/TestPreparationFailedSubscriber.php³  EN„i³  ºÉ£Å¤      E   phpunit/Logging/JUnit/Subscriber/TestPreparationStartedSubscriber.php¿  EN„i¿  $†‘2¤      ;   phpunit/Logging/JUnit/Subscriber/TestPreparedSubscriber.php}  EN„i}  ñı»‡¤      J   phpunit/Logging/JUnit/Subscriber/TestPrintedUnexpectedOutputSubscriber.phpy  EN„iy  ÷Öú¤      J   phpunit/Logging/JUnit/Subscriber/TestRunnerExecutionFinishedSubscriber.phpQ  EN„iQ  2õ÷÷¤      :   phpunit/Logging/JUnit/Subscriber/TestSkippedSubscriber.php}  EN„i}  ¿I©¤      @   phpunit/Logging/JUnit/Subscriber/TestSuiteFinishedSubscriber.php-  EN„i-   Cö¶¤      ?   phpunit/Logging/JUnit/Subscriber/TestSuiteStartedSubscriber.php-  EN„i-  }‰£€¤      P   phpunit/Logging/OpenTestReporting/Exception/CannotOpenUriForWritingException.phpÅ  EN„iÅ  Î—ip¤      9   phpunit/Logging/OpenTestReporting/Exception/Exception.php`  EN„i`  Tç>i¤      G   phpunit/Logging/OpenTestReporting/InfrastructureInformationProvider.php
-  EN„i
-  ¼		û¤      2   phpunit/Logging/OpenTestReporting/OtrXmlLogger.phpß>  EN„iß>  á¡³¤      ,   phpunit/Logging/OpenTestReporting/Status.php³  EN„i³  |Ü"£¤      U   phpunit/Logging/OpenTestReporting/Subscriber/AfterLastTestMethodErroredSubscriber.php,  EN„i,  wÖ¤      T   phpunit/Logging/OpenTestReporting/Subscriber/AfterLastTestMethodFailedSubscriber.php%  EN„i%  ë£õ¤      W   phpunit/Logging/OpenTestReporting/Subscriber/BeforeFirstTestMethodErroredSubscriber.php8  EN„i8  –£¤      V   phpunit/Logging/OpenTestReporting/Subscriber/BeforeFirstTestMethodFailedSubscriber.php1  EN„i1  r¤™¤      ;   phpunit/Logging/OpenTestReporting/Subscriber/Subscriber.phpg  EN„ig  †€!{¤      F   phpunit/Logging/OpenTestReporting/Subscriber/TestAbortedSubscriber.phpÀ  EN„iÀ  şsE¤      F   phpunit/Logging/OpenTestReporting/Subscriber/TestErroredSubscriber.php•  EN„i•  RO(¤      E   phpunit/Logging/OpenTestReporting/Subscriber/TestFailedSubscriber.php  EN„i  #İ¤      G   phpunit/Logging/OpenTestReporting/Subscriber/TestFinishedSubscriber.php•  EN„i•  Hœ¤      Q   phpunit/Logging/OpenTestReporting/Subscriber/TestPreparationErroredSubscriber.phpÍ  EN„iÍ  ¦£Ø¾¤      P   phpunit/Logging/OpenTestReporting/Subscriber/TestPreparationFailedSubscriber.phpÈ  EN„iÈ  u„µ¤      G   phpunit/Logging/OpenTestReporting/Subscriber/TestPreparedSubscriber.php›  EN„i›  ÙÁ7²¤      M   phpunit/Logging/OpenTestReporting/Subscriber/TestRunnerFinishedSubscriber.phpÑ  EN„iÑ  ùów…¤      L   phpunit/Logging/OpenTestReporting/Subscriber/TestRunnerStartedSubscriber.php©  EN„i©  Òy¡Æ¤      F   phpunit/Logging/OpenTestReporting/Subscriber/TestSkippedSubscriber.php•  EN„i•  iÏIr¤      L   phpunit/Logging/OpenTestReporting/Subscriber/TestSuiteFinishedSubscriber.php©  EN„i©  ¡ĞÉ¤      K   phpunit/Logging/OpenTestReporting/Subscriber/TestSuiteSkippedSubscriber.php©  EN„i©  @*E¤      K   phpunit/Logging/OpenTestReporting/Subscriber/TestSuiteStartedSubscriber.php©  EN„i©  ­E@p¤      2   phpunit/Logging/TeamCity/Subscriber/Subscriber.phpI  EN„iI  Œt¶“¤      E   phpunit/Logging/TeamCity/Subscriber/TestConsideredRiskySubscriber.php³  EN„i³  åÎF¤      =   phpunit/Logging/TeamCity/Subscriber/TestErroredSubscriber.phpƒ  EN„iƒ  ¯y»ˆ¤      <   phpunit/Logging/TeamCity/Subscriber/TestFailedSubscriber.php}  EN„i}  °ôå¤      >   phpunit/Logging/TeamCity/Subscriber/TestFinishedSubscriber.php‰  EN„i‰  ÍT¸›¤      F   phpunit/Logging/TeamCity/Subscriber/TestMarkedIncompleteSubscriber.php¹  EN„i¹  ¾T»b¤      >   phpunit/Logging/TeamCity/Subscriber/TestPreparedSubscriber.php%  EN„i%  ÿ`c+¤      M   phpunit/Logging/TeamCity/Subscriber/TestRunnerExecutionFinishedSubscriber.phpW  EN„iW  ã)Ê®¤      =   phpunit/Logging/TeamCity/Subscriber/TestSkippedSubscriber.phpƒ  EN„iƒ  ÁNÇH¤      W   phpunit/Logging/TeamCity/Subscriber/TestSuiteBeforeFirstTestMethodErroredSubscriber.php  EN„i  ïÊ¹j¤      C   phpunit/Logging/TeamCity/Subscriber/TestSuiteFinishedSubscriber.php9  EN„i9  ¬(s³¤      B   phpunit/Logging/TeamCity/Subscriber/TestSuiteSkippedSubscriber.php—  EN„i—  5²B;¤      B   phpunit/Logging/TeamCity/Subscriber/TestSuiteStartedSubscriber.php3  EN„i3  ±Ò“¤      +   phpunit/Logging/TeamCity/TeamCityLogger.php’*  EN„i’*  *é]4¤      (   phpunit/Logging/TestDox/HtmlRenderer.php·  EN„i·  ¹O!‘¤      *   phpunit/Logging/TestDox/NamePrettifier.phpç.  EN„iç.  Û¶»¤      -   phpunit/Logging/TestDox/PlainTextRenderer.php„  EN„i„  NÅô¤      <   phpunit/Logging/TestDox/TestResult/Subscriber/Subscriber.phpf  EN„if  7kC¤      O   phpunit/Logging/TestDox/TestResult/Subscriber/TestConsideredRiskySubscriber.phpP  EN„iP  »J'¤      G   phpunit/Logging/TestDox/TestResult/Subscriber/TestErroredSubscriber.php   EN„i   t8¤      F   phpunit/Logging/TestDox/TestResult/Subscriber/TestFailedSubscriber.php  EN„i  ñä;À¤      H   phpunit/Logging/TestDox/TestResult/Subscriber/TestFinishedSubscriber.phpŠ  EN„iŠ  MÉ~£¤      P   phpunit/Logging/TestDox/TestResult/Subscriber/TestMarkedIncompleteSubscriber.phpV  EN„iV  ]ùó¤      F   phpunit/Logging/TestDox/TestResult/Subscriber/TestPassedSubscriber.php  EN„i  ÔBº¤      H   phpunit/Logging/TestDox/TestResult/Subscriber/TestPreparedSubscriber.php&  EN„i&  ÚÈé¤      G   phpunit/Logging/TestDox/TestResult/Subscriber/TestSkippedSubscriber.php   EN„i   ´Õj¤      T   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredDeprecationSubscriber.phpn  EN„in  Q¤      O   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredNoticeSubscriber.phpP  EN„iP  °ÔÃ)¤      W   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredPhpDeprecationSubscriber.php€  EN„i€  ˜]¤      R   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredPhpNoticeSubscriber.phpb  EN„ib  ae¤      S   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredPhpWarningSubscriber.phph  EN„ih  ¢QF¤      [   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredPhpunitDeprecationSubscriber.php˜  EN„i˜  ^õ¤      U   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredPhpunitErrorSubscriber.phpt  EN„it  ‘Gâ°¤      W   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredPhpunitWarningSubscriber.php€  EN„i€  îk½<¤      P   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredWarningSubscriber.phpV  EN„iV  xİB\¤      1   phpunit/Logging/TestDox/TestResult/TestResult.phpf  EN„if  é˜µ¤      ;   phpunit/Logging/TestDox/TestResult/TestResultCollection.phps  EN„is  ¹Ì¤      C   phpunit/Logging/TestDox/TestResult/TestResultCollectionIterator.phpÑ  EN„iÑ  yÀDÙ¤      :   phpunit/Logging/TestDox/TestResult/TestResultCollector.phpÓ)  EN„iÓ)  <[Qì¤         phpunit/Metadata/After.phpT  EN„iT  Æ?êH¤         phpunit/Metadata/AfterClass.php^  EN„i^  Í¯%d¤      8   phpunit/Metadata/AllowMockObjectsWithoutExpectations.phpb  EN„ib  I)¨¤      %   phpunit/Metadata/Api/CodeCoverage.php  EN„i  [pá¤      %   phpunit/Metadata/Api/DataProvider.php (  EN„i (  <Şé8¤      %   phpunit/Metadata/Api/Dependencies.php†  EN„i†  Š6Á¾¤         phpunit/Metadata/Api/Groups.phpJ  EN„iJ  %“PU¤      $   phpunit/Metadata/Api/HookMethods.php  EN„i  ÙE¤      %   phpunit/Metadata/Api/ProvidedData.phpû  EN„iû  O	„®¤      %   phpunit/Metadata/Api/Requirements.phpÇ  EN„iÇ  ¹ı†º¤      "   phpunit/Metadata/BackupGlobals.phpa  EN„ia  ³æè2¤      +   phpunit/Metadata/BackupStaticProperties.phps  EN„is  ¾“È?¤         phpunit/Metadata/Before.phpV  EN„iV  É§^¤          phpunit/Metadata/BeforeClass.php`  EN„i`  ãƒ|\¤          phpunit/Metadata/CoversClass.phpí  EN„ií  Tp&¤      1   phpunit/Metadata/CoversClassesThatExtendClass.php  EN„i  ü:YŠ¤      8   phpunit/Metadata/CoversClassesThatImplementInterface.php9  EN„i9  öØQ÷¤      #   phpunit/Metadata/CoversFunction.php  EN„i  Ì	Õé¤      !   phpunit/Metadata/CoversMethod.php3  EN„i3  ÌÊ¤      $   phpunit/Metadata/CoversNamespace.php  EN„i  Öñ‹‡¤      "   phpunit/Metadata/CoversNothing.php6  EN„i6  I¥Õ¤          phpunit/Metadata/CoversTrait.phpí  EN„ií  |15j¤      !   phpunit/Metadata/DataProvider.php#  EN„i#  ÑïG…¤      #   phpunit/Metadata/DependsOnClass.phpU  EN„iU  8¹åB¤      $   phpunit/Metadata/DependsOnMethod.php›  EN„i›  ÙK<¤      ?   phpunit/Metadata/DisableReturnValueGenerationForTestDoubles.phpp  EN„ip  ‘	¤      -   phpunit/Metadata/DoesNotPerformAssertions.phpL  EN„iL  {¯T¤      (   phpunit/Metadata/Exception/Exception.phpÀ  EN„iÀ  älñ¤      8   phpunit/Metadata/Exception/InvalidAttributeException.phpw  EN„iw  Òo‡¤      A   phpunit/Metadata/Exception/InvalidVersionRequirementException.php  EN„i  -µ[D¤      <   phpunit/Metadata/Exception/NoVersionRequirementException.php  EN„i  gÌ®¤      4   phpunit/Metadata/ExcludeGlobalVariableFromBackup.phpd  EN„id  :‡¤      4   phpunit/Metadata/ExcludeStaticPropertyFromBackup.phpg  EN„ig  |}›-¤         phpunit/Metadata/Group.phpñ  EN„iñ  =ÈIs¤      '   phpunit/Metadata/IgnoreDeprecations.php=  EN„i=  ­“º/¤      .   phpunit/Metadata/IgnorePhpunitDeprecations.phpª  EN„iª  (\¤      *   phpunit/Metadata/IgnorePhpunitWarnings.phpC  EN„iC  R¸Ÿ™¤         phpunit/Metadata/Metadata.php1u  EN„i1u  |Ëé¤      '   phpunit/Metadata/MetadataCollection.php8  EN„i8  ƒH»0¤      /   phpunit/Metadata/MetadataCollectionIterator.phpD  EN„iD  ñÎ¤      +   phpunit/Metadata/Parser/AttributeParser.php¹…  EN„i¹…  ßÑ˜‰¤      )   phpunit/Metadata/Parser/CachingParser.php¯
-  EN„i¯
-  ®t¤      "   phpunit/Metadata/Parser/Parser.php3  EN„i3  dİË$¤      $   phpunit/Metadata/Parser/Registry.php  EN„i  ç˜wR¤      "   phpunit/Metadata/PostCondition.phpd  EN„id  —‚±¤      !   phpunit/Metadata/PreCondition.phpb  EN„ib  ryq¤      (   phpunit/Metadata/PreserveGlobalState.phpm  EN„im  ×Mß7¤      0   phpunit/Metadata/RequiresEnvironmentVariable.phpY  EN„iY  ò¤      %   phpunit/Metadata/RequiresFunction.php  EN„i  ™­¤      #   phpunit/Metadata/RequiresMethod.php7  EN„i7  Cñã¤      ,   phpunit/Metadata/RequiresOperatingSystem.php?  EN„i?  ,’>¸¤      2   phpunit/Metadata/RequiresOperatingSystemFamily.phpu  EN„iu  >rã;¤          phpunit/Metadata/RequiresPhp.phpŞ  EN„iŞ  VµƒÕ¤      )   phpunit/Metadata/RequiresPhpExtension.php°  EN„i°  yvàs¤      $   phpunit/Metadata/RequiresPhpunit.phpæ  EN„iæ  ^}Ç¤      -   phpunit/Metadata/RequiresPhpunitExtension.phpQ  EN„iQ   º]¤      $   phpunit/Metadata/RequiresSetting.php  EN„i  $8‘Ú¤      .   phpunit/Metadata/RunClassInSeparateProcess.phpN  EN„iN  °8Æ¤      )   phpunit/Metadata/RunInSeparateProcess.phpD  EN„iD  ÿŸi‹¤      0   phpunit/Metadata/RunTestsInSeparateProcesses.phpR  EN„iR  Yß­s¤         phpunit/Metadata/Test.php$  EN„i$  1Ñ¡¤         phpunit/Metadata/TestDox.phpÒ  EN„iÒ  ŸğV>¤      %   phpunit/Metadata/TestDoxFormatter.php;  EN„i;  6ì>Ã¤         phpunit/Metadata/TestWith.php  EN„i  Şä^¤         phpunit/Metadata/UsesClass.phpé  EN„ié  ¤¾E¤      /   phpunit/Metadata/UsesClassesThatExtendClass.php  EN„i  òN¢¤      6   phpunit/Metadata/UsesClassesThatImplementInterface.php5  EN„i5  7(¬¤      !   phpunit/Metadata/UsesFunction.php  EN„i  ‹Èx¤         phpunit/Metadata/UsesMethod.php/  EN„i/  …Hú}¤      "   phpunit/Metadata/UsesNamespace.phpı  EN„iı  ÕsK¤         phpunit/Metadata/UsesTrait.phpé  EN„ié  Yâ&*¤      2   phpunit/Metadata/Version/ComparisonRequirement.phpW  EN„iW  ìÈ–?¤      2   phpunit/Metadata/Version/ConstraintRequirement.php  EN„i  ^.8¤      (   phpunit/Metadata/Version/Requirement.phpş  EN„iş  ¢âI¿¤      ,   phpunit/Metadata/WithEnvironmentVariable.phpö  EN„iö  £->D¤      (   phpunit/Metadata/WithoutErrorHandler.phpB  EN„iB  %€W­¤      .   phpunit/Runner/BackedUpEnvironmentVariable.php«  EN„i«  Ô#{°¤      $   phpunit/Runner/Baseline/Baseline.phpg  EN„ig  Qá<Â¤      A   phpunit/Runner/Baseline/Exception/CannotLoadBaselineException.php~  EN„i~  =)Sb¤      B   phpunit/Runner/Baseline/Exception/CannotWriteBaselineException.php  EN„i  ¶ 4É¤      B   phpunit/Runner/Baseline/Exception/FileDoesNotHaveLineException.php1  EN„i1  ü3€¤      %   phpunit/Runner/Baseline/Generator.phpñ  EN„iñ  –öÖ¤      !   phpunit/Runner/Baseline/Issue.php)  EN„i)  Û<É¤      "   phpunit/Runner/Baseline/Reader.phpÖ  EN„iÖ  ´ÿÀ{¤      2   phpunit/Runner/Baseline/RelativePathCalculator.phpÎ
-  EN„iÎ
-  íËe¥¤      1   phpunit/Runner/Baseline/Subscriber/Subscriber.phpH  EN„iH  Ğ43¤      I   phpunit/Runner/Baseline/Subscriber/TestTriggeredDeprecationSubscriber.phpû  EN„iû  ü_E¤      D   phpunit/Runner/Baseline/Subscriber/TestTriggeredNoticeSubscriber.phpâ  EN„iâ  jâÄ¤      L   phpunit/Runner/Baseline/Subscriber/TestTriggeredPhpDeprecationSubscriber.php
-  EN„i
-  Âk°±¤      G   phpunit/Runner/Baseline/Subscriber/TestTriggeredPhpNoticeSubscriber.phpñ  EN„iñ  ÒîL¤      H   phpunit/Runner/Baseline/Subscriber/TestTriggeredPhpWarningSubscriber.phpö  EN„iö  ´MŠ¤      E   phpunit/Runner/Baseline/Subscriber/TestTriggeredWarningSubscriber.phpç  EN„iç  àQÌ½¤      "   phpunit/Runner/Baseline/Writer.phpj	  EN„ij	  öı†q¤         phpunit/Runner/CodeCoverage.php®=  EN„i®=  9·ûy¤      3   phpunit/Runner/CodeCoverageInitializationStatus.phpT  EN„iT  ‰52q¤      1   phpunit/Runner/DeprecationCollector/Collector.phpZ  EN„iZ  ì–c¤      .   phpunit/Runner/DeprecationCollector/Facade.phpô  EN„iô  &¨I¤      <   phpunit/Runner/DeprecationCollector/InIsolationCollector.php"  EN„i"  óß}È¤      =   phpunit/Runner/DeprecationCollector/Subscriber/Subscriber.php&  EN„i&  ˜¬\¤      I   phpunit/Runner/DeprecationCollector/Subscriber/TestPreparedSubscriber.php/  EN„i/  Kd€I¤      U   phpunit/Runner/DeprecationCollector/Subscriber/TestTriggeredDeprecationSubscriber.php}  EN„i}  Yò¤         phpunit/Runner/ErrorHandler.phpº8  EN„iº8  àÙÔl¤      8   phpunit/Runner/Exception/ClassCannotBeFoundException.php%  EN„i%  uëX¤      @   phpunit/Runner/Exception/ClassDoesNotExtendTestCaseException.phpQ  EN„iQ  ÎºYÀ¤      5   phpunit/Runner/Exception/ClassIsAbstractException.php'  EN„i'  ƒìT¤      <   phpunit/Runner/Exception/CodeCoverageFileExistsException.phpk  EN„ik  ƒÙŸ¤      ;   phpunit/Runner/Exception/DirectoryDoesNotExistException.php+  EN„i+  EH¾-¤      +   phpunit/Runner/Exception/ErrorException.phpD  EN„iD  i}Å¤      &   phpunit/Runner/Exception/Exception.php  EN„i  úYŠK¤      6   phpunit/Runner/Exception/FileDoesNotExistException.phpş  EN„iş  dfH!¤      2   phpunit/Runner/Exception/InvalidOrderException.phpa  EN„ia  [Èt%¤      ;   phpunit/Runner/Exception/ParameterDoesNotExistException.php  EN„i  Z­Ÿh¤      &   phpunit/Runner/Extension/Extension.php…  EN„i…  sÆ²¤      2   phpunit/Runner/Extension/ExtensionBootstrapper.phpá	  EN„iá	  .îÑL¤      #   phpunit/Runner/Extension/Facade.php‘	  EN„i‘	  ÇŒ
-¤      0   phpunit/Runner/Extension/ParameterCollection.phpL  EN„iL  pıñ(¤      '   phpunit/Runner/Extension/PharLoader.php  EN„i  ¢Ã†s¤      4   phpunit/Runner/Filter/ExcludeGroupFilterIterator.phpQ  EN„iQ  úFßİ¤      3   phpunit/Runner/Filter/ExcludeNameFilterIterator.php£  EN„i£  BêÕ¤      !   phpunit/Runner/Filter/Factory.phpõ	  EN„iõ	  Ä1¤      -   phpunit/Runner/Filter/GroupFilterIterator.php  EN„i  <e³I¤      4   phpunit/Runner/Filter/IncludeGroupFilterIterator.phpP  EN„iP  Iÿ £¤      3   phpunit/Runner/Filter/IncludeNameFilterIterator.php¢  EN„i¢  jjÏ¤      ,   phpunit/Runner/Filter/NameFilterIterator.php/  EN„i/  åoÕ¤      .   phpunit/Runner/Filter/TestIdFilterIterator.phpº  EN„iº  JØİ,¤      =   phpunit/Runner/GarbageCollection/GarbageCollectionHandler.php   EN„i    µÏ¤      K   phpunit/Runner/GarbageCollection/Subscriber/ExecutionFinishedSubscriber.php<  EN„i<  /ëƒt¤      J   phpunit/Runner/GarbageCollection/Subscriber/ExecutionStartedSubscriber.php5  EN„i5  òXê$¤      :   phpunit/Runner/GarbageCollection/Subscriber/Subscriber.php  EN„i  l´Ñ¤      F   phpunit/Runner/GarbageCollection/Subscriber/TestFinishedSubscriber.phpÏ  EN„iÏ  „g6¤      (   phpunit/Runner/HookMethod/HookMethod.php"  EN„i"  é)¤      2   phpunit/Runner/HookMethod/HookMethodCollection.phpÅ	  EN„iÅ	  ¥~„É¤         phpunit/Runner/IssueFilter.phpÂ  EN„iÂ  ù-I¤      :   phpunit/Runner/Phpt/Exception/InvalidPhptFileException.php  EN„i  úÁµÒ¤      I   phpunit/Runner/Phpt/Exception/PhptExternalFileCannotBeLoadedException.phpo  EN„io  .Ğˆ¤      A   phpunit/Runner/Phpt/Exception/UnsupportedPhptSectionException.phpK  EN„iK  #BÇ£¤         phpunit/Runner/Phpt/Parser.php<  EN„i<  ‘ï6¤          phpunit/Runner/Phpt/Renderer.php-  EN„i-  ‹”v×¤          phpunit/Runner/Phpt/TestCase.phpN  EN„iN  Qí#¤      &   phpunit/Runner/Phpt/templates/phpt.tplÓ  EN„iÓ  >Üßu¤      1   phpunit/Runner/ResultCache/DefaultResultCache.phpø  EN„iø  ¸Ñ˜¤      .   phpunit/Runner/ResultCache/NullResultCache.php«  EN„i«  ÿM¤      *   phpunit/Runner/ResultCache/ResultCache.phpó  EN„ió  M¸˜¤      1   phpunit/Runner/ResultCache/ResultCacheHandler.php$  EN„i$  ®yù…¤      ,   phpunit/Runner/ResultCache/ResultCacheId.php¢  EN„i¢  ,ã¶¤      4   phpunit/Runner/ResultCache/Subscriber/Subscriber.phpc  EN„ic  ·Ë¤      G   phpunit/Runner/ResultCache/Subscriber/TestConsideredRiskySubscriber.phpT  EN„iT  ­_€¤      ?   phpunit/Runner/ResultCache/Subscriber/TestErroredSubscriber.php$  EN„i$  “İ˜Î¤      >   phpunit/Runner/ResultCache/Subscriber/TestFailedSubscriber.php  EN„i  Üú…†¤      @   phpunit/Runner/ResultCache/Subscriber/TestFinishedSubscriber.phpÉ  EN„iÉ  íÎg¤      H   phpunit/Runner/ResultCache/Subscriber/TestMarkedIncompleteSubscriber.phpZ  EN„iZ  ŸŞ¦v¤      @   phpunit/Runner/ResultCache/Subscriber/TestPreparedSubscriber.php*  EN„i*  yÑ¤      ?   phpunit/Runner/ResultCache/Subscriber/TestSkippedSubscriber.phpÃ  EN„iÃ  à.“Í¤      E   phpunit/Runner/ResultCache/Subscriber/TestSuiteFinishedSubscriber.php8  EN„i8  Ê×/ı¤      D   phpunit/Runner/ResultCache/Subscriber/TestSuiteStartedSubscriber.php2  EN„i2  ª/ªÂ¤      "   phpunit/Runner/ShutdownHandler.phpc  EN„ic  ©Çeß¤      '   phpunit/Runner/TestResult/Collector.php¿L  EN„i¿L  \L¤      $   phpunit/Runner/TestResult/Facade.phpê  EN„iê  XmB¤      #   phpunit/Runner/TestResult/Issue.phpà  EN„ià  „9×=¤      )   phpunit/Runner/TestResult/PassedTests.phpÏ  EN„iÏ  Ì8¤      N   phpunit/Runner/TestResult/Subscriber/AfterTestClassMethodErroredSubscriber.php˜  EN„i˜  8)xº¤      M   phpunit/Runner/TestResult/Subscriber/AfterTestClassMethodFailedSubscriber.php’  EN„i’  -ÀQR¤      O   phpunit/Runner/TestResult/Subscriber/BeforeTestClassMethodErroredSubscriber.php¢  EN„i¢  U½E2¤      N   phpunit/Runner/TestResult/Subscriber/BeforeTestClassMethodFailedSubscriber.phpœ  EN„iœ  [Æ=„¤      F   phpunit/Runner/TestResult/Subscriber/ChildProcessErroredSubscriber.phpV  EN„iV  -4g­¤      C   phpunit/Runner/TestResult/Subscriber/ExecutionStartedSubscriber.php˜  EN„i˜  XUÕ¤      3   phpunit/Runner/TestResult/Subscriber/Subscriber.php`  EN„i`  T¹1{¤      F   phpunit/Runner/TestResult/Subscriber/TestConsideredRiskySubscriber.php\  EN„i\  -ï½4¤      >   phpunit/Runner/TestResult/Subscriber/TestErroredSubscriber.php,  EN„i,  ÿ;¦Ô¤      =   phpunit/Runner/TestResult/Subscriber/TestFailedSubscriber.php&  EN„i&  ×0Ë¤      ?   phpunit/Runner/TestResult/Subscriber/TestFinishedSubscriber.php2  EN„i2  Ş»İƒ¤      G   phpunit/Runner/TestResult/Subscriber/TestMarkedIncompleteSubscriber.phpb  EN„ib  C•¬¿¤      ?   phpunit/Runner/TestResult/Subscriber/TestPreparedSubscriber.php,  EN„i,  <Ú¸G¤      Q   phpunit/Runner/TestResult/Subscriber/TestRunnerTriggeredDeprecationSubscriber.php’  EN„i’  šÅÍ<¤      L   phpunit/Runner/TestResult/Subscriber/TestRunnerTriggeredNoticeSubscriber.phpt  EN„it  ‚½U"¤      M   phpunit/Runner/TestResult/Subscriber/TestRunnerTriggeredWarningSubscriber.phpz  EN„iz  Ú+d¤      >   phpunit/Runner/TestResult/Subscriber/TestSkippedSubscriber.php,  EN„i,  Û$ñ¤      D   phpunit/Runner/TestResult/Subscriber/TestSuiteFinishedSubscriber.phpF  EN„iF  2Šá¼¤      C   phpunit/Runner/TestResult/Subscriber/TestSuiteSkippedSubscriber.php@  EN„i@  OU&¤      C   phpunit/Runner/TestResult/Subscriber/TestSuiteStartedSubscriber.php@  EN„i@  ƒˆi¤      K   phpunit/Runner/TestResult/Subscriber/TestTriggeredDeprecationSubscriber.phpz  EN„iz  °|?¤      E   phpunit/Runner/TestResult/Subscriber/TestTriggeredErrorSubscriber.phpV  EN„iV  ¶‘ï“¤      F   phpunit/Runner/TestResult/Subscriber/TestTriggeredNoticeSubscriber.php\  EN„i\  ¡AU‹¤      N   phpunit/Runner/TestResult/Subscriber/TestTriggeredPhpDeprecationSubscriber.phpŒ  EN„iŒ  B.XŞ¤      I   phpunit/Runner/TestResult/Subscriber/TestTriggeredPhpNoticeSubscriber.phpn  EN„in  E…@¤      J   phpunit/Runner/TestResult/Subscriber/TestTriggeredPhpWarningSubscriber.phpt  EN„it  ’ÈSÌ¤      R   phpunit/Runner/TestResult/Subscriber/TestTriggeredPhpunitDeprecationSubscriber.php¤  EN„i¤  ù‘à/¤      L   phpunit/Runner/TestResult/Subscriber/TestTriggeredPhpunitErrorSubscriber.php€  EN„i€  Ò)i2¤      M   phpunit/Runner/TestResult/Subscriber/TestTriggeredPhpunitNoticeSubscriber.php†  EN„i†  lÆä¤      N   phpunit/Runner/TestResult/Subscriber/TestTriggeredPhpunitWarningSubscriber.phpŒ  EN„iŒ  ,,ˆŒ¤      G   phpunit/Runner/TestResult/Subscriber/TestTriggeredWarningSubscriber.phpb  EN„ib  Í8Ux¤      (   phpunit/Runner/TestResult/TestResult.php‘J  EN„i‘J  ğ¸ôT¤      "   phpunit/Runner/TestSuiteLoader.php†  EN„i†  Bï•¤      "   phpunit/Runner/TestSuiteSorter.phpD#  EN„iD#  XT$H¤         phpunit/Runner/Version.php.  EN„i.  ¬/ğw¤         phpunit/TextUI/Application.phpd  EN„id  I·×É¤      "   phpunit/TextUI/Command/Command.phpH  EN„iH  "Fò¤      9   phpunit/TextUI/Command/Commands/AtLeastVersionCommand.php5  EN„i5  zĞ´¤      @   phpunit/TextUI/Command/Commands/CheckPhpConfigurationCommand.phpF  EN„iF  ”£¤      @   phpunit/TextUI/Command/Commands/GenerateConfigurationCommand.php#  EN„i#  ã2® ¤      5   phpunit/TextUI/Command/Commands/ListGroupsCommand.php3  EN„i3  ^Ø¤      8   phpunit/TextUI/Command/Commands/ListTestFilesCommand.php×  EN„i×  eêj%¤      9   phpunit/TextUI/Command/Commands/ListTestSuitesCommand.php¦
-  EN„i¦
-  *¶h¸¤      :   phpunit/TextUI/Command/Commands/ListTestsAsTextCommand.php$  EN„i$  ŒeÏš¤      9   phpunit/TextUI/Command/Commands/ListTestsAsXmlCommand.phpg  EN„ig  à+¤      ?   phpunit/TextUI/Command/Commands/MigrateConfigurationCommand.php  EN„i  ¦—£#¤      3   phpunit/TextUI/Command/Commands/ShowHelpCommand.phpš  EN„iš  ÿ§x¤      6   phpunit/TextUI/Command/Commands/ShowVersionCommand.phpÇ  EN„iÇ  !n˜¤      7   phpunit/TextUI/Command/Commands/VersionCheckCommand.php]	  EN„i]	  `}¤      @   phpunit/TextUI/Command/Commands/WarmCodeCoverageCacheCommand.phpÅ  EN„iÅ  Ái¤      !   phpunit/TextUI/Command/Result.phpÍ  EN„iÍ  P,0Š¤      0   phpunit/TextUI/Configuration/BootstrapLoader.phpr	  EN„ir	  b,š£¤      (   phpunit/TextUI/Configuration/Builder.phpä  EN„iä  ß• 5¤      ,   phpunit/TextUI/Configuration/Cli/Builder.phpñˆ  EN„iñˆ  Tó¤      2   phpunit/TextUI/Configuration/Cli/Configuration.phpÜ
- EN„iÜ
- ªô‡¤      .   phpunit/TextUI/Configuration/Cli/Exception.php[  EN„i[  ¨æÎ'¤      ?   phpunit/TextUI/Configuration/Cli/XmlConfigurationFileFinder.phpÌ  EN„iÌ  Dı±ü¤      ;   phpunit/TextUI/Configuration/CodeCoverageFilterRegistry.php¾  EN„i¾  º™ò*¤      .   phpunit/TextUI/Configuration/Configuration.php,·  EN„i,·  YÓO¤      O   phpunit/TextUI/Configuration/Exception/BootstrapScriptDoesNotExistException.php6  EN„i6  Ö4Y¤      C   phpunit/TextUI/Configuration/Exception/BootstrapScriptException.php€  EN„i€  {™’Ö¤      D   phpunit/TextUI/Configuration/Exception/CannotFindSchemaException.php’  EN„i’  ¸«¢O¤      S   phpunit/TextUI/Configuration/Exception/CodeCoverageReportNotConfiguredException.php  EN„i  ©ÙVF¤      N   phpunit/TextUI/Configuration/Exception/ConfigurationCannotBeBuiltException.php‹  EN„i‹  6¯Õ¤      4   phpunit/TextUI/Configuration/Exception/Exception.php3  EN„i3  ¿l´p¤      G   phpunit/TextUI/Configuration/Exception/FilterNotConfiguredException.php„  EN„i„  ´]Ü9¤      H   phpunit/TextUI/Configuration/Exception/LoggingNotConfiguredException.php…  EN„i…  N†¤      >   phpunit/TextUI/Configuration/Exception/NoBaselineException.php{  EN„i{  %Iû¤      ?   phpunit/TextUI/Configuration/Exception/NoBootstrapException.php|  EN„i|  eIÂæ¤      D   phpunit/TextUI/Configuration/Exception/NoCacheDirectoryException.php  EN„i  ÍAŠ¤      G   phpunit/TextUI/Configuration/Exception/NoConfigurationFileException.php„  EN„i„  ¡Ş@À¤      L   phpunit/TextUI/Configuration/Exception/NoCoverageCacheDirectoryException.php‰  EN„i‰  æGt½¤      C   phpunit/TextUI/Configuration/Exception/NoCustomCssFileException.php€  EN„i€  ¾İòÎ¤      F   phpunit/TextUI/Configuration/Exception/NoDefaultTestSuiteException.phpƒ  EN„iƒ  àĞÃ¿¤      L   phpunit/TextUI/Configuration/Exception/NoPharExtensionDirectoryException.php‰  EN„i‰  ™jÃ¤      \   phpunit/TextUI/Configuration/Exception/SpecificDeprecationToStopOnNotConfiguredException.php™  EN„i™  ì+Ì‡¤      '   phpunit/TextUI/Configuration/Merger.phpá¤  EN„iá¤  GfÖü¤      +   phpunit/TextUI/Configuration/PhpHandler.phpÉ  EN„iÉ  à‘H¤      )   phpunit/TextUI/Configuration/Registry.phph  EN„ih  ~Øó«¤      -   phpunit/TextUI/Configuration/SourceFilter.php¶  EN„i¶  jÖb¤      -   phpunit/TextUI/Configuration/SourceMapper.php„  EN„i„  >sÊë¤      1   phpunit/TextUI/Configuration/TestSuiteBuilder.phpò  EN„iò  O;ei¤      /   phpunit/TextUI/Configuration/Value/Constant.php-  EN„i-  9âµ¤      9   phpunit/TextUI/Configuration/Value/ConstantCollection.php  EN„i  š8ûÌ¤      A   phpunit/TextUI/Configuration/Value/ConstantCollectionIterator.phpn  EN„in  Ì%¤      0   phpunit/TextUI/Configuration/Value/Directory.php‰  EN„i‰  nÏØ%¤      :   phpunit/TextUI/Configuration/Value/DirectoryCollection.phpı  EN„iı  Ûv|¤      B   phpunit/TextUI/Configuration/Value/DirectoryCollectionIterator.php  EN„i  ßö’¤      9   phpunit/TextUI/Configuration/Value/ExtensionBootstrap.php  EN„i  „¤      C   phpunit/TextUI/Configuration/Value/ExtensionBootstrapCollection.php«  EN„i«  ŒI¤      K   phpunit/TextUI/Configuration/Value/ExtensionBootstrapCollectionIterator.phpÜ  EN„iÜ  3¢FÃ¤      +   phpunit/TextUI/Configuration/Value/File.php  EN„i  EÁğ¤      5   phpunit/TextUI/Configuration/Value/FileCollection.phpŸ  EN„iŸ  %-Ã¤      =   phpunit/TextUI/Configuration/Value/FileCollectionIterator.phpB  EN„iB  šQ¤      6   phpunit/TextUI/Configuration/Value/FilterDirectory.phpY  EN„iY  'Ùo‘¤      @   phpunit/TextUI/Configuration/Value/FilterDirectoryCollection.php3  EN„i3  ÍJ±¤      H   phpunit/TextUI/Configuration/Value/FilterDirectoryCollectionIterator.php  EN„i  éªù¤      ,   phpunit/TextUI/Configuration/Value/Group.php…  EN„i…  šVÛ_¤      6   phpunit/TextUI/Configuration/Value/GroupCollection.php"  EN„i"  5ÓnÛ¤      >   phpunit/TextUI/Configuration/Value/GroupCollectionIterator.phpM  EN„iM  ­ìi¤      1   phpunit/TextUI/Configuration/Value/IniSetting.php   EN„i   ­E¨Õ¤      ;   phpunit/TextUI/Configuration/Value/IniSettingCollection.php°  EN„i°  ˆİn¤      C   phpunit/TextUI/Configuration/Value/IniSettingCollectionIterator.php„  EN„i„  ôÒ8¤      *   phpunit/TextUI/Configuration/Value/Php.phpî  EN„iî  ö¦«¤      -   phpunit/TextUI/Configuration/Value/Source.php=  EN„i=  bIçå¤      4   phpunit/TextUI/Configuration/Value/TestDirectory.php‰  EN„i‰  ©TÏ¤      >   phpunit/TextUI/Configuration/Value/TestDirectoryCollection.php  EN„i  :Àë…¤      F   phpunit/TextUI/Configuration/Value/TestDirectoryCollectionIterator.php“  EN„i“  µÄß)¤      /   phpunit/TextUI/Configuration/Value/TestFile.phpL  EN„iL  ø—ìú¤      9   phpunit/TextUI/Configuration/Value/TestFileCollection.php¿  EN„i¿  Æo¤      A   phpunit/TextUI/Configuration/Value/TestFileCollectionIterator.phpV  EN„iV  ’×D¤      0   phpunit/TextUI/Configuration/Value/TestSuite.phpŠ  EN„iŠ  ùÇ»¤      :   phpunit/TextUI/Configuration/Value/TestSuiteCollection.phpô  EN„iô  ‘dÎ‹¤      B   phpunit/TextUI/Configuration/Value/TestSuiteCollectionIterator.phpy  EN„iy  ¶·!&¤      /   phpunit/TextUI/Configuration/Value/Variable.php«  EN„i«  'z§3¤      9   phpunit/TextUI/Configuration/Value/VariableCollection.php  EN„i  P]y¤      A   phpunit/TextUI/Configuration/Value/VariableCollectionIterator.phpn  EN„in  ;iK¤      >   phpunit/TextUI/Configuration/Xml/CodeCoverage/CodeCoverage.php€  EN„i€   &¤      ?   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/Clover.php&  EN„i&  á+­¤      B   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/Cobertura.php)  EN„i)  ±‹ZÅ¤      ?   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/Crap4j.phpË  EN„iË  âÌñ¤      =   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/Html.php  EN„i  Ô{Oè¤      C   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/OpenClover.php*  EN„i*  Õ	´/¤      <   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/Php.php#  EN„i#  Hô3¤      =   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/Text.phpÎ  EN„iÎ  VÉ^ƒ¤      <   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/Xml.php÷  EN„i÷  xf„¤      2   phpunit/TextUI/Configuration/Xml/Configuration.php2  EN„i2  ’”¤      9   phpunit/TextUI/Configuration/Xml/DefaultConfiguration.phpU  EN„iU  JŸ®¨¤      .   phpunit/TextUI/Configuration/Xml/Exception.php_  EN„i_  +øg3¤      .   phpunit/TextUI/Configuration/Xml/Generator.phpÏ  EN„iÏ  bâ€¤      +   phpunit/TextUI/Configuration/Xml/Groups.php½  EN„i½  mu’¤      @   phpunit/TextUI/Configuration/Xml/LoadedFromFileConfiguration.phpƒ  EN„iƒ  aAÇr¤      +   phpunit/TextUI/Configuration/Xml/Loader.phpø™  EN„iø™  ÖİA%¤      2   phpunit/TextUI/Configuration/Xml/Logging/Junit.php  EN„i  OÙ¤      4   phpunit/TextUI/Configuration/Xml/Logging/Logging.php  EN„i  Y8Œ•¤      0   phpunit/TextUI/Configuration/Xml/Logging/Otr.php  EN„i  ±4.€¤      5   phpunit/TextUI/Configuration/Xml/Logging/TeamCity.php  EN„i  &Sk¤      9   phpunit/TextUI/Configuration/Xml/Logging/TestDox/Html.php   EN„i   *IòŒ¤      9   phpunit/TextUI/Configuration/Xml/Logging/TestDox/Text.php   EN„i   ¬l¦¤      ?   phpunit/TextUI/Configuration/Xml/Migration/MigrationBuilder.phpƒ  EN„iƒ  ıã9¤      A   phpunit/TextUI/Configuration/Xml/Migration/MigrationException.phpv  EN„iv  Û[–r¤      I   phpunit/TextUI/Configuration/Xml/Migration/Migrations/ConvertLogTypes.php  EN„i  < ëÙ¤      P   phpunit/TextUI/Configuration/Xml/Migration/Migrations/CoverageCloverToReport.phpË  EN„iË  ³b5z¤      P   phpunit/TextUI/Configuration/Xml/Migration/Migrations/CoverageCrap4jToReport.php  EN„i  ˆæ“¤      N   phpunit/TextUI/Configuration/Xml/Migration/Migrations/CoverageHtmlToReport.php  EN„i  l;^©¤      M   phpunit/TextUI/Configuration/Xml/Migration/Migrations/CoveragePhpToReport.php¹  EN„i¹  ™c'Ç¤      N   phpunit/TextUI/Configuration/Xml/Migration/Migrations/CoverageTextToReport.php  EN„i  í*LĞ¤      M   phpunit/TextUI/Configuration/Xml/Migration/Migrations/CoverageXmlToReport.php¾  EN„i¾  gºŠú¤      Z   phpunit/TextUI/Configuration/Xml/Migration/Migrations/IntroduceCacheDirectoryAttribute.phpĞ  EN„iĞ  i¬"¤      R   phpunit/TextUI/Configuration/Xml/Migration/Migrations/IntroduceCoverageElement.phpU  EN„iU  Fc¤      N   phpunit/TextUI/Configuration/Xml/Migration/Migrations/LogToReportMigration.php¬	  EN„i¬	  CÜkí¤      C   phpunit/TextUI/Configuration/Xml/Migration/Migrations/Migration.php_  EN„i_  *ÉŸ,¤      e   phpunit/TextUI/Configuration/Xml/Migration/Migrations/MoveAttributesFromFilterWhitelistToCoverage.php(  EN„i(  ‘,«¤      Z   phpunit/TextUI/Configuration/Xml/Migration/Migrations/MoveAttributesFromRootToCoverage.phpù  EN„iù  ["ı¤      Y   phpunit/TextUI/Configuration/Xml/Migration/Migrations/MoveCoverageDirectoriesToSource.php  EN„i  *Vº¹¤      Y   phpunit/TextUI/Configuration/Xml/Migration/Migrations/MoveWhitelistExcludesToCoverage.php6	  EN„i6	  !„À¤      Y   phpunit/TextUI/Configuration/Xml/Migration/Migrations/MoveWhitelistIncludesToCoverage.phpi  EN„ii  )ìâ£¤      s   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveBeStrictAboutResourceUsageDuringSmallTestsAttribute.php  EN„i  «ëÜ¤      h   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveBeStrictAboutTodoAnnotatedTestsAttribute.phpá  EN„iá  P’ƒÅ¤      X   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveCacheResultFileAttribute.php±  EN„i±  	1§¤      T   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveCacheTokensAttribute.php¥  EN„i¥  1ªú¤      `   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveConversionToExceptionsAttributes.php€  EN„i€  ¨:o¤      f   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveCoverageElementCacheDirectoryAttribute.phpı  EN„iı  ¤ï¯ª¤      m   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveCoverageElementProcessUncoveredFilesAttribute.php  EN„i  ì€>¤      K   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveEmptyFilter.phpî  EN„iî  åRµƒ¤      I   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveListeners.php›  EN„i›  Í'6ï¤      H   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveLogTypes.phpİ  EN„iİ  ‡tRO¤      O   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveLoggingElements.php(  EN„i(  '—¤      V   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveNoInteractionAttribute.php«  EN„i«  n'°.¤      Q   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemovePrinterAttributes.php  EN„i  ]ï2/¤      x   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveRegisterMockObjectsFromTestArgumentsRecursivelyAttribute.php  EN„i  ¿ÕW¤      T   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveTestDoxGroupsElement.phpª  EN„iª  ô×´š¤      Y   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveTestSuiteLoaderAttributes.php;  EN„i;  )ó†¤      P   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveVerboseAttribute.php™  EN„i™  Õª”±¤      _   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RenameBackupStaticAttributesAttribute.php˜  EN„i˜  "Zù¤      f   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RenameBeStrictAboutCoversAnnotationAttribute.phpÂ  EN„iÂ  uÀË¤      ^   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RenameForceCoversAnnotationAttribute.php–  EN„i–  ƒ–¢U¤      k   phpunit/TextUI/Configuration/Xml/Migration/Migrations/ReplaceRestrictDeprecationsWithIgnoreDeprecations.php‰  EN„i‰  t¯³7¤      N   phpunit/TextUI/Configuration/Xml/Migration/Migrations/UpdateSchemaLocation.phpÙ  EN„iÙ  .P¦Ó¤      7   phpunit/TextUI/Configuration/Xml/Migration/Migrator.phpÑ  EN„iÑ  Õ+§¼¤      ?   phpunit/TextUI/Configuration/Xml/Migration/SnapshotNodeList.php>  EN„i>  ı+	¤      ,   phpunit/TextUI/Configuration/Xml/PHPUnit.php›A  EN„i›A  \À0$¤      O   phpunit/TextUI/Configuration/Xml/SchemaDetector/FailedSchemaDetectionResult.php}  EN„i}  |¥€¤      I   phpunit/TextUI/Configuration/Xml/SchemaDetector/SchemaDetectionResult.php  EN„i  (ù¯¤      B   phpunit/TextUI/Configuration/Xml/SchemaDetector/SchemaDetector.phpo  EN„io  Ğc€ª¤      S   phpunit/TextUI/Configuration/Xml/SchemaDetector/SuccessfulSchemaDetectionResult.phpF  EN„iF  kÚÎw¤      1   phpunit/TextUI/Configuration/Xml/SchemaFinder.phpy  EN„iy  )}š3¤      4   phpunit/TextUI/Configuration/Xml/TestSuiteMapper.php<  EN„i<  `gı£¤      ?   phpunit/TextUI/Configuration/Xml/Validator/ValidationResult.phpo  EN„io  f²1¤      8   phpunit/TextUI/Configuration/Xml/Validator/Validator.phpù  EN„iù  I‹ö`¤      6   phpunit/TextUI/Exception/CannotOpenSocketException.php  EN„i  zçá¤      &   phpunit/TextUI/Exception/Exception.php$  EN„i$  æ˜¤      3   phpunit/TextUI/Exception/InvalidSocketException.php  EN„i  ÊI
-¤      -   phpunit/TextUI/Exception/RuntimeException.phpG  EN„iG  ¾n	V¤      ;   phpunit/TextUI/Exception/TestDirectoryNotFoundException.php  EN„i  HË²P¤      6   phpunit/TextUI/Exception/TestFileNotFoundException.phpş  EN„iş  =ƒ|¤         phpunit/TextUI/Help.phpD  EN„iD  ´ÿÎå¤      A   phpunit/TextUI/Output/Default/ProgressPrinter/ProgressPrinter.php~4  EN„i~4  N¹Åv¤      c   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/BeforeTestClassMethodErroredSubscriber.phpº  EN„iº  PÏD×¤      Z   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/ChildProcessErroredSubscriber.phpt  EN„it  ¸ O=¤      G   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/Subscriber.php¦  EN„i¦  %¢¹ß¤      Z   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestConsideredRiskySubscriber.phpt  EN„it  Üb¤      R   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestErroredSubscriber.phpJ  EN„iJ  xmÇ¢¤      Q   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestFailedSubscriber.php>  EN„i>  Y'¹‡¤      S   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestFinishedSubscriber.phpJ  EN„iJ  zJ–é¤      [   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestMarkedIncompleteSubscriber.phpz  EN„iz  Âjø\¤      S   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestPreparedSubscriber.phpJ  EN„iJ  ùû¤      a   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestRunnerExecutionStartedSubscriber.php˜  EN„i˜  ê¥j ¤      R   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestSkippedSubscriber.phpD  EN„iD  …è¨š¤      W   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestSuiteSkippedSubscriber.phpt  EN„it  ‘¨—e¤      _   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredDeprecationSubscriber.php˜  EN„i˜  d¿Vé¤      Y   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredErrorSubscriber.phpt  EN„it  y´‘Ñ¤      Z   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredNoticeSubscriber.phpz  EN„iz  ­[¾Ó¤      b   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredPhpDeprecationSubscriber.phpª  EN„iª  A”¤      ]   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredPhpNoticeSubscriber.phpŒ  EN„iŒ  ¸•‚è¤      ^   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredPhpWarningSubscriber.php’  EN„i’  ¦Ú+¤      f   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredPhpunitDeprecationSubscriber.php¼  EN„i¼  ?ï>f¤      a   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredPhpunitNoticeSubscriber.php  EN„i  ØMä¤      b   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredPhpunitWarningSubscriber.phpª  EN„iª  ëuı¤      [   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredWarningSubscriber.php€  EN„i€  ëİ´¤      /   phpunit/TextUI/Output/Default/ResultPrinter.phpxR  EN„ixR  &7Õv¤      9   phpunit/TextUI/Output/Default/UnexpectedOutputPrinter.phpØ  EN„iØ  qp‘¤          phpunit/TextUI/Output/Facade.php7#  EN„i7#  {p	r¤      0   phpunit/TextUI/Output/Printer/DefaultPrinter.phpˆ  EN„iˆ  ¯"$¤      -   phpunit/TextUI/Output/Printer/NullPrinter.php§  EN„i§  &W„ş¤      )   phpunit/TextUI/Output/Printer/Printer.php\  EN„i\  gD“ß¤      (   phpunit/TextUI/Output/SummaryPrinter.phpÍ  EN„iÍ  ”‰e¿¤      /   phpunit/TextUI/Output/TestDox/ResultPrinter.phpØ1  EN„iØ1  ‚ÁqE¤      *   phpunit/TextUI/ShellExitCodeCalculator.phpF  EN„iF  öë©å¤         phpunit/TextUI/TestRunner.php×  EN„i×  m/$Ø¤      +   phpunit/TextUI/TestSuiteFilterProcessor.phpF
-  EN„iF
-  œî5¶¤         phpunit/Util/Color.phpš  EN„iš  G–£¤      $   phpunit/Util/Exception/Exception.php"  EN„i"  ğ‘Ò¤      4   phpunit/Util/Exception/InvalidDirectoryException.php  EN„i  ¦ç3¤      /   phpunit/Util/Exception/InvalidJsonException.php\  EN„i\  ÷nt¤      :   phpunit/Util/Exception/InvalidVersionOperatorException.php  EN„i  p2ïÙ¤      .   phpunit/Util/Exception/PhpProcessException.phpm  EN„im  Z|¤      '   phpunit/Util/Exception/XmlException.phpf  EN„if  Î;´Q¤         phpunit/Util/ExcludeList.php¿  EN„i¿  •ªCf¤         phpunit/Util/Exporter.phpV  EN„iV  ÔMRç¤         phpunit/Util/Filesystem.phpR  EN„iR  ñ]â_¤         phpunit/Util/Filter.phpÕ  EN„iÕ  xâÔ¤         phpunit/Util/GlobalState.php#  EN„i#  ‰Â?¤          phpunit/Util/Http/Downloader.phpt  EN„it  .Ø=Ã¤      #   phpunit/Util/Http/PhpDownloader.php  EN„i  KÃ>Æ¤         phpunit/Util/Json.php  EN„i  â¢o¤      %   phpunit/Util/PHP/DefaultJobRunner.phpe  EN„ie  ¢ Pí¤         phpunit/Util/PHP/Job.php  EN„i  QPğ¤         phpunit/Util/PHP/JobRunner.phpe  EN„ie  É<pT¤      &   phpunit/Util/PHP/JobRunnerRegistry.phpc  EN„ic  ğoÎò¤         phpunit/Util/PHP/Result.php~  EN„i~  šsœB¤         phpunit/Util/Reflection.phpu  EN„iu  .Ë¤         phpunit/Util/Test.phpˆ  EN„iˆ  šnàÛ¤      (   phpunit/Util/ThrowableToStringMapper.php´  EN„i´  Øø½Í¤      *   phpunit/Util/VersionComparisonOperator.php  EN„i  Şâ«¤         phpunit/Util/Xml/Loader.php+	  EN„i+	  4?CR¤         phpunit/Util/Xml/Xml.php3  EN„i3  ³Àİ¤         sbom.xml#  EN„i#  RÅ¤         schema/10.0.xsd=  EN„i=  |H¤         schema/10.1.xsd«B  EN„i«B  Ü­r—¤         schema/10.2.xsdQE  EN„iQE  ¸çÿn¤         schema/10.3.xsdF  EN„iF  ›¶3&¤         schema/10.4.xsdGF  EN„iGF  ?”ñÁ¤         schema/10.5.xsdÛG  EN„iÛG  ÔaÈI¤         schema/11.0.xsdTF  EN„iTF  ÷É?z¤         schema/11.1.xsd®H  EN„i®H  !Êgè¤         schema/11.2.xsdH  EN„iH  ëÍæ¤         schema/11.3.xsdyI  EN„iyI  “ô¹¤         schema/11.4.xsd#I  EN„i#I  î0$”¤         schema/11.5.xsdK  EN„iK  sÄH±¤         schema/12.0.xsdzI  EN„izI  fªGj¤         schema/12.1.xsdÛJ  EN„iÛJ  Šºb¤         schema/12.2.xsdÒL  EN„iÒL  s$˜¢¤         schema/12.3.xsdM  EN„iM  Ê—>º¤         schema/12.4.xsdM  EN„iM  Û¢ığ¤         schema/8.5.xsdÓB  EN„iÓB  2A[­¤         schema/9.0.xsd4B  EN„i4B  •¨7w¤         schema/9.1.xsdÕB  EN„iÕB  ßq'8¤         schema/9.2.xsdÜB  EN„iÜB  c·Á-¤         schema/9.3.xsd¼E  EN„i¼E  ¿ùq¤         schema/9.4.xsd
-F  EN„i
-F  DOFI¤         schema/9.5.xsdDF  EN„iDF  ûùs|¤         sebastian-cli-parser/LICENSEû  EN„iû  z60¤         sebastian-cli-parser/Parser.phpÚ  EN„iÚ  EEü–¤      <   sebastian-cli-parser/exceptions/AmbiguousOptionException.phpİ  EN„iİ  +Mó…¤      -   sebastian-cli-parser/exceptions/Exception.phpy  EN„iy  >€±¤      G   sebastian-cli-parser/exceptions/OptionDoesNotAllowArgumentException.phpc  EN„ic  ŠRjY¤      J   sebastian-cli-parser/exceptions/RequiredOptionArgumentMissingException.phpl  EN„il  zQ¢¤      :   sebastian-cli-parser/exceptions/UnknownOptionException.phpv  EN„iv  ëÛÿä¤      (   sebastian-comparator/ArrayComparator.phpi  EN„ii  cT±_¤      *   sebastian-comparator/ClosureComparator.phpI  EN„iI  ~6 ¤      #   sebastian-comparator/Comparator.phpĞ  EN„iĞ  'bŸ¤      *   sebastian-comparator/ComparisonFailure.php“  EN„i“  ›‹ÕD¤      *   sebastian-comparator/DOMNodeComparator.php
+  ©t…id
+  kîÍ¤      :   phpunit/Framework/Constraint/Equality/IsEqualWithDelta.php¸	  ©t…i¸	  ;y6ê¤      4   phpunit/Framework/Constraint/Exception/Exception.phpé  ©t…ié  X}íÿ¤      8   phpunit/Framework/Constraint/Exception/ExceptionCode.php0  ©t…i0  ~Ñ¤      G   phpunit/Framework/Constraint/Exception/ExceptionMessageIsOrContains.php$  ©t…i$  x›¤ñ¤      S   phpunit/Framework/Constraint/Exception/ExceptionMessageMatchesRegularExpression.php·  ©t…i·  7Ë«F¤      ;   phpunit/Framework/Constraint/Filesystem/DirectoryExists.phpù  ©t…iù  -pˆ¤      6   phpunit/Framework/Constraint/Filesystem/FileExists.phpô  ©t…iô  ÿ+ğ÷¤      6   phpunit/Framework/Constraint/Filesystem/IsReadable.phpô  ©t…iô  “A†¤      6   phpunit/Framework/Constraint/Filesystem/IsWritable.phpô  ©t…iô  öÆùB¤      +   phpunit/Framework/Constraint/IsAnything.phpA  ©t…iA  kÒš6¤      ,   phpunit/Framework/Constraint/IsIdentical.phpæ  ©t…iæ  rÚª¤      ,   phpunit/Framework/Constraint/JsonMatches.php
+  ©t…i
+  9~¬8¤      .   phpunit/Framework/Constraint/Math/IsFinite.phpz  ©t…iz  ÔŠø¤      0   phpunit/Framework/Constraint/Math/IsInfinite.php‚  ©t…i‚  íC²¤      +   phpunit/Framework/Constraint/Math/IsNan.phpn  ©t…in  Çx¤      4   phpunit/Framework/Constraint/Object/ObjectEquals.phpO  ©t…iO  írL¤      9   phpunit/Framework/Constraint/Object/ObjectHasProperty.phpu  ©t…iu  ÷e¥¤      8   phpunit/Framework/Constraint/Operator/BinaryOperator.php  ©t…i  X‹¤      4   phpunit/Framework/Constraint/Operator/LogicalAnd.phpY  ©t…iY  ÿ‡ı¤      4   phpunit/Framework/Constraint/Operator/LogicalNot.phpü  ©t…iü  âèRf¤      3   phpunit/Framework/Constraint/Operator/LogicalOr.php1  ©t…i1  ¾ä¤      4   phpunit/Framework/Constraint/Operator/LogicalXor.php  ©t…i   x{F¤      2   phpunit/Framework/Constraint/Operator/Operator.php'  ©t…i'  áJÂ%¤      7   phpunit/Framework/Constraint/Operator/UnaryOperator.php  ©t…i  5D¤      .   phpunit/Framework/Constraint/String/IsJson.phpò	  ©t…iò	  î–±¤      9   phpunit/Framework/Constraint/String/RegularExpression.php^  ©t…i^  ŠË¬>¤      6   phpunit/Framework/Constraint/String/StringContains.php?  ©t…i?  š¶©¤¤      6   phpunit/Framework/Constraint/String/StringEndsWith.phpğ  ©t…iğ  @%õ-¤      M   phpunit/Framework/Constraint/String/StringEqualsStringIgnoringLineEndings.php7  ©t…i7  […J¤      F   phpunit/Framework/Constraint/String/StringMatchesFormatDescription.php~  ©t…i~  ğÓ¤      8   phpunit/Framework/Constraint/String/StringStartsWith.phpø  ©t…iø  ™.ÿ¤      @   phpunit/Framework/Constraint/Traversable/TraversableContains.phpK  ©t…iK  #Ç¦¤      E   phpunit/Framework/Constraint/Traversable/TraversableContainsEqual.php!  ©t…i!  ×b/¤      I   phpunit/Framework/Constraint/Traversable/TraversableContainsIdentical.phpò  ©t…iò  íµÍ#¤      D   phpunit/Framework/Constraint/Traversable/TraversableContainsOnly.phpH	  ©t…iH	  DsÖå¤      2   phpunit/Framework/Constraint/Type/IsInstanceOf.phpÊ  ©t…iÊ  9;>¤      ,   phpunit/Framework/Constraint/Type/IsNull.php\  ©t…i\  a#‡ ¤      ,   phpunit/Framework/Constraint/Type/IsType.phpâ	  ©t…iâ	  ÃÈÚ°¤      +   phpunit/Framework/DataProviderTestSuite.php@	  ©t…i@	  E­‹ø¤      4   phpunit/Framework/Exception/AssertionFailedError.phpş  ©t…iş  Ï5/¤      4   phpunit/Framework/Exception/EmptyStringException.phpC  ©t…iC  ‹ÖšÍ¤      <   phpunit/Framework/Exception/ErrorLogNotWritableException.php¹  ©t…i¹  _}¤      )   phpunit/Framework/Exception/Exception.php›
+  ©t…i›
+  ²,Õú¤      :   phpunit/Framework/Exception/ExpectationFailedException.phpÎ  ©t…iÎ  Ş]û»¤      >   phpunit/Framework/Exception/GeneratorNotSupportedException.php:  ©t…i:  ™ j{¤      9   phpunit/Framework/Exception/Incomplete/IncompleteTest.php,  ©t…i,  _Kª¤      >   phpunit/Framework/Exception/Incomplete/IncompleteTestError.phpk  ©t…ik  ÷›øè¤      8   phpunit/Framework/Exception/InvalidArgumentException.php;  ©t…i;  ÷ñ‹)¤      <   phpunit/Framework/Exception/InvalidDataProviderException.phpÉ  ©t…iÉ  ¥¾'¤      :   phpunit/Framework/Exception/InvalidDependencyException.phpo  ©t…io  i¾Ôí¤      9   phpunit/Framework/Exception/NoChildTestSuiteException.php9  ©t…i9  4´İ¤      N   phpunit/Framework/Exception/ObjectEquals/ActualValueIsNotAnObjectException.php­  ©t…i­  ·òW÷¤      `   phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotAcceptParameterTypeException.phpW  ©t…iW  Œ‹–½¤      b   phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotDeclareBoolReturnTypeException.php>  ©t…i>  {ı– ¤      g   phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotDeclareExactlyOneParameterException.phpH  ©t…iH  °t ²¤      a   phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotDeclareParameterTypeException.phpF  ©t…iF  ñ†9¤      R   phpunit/Framework/Exception/ObjectEquals/ComparisonMethodDoesNotExistException.php  ©t…i  İ/]¤      8   phpunit/Framework/Exception/PhptAssertionFailedError.phpÃ  ©t…iÃ  èèy¤      9   phpunit/Framework/Exception/ProcessIsolationException.php9  ©t…i9  ,ÿÃ¤      3   phpunit/Framework/Exception/Skipped/SkippedTest.php)  ©t…i)  Àó¤      =   phpunit/Framework/Exception/Skipped/SkippedTestSuiteError.phpj  ©t…ij  wÜŠ¤      C   phpunit/Framework/Exception/Skipped/SkippedWithMessageException.phpp  ©t…ip  X&º>¤      @   phpunit/Framework/Exception/UnknownClassOrInterfaceException.phpö  ©t…iö  Hnw¤      :   phpunit/Framework/Exception/UnknownNativeTypeException.phpç  ©t…iç  œ%]¤      .   phpunit/Framework/ExecutionOrderDependency.php  ©t…i  ë×œğ¤      3   phpunit/Framework/MockObject/ConfigurableMethod.phpï  ©t…iï  Ì^ÉP¤      A   phpunit/Framework/MockObject/Exception/BadMethodCallException.phpo  ©t…io  äÛ!¤      H   phpunit/Framework/MockObject/Exception/CannotUseOnlyMethodsException.phpt  ©t…it  ™¬
+¤      4   phpunit/Framework/MockObject/Exception/Exception.php,  ©t…i,  ÷Rœ?¤      K   phpunit/Framework/MockObject/Exception/IncompatibleReturnValueException.phpå  ©t…iå  2íK]¤      H   phpunit/Framework/MockObject/Exception/MatchBuilderNotFoundException.php.  ©t…i.  ú¤´a¤      L   phpunit/Framework/MockObject/Exception/MatcherAlreadyRegisteredException.php&  ©t…i&  æİîŸ¤      L   phpunit/Framework/MockObject/Exception/MethodCannotBeConfiguredException.phpˆ  ©t…iˆ  7À„3¤      O   phpunit/Framework/MockObject/Exception/MethodNameAlreadyConfiguredException.phpò  ©t…iò  <Ú¬>¤      K   phpunit/Framework/MockObject/Exception/MethodNameNotConfiguredException.phpê  ©t…iê  ªYi¤      U   phpunit/Framework/MockObject/Exception/MethodParametersAlreadyConfiguredException.phpû  ©t…iû  ¥s¤      H   phpunit/Framework/MockObject/Exception/NeverReturningMethodException.phpe  ©t…ie  ]M6…¤      Q   phpunit/Framework/MockObject/Exception/NoMoreParameterSetsConfiguredException.phpò  ©t…iò  °C½Ì¤      P   phpunit/Framework/MockObject/Exception/NoMoreReturnValuesConfiguredException.php×  ©t…i×  H]²ò¤      L   phpunit/Framework/MockObject/Exception/ReturnValueNotConfiguredException.php¨  ©t…i¨  2’×V¤      ;   phpunit/Framework/MockObject/Exception/RuntimeException.phpc  ©t…ic  õ€=	¤      D   phpunit/Framework/MockObject/Exception/TestDoubleSealedException.php  ©t…i  my®¤      7   phpunit/Framework/MockObject/Generator/DoubledClass.php  ©t…i  8¢Àó¤      8   phpunit/Framework/MockObject/Generator/DoubledMethod.php~)  ©t…i~)  Ò'W±¤      ;   phpunit/Framework/MockObject/Generator/DoubledMethodSet.phpÚ  ©t…iÚ  #0¤      P   phpunit/Framework/MockObject/Generator/Exception/ClassIsEnumerationException.phpJ  ©t…iJ   `@¤      J   phpunit/Framework/MockObject/Generator/Exception/ClassIsFinalException.phpF  ©t…iF  Ôƒ¤      M   phpunit/Framework/MockObject/Generator/Exception/DuplicateMethodException.phpF  ©t…iF  ÂAé¤      >   phpunit/Framework/MockObject/Generator/Exception/Exception.phpn  ©t…in  ½q~•¤      O   phpunit/Framework/MockObject/Generator/Exception/InvalidMethodNameException.php<  ©t…i<  ×ÓªÙ¤      O   phpunit/Framework/MockObject/Generator/Exception/MethodNamedMethodException.phpÃ  ©t…iÃ  W²6¶¤      N   phpunit/Framework/MockObject/Generator/Exception/NameAlreadyInUseException.phpi  ©t…ii  Ø´¤      H   phpunit/Framework/MockObject/Generator/Exception/ReflectionException.php…  ©t…i…  "è¤      E   phpunit/Framework/MockObject/Generator/Exception/RuntimeException.php‚  ©t…i‚  „Ãø¤      N   phpunit/Framework/MockObject/Generator/Exception/UnknownInterfaceException.php;  ©t…i;  ¹:yá¤      I   phpunit/Framework/MockObject/Generator/Exception/UnknownTypeException.php-  ©t…i-  ¨‰V¤      4   phpunit/Framework/MockObject/Generator/Generator.phpŒb  ©t…iŒb  CCå¤      9   phpunit/Framework/MockObject/Generator/HookedProperty.php   ©t…i   Ú¤      B   phpunit/Framework/MockObject/Generator/HookedPropertyGenerator.phpI  ©t…iI  Ïƒt¤      9   phpunit/Framework/MockObject/Generator/TemplateLoader.phpÙ  ©t…iÙ  ˆHU!¤      @   phpunit/Framework/MockObject/Generator/templates/deprecation.tpl;   ©t…i;   O5øs¤      C   phpunit/Framework/MockObject/Generator/templates/doubled_method.tplC  ©t…iC  ¡÷Mé¤      J   phpunit/Framework/MockObject/Generator/templates/doubled_static_method.tplî   ©t…iî    4éR¤      A   phpunit/Framework/MockObject/Generator/templates/intersection.tplL   ©t…iL   ®-X¤      F   phpunit/Framework/MockObject/Generator/templates/test_double_class.tpl[   ©t…i[   üj½Ğ¤      ,   phpunit/Framework/MockObject/MockBuilder.php"
+  ©t…i"
+  (Ê³¤      I   phpunit/Framework/MockObject/Runtime/AbstractInvocationImplementation.phpo!  ©t…io!  ÒıÃ;¤      ?   phpunit/Framework/MockObject/Runtime/Api/DoubledCloneMethod.php  ©t…i  ¥•J%¤      3   phpunit/Framework/MockObject/Runtime/Api/Method.php  ©t…i  ¡£)²¤      :   phpunit/Framework/MockObject/Runtime/Api/MockObjectApi.php  ©t…i  V‚Ô¤      ?   phpunit/Framework/MockObject/Runtime/Api/ProxiedCloneMethod.php7  ©t…i7  ‰˜Â˜¤      4   phpunit/Framework/MockObject/Runtime/Api/StubApi.phpĞ  ©t…iĞ  $ÊFñ¤      <   phpunit/Framework/MockObject/Runtime/Api/TestDoubleState.php}  ©t…i}  læ¤      C   phpunit/Framework/MockObject/Runtime/Interface/InvocationMocker.php]  ©t…i]  ~™ş¤      D   phpunit/Framework/MockObject/Runtime/Interface/InvocationStubber.php  ©t…i  h›„O¤      =   phpunit/Framework/MockObject/Runtime/Interface/MockObject.php‚  ©t…i‚  …6¨A¤      E   phpunit/Framework/MockObject/Runtime/Interface/MockObjectInternal.phpû  ©t…iû  êúı“¤      7   phpunit/Framework/MockObject/Runtime/Interface/Stub.php‰  ©t…i‰  cvã¤      ?   phpunit/Framework/MockObject/Runtime/Interface/StubInternal.php9  ©t…i9   {Æå¤      3   phpunit/Framework/MockObject/Runtime/Invocation.phpQ  ©t…iQ  ¤€~º¤      :   phpunit/Framework/MockObject/Runtime/InvocationHandler.php  ©t…i  eå¤      G   phpunit/Framework/MockObject/Runtime/InvocationMockerImplementation.phpï
+  ©t…iï
+  ¹ÖB¤      H   phpunit/Framework/MockObject/Runtime/InvocationStubberImplementation.php§  ©t…i§  ’ÓüÂ¤      0   phpunit/Framework/MockObject/Runtime/Matcher.phpô  ©t…iô  qb­¤      =   phpunit/Framework/MockObject/Runtime/MethodNameConstraint.php  ©t…i  ı/ƒ¤      E   phpunit/Framework/MockObject/Runtime/PropertyHook/PropertyGetHook.php  ©t…i  »Æ6Ì¤      B   phpunit/Framework/MockObject/Runtime/PropertyHook/PropertyHook.php5  ©t…i5  NE5Ò¤      E   phpunit/Framework/MockObject/Runtime/PropertyHook/PropertySetHook.php  ©t…i  `²>n¤      =   phpunit/Framework/MockObject/Runtime/ReturnValueGenerator.phpÏ  ©t…iÏ  ×í¦
+¤      =   phpunit/Framework/MockObject/Runtime/Rule/AnyInvokedCount.phpƒ  ©t…iƒ  /d²k¤      ;   phpunit/Framework/MockObject/Runtime/Rule/AnyParameters.php/  ©t…i/  ÿpv¤      =   phpunit/Framework/MockObject/Runtime/Rule/InvocationOrder.php7  ©t…i7  =€Ä˜¤      A   phpunit/Framework/MockObject/Runtime/Rule/InvokedAtLeastCount.php*  ©t…i*  ä™†³¤      @   phpunit/Framework/MockObject/Runtime/Rule/InvokedAtLeastOnce.phpG  ©t…iG  ãfËs¤      @   phpunit/Framework/MockObject/Runtime/Rule/InvokedAtMostCount.php  ©t…i  yÃI¤      :   phpunit/Framework/MockObject/Runtime/Rule/InvokedCount.phpÁ	  ©t…iÁ	   I¤      8   phpunit/Framework/MockObject/Runtime/Rule/MethodName.php{  ©t…i{  >Êh¤      B   phpunit/Framework/MockObject/Runtime/Rule/OrderedParameterSets.phpH
+  ©t…iH
+  ;ã÷¤      8   phpunit/Framework/MockObject/Runtime/Rule/Parameters.php¯  ©t…i¯  ï)NÁ¤      <   phpunit/Framework/MockObject/Runtime/Rule/ParametersRule.phpë  ©t…ië  v®Y¤      D   phpunit/Framework/MockObject/Runtime/Rule/UnorderedParameterSets.php"  ©t…i"  ¬dıï¤      >   phpunit/Framework/MockObject/Runtime/Stub/ConsecutiveCalls.php   ©t…i   ËdRY¤      7   phpunit/Framework/MockObject/Runtime/Stub/Exception.php¦  ©t…i¦  áëK¶¤      <   phpunit/Framework/MockObject/Runtime/Stub/ReturnArgument.phpŸ  ©t…iŸ  rjc¤      <   phpunit/Framework/MockObject/Runtime/Stub/ReturnCallback.phpÔ  ©t…iÔ  2à¶Q¤      =   phpunit/Framework/MockObject/Runtime/Stub/ReturnReference.phpf  ©t…if  ¦ÿ¬Ó¤      8   phpunit/Framework/MockObject/Runtime/Stub/ReturnSelf.phpE  ©t…iE  “”DÑ¤      8   phpunit/Framework/MockObject/Runtime/Stub/ReturnStub.phpT  ©t…iT  å{ÈŠ¤      <   phpunit/Framework/MockObject/Runtime/Stub/ReturnValueMap.phpl  ©t…il  $}S¤      2   phpunit/Framework/MockObject/Runtime/Stub/Stub.phpé  ©t…ié  Ó±Ê¤      2   phpunit/Framework/MockObject/TestDoubleBuilder.php¢  ©t…i¢  âH-d¤      0   phpunit/Framework/MockObject/TestStubBuilder.phpª  ©t…iª  ‚B<\¤          phpunit/Framework/NativeType.php&  ©t…i&  |Ñgç¤      !   phpunit/Framework/Reorderable.phpø  ©t…iø  €¶çö¤      $   phpunit/Framework/SelfDescribing.phpy  ©t…iy  ;Å;¤         phpunit/Framework/Test.phpã  ©t…iã  ­ñ9¤      !   phpunit/Framework/TestBuilder.php)  ©t…i)  „v”¤         phpunit/Framework/TestCase.phpà% ©t…ià% }¾–b¤      <   phpunit/Framework/TestRunner/ChildProcessResultProcessor.php8  ©t…i8  =¾;ì¤      3   phpunit/Framework/TestRunner/IsolatedTestRunner.php‚  ©t…i‚  Ú×í¤      ;   phpunit/Framework/TestRunner/IsolatedTestRunnerRegistry.php/  ©t…i/  ˜¥Ú¤      :   phpunit/Framework/TestRunner/SeparateProcessTestRunner.php‹  ©t…i‹  şV“…¤      +   phpunit/Framework/TestRunner/TestRunner.phpÕ,  ©t…iÕ,  DŸ]Á¤      1   phpunit/Framework/TestRunner/templates/method.tplà  ©t…ià  U»PÏ¤      $   phpunit/Framework/TestSize/Known.phpØ  ©t…iØ  ¯½R¤      $   phpunit/Framework/TestSize/Large.phpb  ©t…ib  ;qç¤      %   phpunit/Framework/TestSize/Medium.phpd  ©t…id  TA¦Ñ¤      $   phpunit/Framework/TestSize/Small.phpV  ©t…iV  XÃ¢™¤      '   phpunit/Framework/TestSize/TestSize.php¤  ©t…i¤  ÅìHÑ¤      &   phpunit/Framework/TestSize/Unknown.phpç  ©t…iç  fÚœ¤      ,   phpunit/Framework/TestStatus/Deprecation.php3  ©t…i3  ‡mĞ|¤      &   phpunit/Framework/TestStatus/Error.php!  ©t…i!  ÊXP>¤      (   phpunit/Framework/TestStatus/Failure.php'  ©t…i'  µgö%¤      +   phpunit/Framework/TestStatus/Incomplete.php0  ©t…i0  Üqöq¤      &   phpunit/Framework/TestStatus/Known.phpŸ  ©t…iŸ  ‘Â–¤      '   phpunit/Framework/TestStatus/Notice.php$  ©t…i$  «¥!H¤      &   phpunit/Framework/TestStatus/Risky.php!  ©t…i!  t E¤      (   phpunit/Framework/TestStatus/Skipped.php'  ©t…i'   <¤      (   phpunit/Framework/TestStatus/Success.php'  ©t…i'  Şa&¥¤      +   phpunit/Framework/TestStatus/TestStatus.phpÀ  ©t…iÀ  +u¤      (   phpunit/Framework/TestStatus/Unknown.php-  ©t…i-  FuXN¤      (   phpunit/Framework/TestStatus/Warning.php'  ©t…i'  =â¤         phpunit/Framework/TestSuite.phpK  ©t…iK  !%Ÿ¤      '   phpunit/Framework/TestSuiteIterator.phpç  ©t…iç  %Nî¤         phpunit/Logging/EventLogger.phpI  ©t…iI  cïµ¾¤      (   phpunit/Logging/JUnit/JunitXmlLogger.php¹1  ©t…i¹1  µÿW¤      /   phpunit/Logging/JUnit/Subscriber/Subscriber.php=  ©t…i=  ôıxÛ¤      :   phpunit/Logging/JUnit/Subscriber/TestErroredSubscriber.php}  ©t…i}  £Šá¤      9   phpunit/Logging/JUnit/Subscriber/TestFailedSubscriber.phpw  ©t…iw  †€¤      ;   phpunit/Logging/JUnit/Subscriber/TestFinishedSubscriber.phpƒ  ©t…iƒ  "^—¤      C   phpunit/Logging/JUnit/Subscriber/TestMarkedIncompleteSubscriber.php³  ©t…i³  5İTY¤      E   phpunit/Logging/JUnit/Subscriber/TestPreparationErroredSubscriber.php¹  ©t…i¹  ñDy‰¤      D   phpunit/Logging/JUnit/Subscriber/TestPreparationFailedSubscriber.php³  ©t…i³  ºÉ£Å¤      E   phpunit/Logging/JUnit/Subscriber/TestPreparationStartedSubscriber.php¿  ©t…i¿  $†‘2¤      ;   phpunit/Logging/JUnit/Subscriber/TestPreparedSubscriber.php}  ©t…i}  ñı»‡¤      J   phpunit/Logging/JUnit/Subscriber/TestPrintedUnexpectedOutputSubscriber.phpy  ©t…iy  ÷Öú¤      J   phpunit/Logging/JUnit/Subscriber/TestRunnerExecutionFinishedSubscriber.phpQ  ©t…iQ  2õ÷÷¤      :   phpunit/Logging/JUnit/Subscriber/TestSkippedSubscriber.php}  ©t…i}  ¿I©¤      @   phpunit/Logging/JUnit/Subscriber/TestSuiteFinishedSubscriber.php-  ©t…i-   Cö¶¤      ?   phpunit/Logging/JUnit/Subscriber/TestSuiteStartedSubscriber.php-  ©t…i-  }‰£€¤      P   phpunit/Logging/OpenTestReporting/Exception/CannotOpenUriForWritingException.phpÅ  ©t…iÅ  Î—ip¤      9   phpunit/Logging/OpenTestReporting/Exception/Exception.php`  ©t…i`  Tç>i¤      G   phpunit/Logging/OpenTestReporting/InfrastructureInformationProvider.phph  ©t…ih  J>¤      2   phpunit/Logging/OpenTestReporting/OtrXmlLogger.phpß>  ©t…iß>  á¡³¤      ,   phpunit/Logging/OpenTestReporting/Status.php³  ©t…i³  |Ü"£¤      U   phpunit/Logging/OpenTestReporting/Subscriber/AfterLastTestMethodErroredSubscriber.php,  ©t…i,  wÖ¤      T   phpunit/Logging/OpenTestReporting/Subscriber/AfterLastTestMethodFailedSubscriber.php%  ©t…i%  ë£õ¤      W   phpunit/Logging/OpenTestReporting/Subscriber/BeforeFirstTestMethodErroredSubscriber.php8  ©t…i8  –£¤      V   phpunit/Logging/OpenTestReporting/Subscriber/BeforeFirstTestMethodFailedSubscriber.php1  ©t…i1  r¤™¤      ;   phpunit/Logging/OpenTestReporting/Subscriber/Subscriber.phpg  ©t…ig  †€!{¤      F   phpunit/Logging/OpenTestReporting/Subscriber/TestAbortedSubscriber.phpÀ  ©t…iÀ  şsE¤      F   phpunit/Logging/OpenTestReporting/Subscriber/TestErroredSubscriber.php•  ©t…i•  RO(¤      E   phpunit/Logging/OpenTestReporting/Subscriber/TestFailedSubscriber.php  ©t…i  #İ¤      G   phpunit/Logging/OpenTestReporting/Subscriber/TestFinishedSubscriber.php•  ©t…i•  Hœ¤      Q   phpunit/Logging/OpenTestReporting/Subscriber/TestPreparationErroredSubscriber.phpÍ  ©t…iÍ  ¦£Ø¾¤      P   phpunit/Logging/OpenTestReporting/Subscriber/TestPreparationFailedSubscriber.phpÈ  ©t…iÈ  u„µ¤      G   phpunit/Logging/OpenTestReporting/Subscriber/TestPreparedSubscriber.php›  ©t…i›  ÙÁ7²¤      M   phpunit/Logging/OpenTestReporting/Subscriber/TestRunnerFinishedSubscriber.phpÑ  ©t…iÑ  ùów…¤      L   phpunit/Logging/OpenTestReporting/Subscriber/TestRunnerStartedSubscriber.php©  ©t…i©  Òy¡Æ¤      F   phpunit/Logging/OpenTestReporting/Subscriber/TestSkippedSubscriber.php•  ©t…i•  iÏIr¤      L   phpunit/Logging/OpenTestReporting/Subscriber/TestSuiteFinishedSubscriber.php©  ©t…i©  ¡ĞÉ¤      K   phpunit/Logging/OpenTestReporting/Subscriber/TestSuiteSkippedSubscriber.php©  ©t…i©  @*E¤      K   phpunit/Logging/OpenTestReporting/Subscriber/TestSuiteStartedSubscriber.php©  ©t…i©  ­E@p¤      2   phpunit/Logging/TeamCity/Subscriber/Subscriber.phpI  ©t…iI  Œt¶“¤      E   phpunit/Logging/TeamCity/Subscriber/TestConsideredRiskySubscriber.php³  ©t…i³  åÎF¤      =   phpunit/Logging/TeamCity/Subscriber/TestErroredSubscriber.phpƒ  ©t…iƒ  ¯y»ˆ¤      <   phpunit/Logging/TeamCity/Subscriber/TestFailedSubscriber.php}  ©t…i}  °ôå¤      >   phpunit/Logging/TeamCity/Subscriber/TestFinishedSubscriber.php‰  ©t…i‰  ÍT¸›¤      F   phpunit/Logging/TeamCity/Subscriber/TestMarkedIncompleteSubscriber.php¹  ©t…i¹  ¾T»b¤      >   phpunit/Logging/TeamCity/Subscriber/TestPreparedSubscriber.php%  ©t…i%  ÿ`c+¤      M   phpunit/Logging/TeamCity/Subscriber/TestRunnerExecutionFinishedSubscriber.phpW  ©t…iW  ã)Ê®¤      =   phpunit/Logging/TeamCity/Subscriber/TestSkippedSubscriber.phpƒ  ©t…iƒ  ÁNÇH¤      W   phpunit/Logging/TeamCity/Subscriber/TestSuiteBeforeFirstTestMethodErroredSubscriber.php  ©t…i  ïÊ¹j¤      C   phpunit/Logging/TeamCity/Subscriber/TestSuiteFinishedSubscriber.php9  ©t…i9  ¬(s³¤      B   phpunit/Logging/TeamCity/Subscriber/TestSuiteSkippedSubscriber.php—  ©t…i—  5²B;¤      B   phpunit/Logging/TeamCity/Subscriber/TestSuiteStartedSubscriber.php3  ©t…i3  ±Ò“¤      +   phpunit/Logging/TeamCity/TeamCityLogger.php’*  ©t…i’*  *é]4¤      (   phpunit/Logging/TestDox/HtmlRenderer.php·  ©t…i·  ¹O!‘¤      *   phpunit/Logging/TestDox/NamePrettifier.php^/  ©t…i^/  Pİ(™¤      -   phpunit/Logging/TestDox/PlainTextRenderer.php„  ©t…i„  NÅô¤      <   phpunit/Logging/TestDox/TestResult/Subscriber/Subscriber.phpf  ©t…if  7kC¤      O   phpunit/Logging/TestDox/TestResult/Subscriber/TestConsideredRiskySubscriber.phpP  ©t…iP  »J'¤      G   phpunit/Logging/TestDox/TestResult/Subscriber/TestErroredSubscriber.php   ©t…i   t8¤      F   phpunit/Logging/TestDox/TestResult/Subscriber/TestFailedSubscriber.php  ©t…i  ñä;À¤      H   phpunit/Logging/TestDox/TestResult/Subscriber/TestFinishedSubscriber.phpŠ  ©t…iŠ  MÉ~£¤      P   phpunit/Logging/TestDox/TestResult/Subscriber/TestMarkedIncompleteSubscriber.phpV  ©t…iV  ]ùó¤      F   phpunit/Logging/TestDox/TestResult/Subscriber/TestPassedSubscriber.php  ©t…i  ÔBº¤      H   phpunit/Logging/TestDox/TestResult/Subscriber/TestPreparedSubscriber.php&  ©t…i&  ÚÈé¤      G   phpunit/Logging/TestDox/TestResult/Subscriber/TestSkippedSubscriber.php   ©t…i   ´Õj¤      T   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredDeprecationSubscriber.phpn  ©t…in  Q¤      O   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredNoticeSubscriber.phpP  ©t…iP  °ÔÃ)¤      W   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredPhpDeprecationSubscriber.php€  ©t…i€  ˜]¤      R   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredPhpNoticeSubscriber.phpb  ©t…ib  ae¤      S   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredPhpWarningSubscriber.phph  ©t…ih  ¢QF¤      [   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredPhpunitDeprecationSubscriber.php˜  ©t…i˜  ^õ¤      U   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredPhpunitErrorSubscriber.phpt  ©t…it  ‘Gâ°¤      W   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredPhpunitWarningSubscriber.php€  ©t…i€  îk½<¤      P   phpunit/Logging/TestDox/TestResult/Subscriber/TestTriggeredWarningSubscriber.phpV  ©t…iV  xİB\¤      1   phpunit/Logging/TestDox/TestResult/TestResult.phpf  ©t…if  é˜µ¤      ;   phpunit/Logging/TestDox/TestResult/TestResultCollection.phps  ©t…is  ¹Ì¤      C   phpunit/Logging/TestDox/TestResult/TestResultCollectionIterator.php¼  ©t…i¼  '4%~¤      :   phpunit/Logging/TestDox/TestResult/TestResultCollector.phpÓ)  ©t…iÓ)  <[Qì¤         phpunit/Metadata/After.php9  ©t…i9  àwÀ ¤         phpunit/Metadata/AfterClass.phpC  ©t…iC  U÷¤      8   phpunit/Metadata/AllowMockObjectsWithoutExpectations.phpb  ©t…ib  I)¨¤      %   phpunit/Metadata/Api/CodeCoverage.phpÑ  ©t…iÑ  ß;ñı¤      %   phpunit/Metadata/Api/DataProvider.php (  ©t…i (  <Şé8¤      %   phpunit/Metadata/Api/Dependencies.php†  ©t…i†  Š6Á¾¤         phpunit/Metadata/Api/Groups.phpJ  ©t…iJ  %“PU¤      $   phpunit/Metadata/Api/HookMethods.php  ©t…i  ÙE¤      %   phpunit/Metadata/Api/ProvidedData.phpû  ©t…iû  O	„®¤      %   phpunit/Metadata/Api/Requirements.phpÇ  ©t…iÇ  ¹ı†º¤      "   phpunit/Metadata/BackupGlobals.phpF  ©t…iF  ´r0õ¤      +   phpunit/Metadata/BackupStaticProperties.phpX  ©t…iX  X\½w¤         phpunit/Metadata/Before.php;  ©t…i;  ®‘Y¦¤          phpunit/Metadata/BeforeClass.phpE  ©t…iE  {‰¸¤          phpunit/Metadata/CoversClass.phpß  ©t…iß  š0¤      1   phpunit/Metadata/CoversClassesThatExtendClass.php  ©t…i  @bãÂ¤      8   phpunit/Metadata/CoversClassesThatImplementInterface.php+  ©t…i+  }¡¯¤      #   phpunit/Metadata/CoversFunction.php  ©t…i  ‹&7¤      !   phpunit/Metadata/CoversMethod.php!  ©t…i!  ³Â8¶¤      $   phpunit/Metadata/CoversNamespace.phpó  ©t…ió  X‘»»¤      "   phpunit/Metadata/CoversNothing.php6  ©t…i6  I¥Õ¤          phpunit/Metadata/CoversTrait.phpß  ©t…iß  “³’¤      !   phpunit/Metadata/DataProvider.php  ©t…i  ú®#‡¤      #   phpunit/Metadata/DependsOnClass.phpG  ©t…iG  ASáH¤      $   phpunit/Metadata/DependsOnMethod.php‰  ©t…i‰  B.T†¤      ?   phpunit/Metadata/DisableReturnValueGenerationForTestDoubles.phpp  ©t…ip  ‘	¤      -   phpunit/Metadata/DoesNotPerformAssertions.phpL  ©t…iL  {¯T¤      (   phpunit/Metadata/Exception/Exception.phpÀ  ©t…iÀ  älñ¤      8   phpunit/Metadata/Exception/InvalidAttributeException.phpw  ©t…iw  Òo‡¤      A   phpunit/Metadata/Exception/InvalidVersionRequirementException.php  ©t…i  -µ[D¤      <   phpunit/Metadata/Exception/NoVersionRequirementException.php  ©t…i  gÌ®¤      4   phpunit/Metadata/ExcludeGlobalVariableFromBackup.phpR  ©t…iR  )§™[¤      4   phpunit/Metadata/ExcludeStaticPropertyFromBackup.phpU  ©t…iU  „Ø£¤         phpunit/Metadata/Group.phpß  ©t…iß  ï 4i¤      '   phpunit/Metadata/IgnoreDeprecations.php&  ©t…i&  ˆ†!F¤      .   phpunit/Metadata/IgnorePhpunitDeprecations.phpª  ©t…iª  (\¤      *   phpunit/Metadata/IgnorePhpunitWarnings.php,  ©t…i,  ßÎo¤         phpunit/Metadata/Level.php¿  ©t…i¿  8VB¤         phpunit/Metadata/Metadata.php%y  ©t…i%y  ã¡ğ¤      '   phpunit/Metadata/MetadataCollection.php=7  ©t…i=7  ½Ìã¤      /   phpunit/Metadata/MetadataCollectionIterator.php/  ©t…i/  2¸†¤      +   phpunit/Metadata/Parser/AttributeParser.php	‡  ©t…i	‡  úHV¤      )   phpunit/Metadata/Parser/CachingParser.php¯
+  ©t…i¯
+  ®t¤      "   phpunit/Metadata/Parser/Parser.php3  ©t…i3  dİË$¤      $   phpunit/Metadata/Parser/Registry.php  ©t…i  ç˜wR¤      "   phpunit/Metadata/PostCondition.phpI  ©t…iI  ù¤sG¤      !   phpunit/Metadata/PreCondition.phpG  ©t…iG  †&›È¤      (   phpunit/Metadata/PreserveGlobalState.phpR  ©t…iR  -¶Ü˜¤      0   phpunit/Metadata/RequiresEnvironmentVariable.phpm  ©t…im  ¼A&Ò¤      %   phpunit/Metadata/RequiresFunction.php
+  ©t…i
+  õ	|^¤      #   phpunit/Metadata/RequiresMethod.php%  ©t…i%  V¢´¤      ,   phpunit/Metadata/RequiresOperatingSystem.php-  ©t…i-  ¥_ã¤      2   phpunit/Metadata/RequiresOperatingSystemFamily.phpc  ©t…ic  µÏ§H¤          phpunit/Metadata/RequiresPhp.phpÃ  ©t…iÃ   ã~P¤      )   phpunit/Metadata/RequiresPhpExtension.php  ©t…i  İ7ùJ¤      $   phpunit/Metadata/RequiresPhpunit.phpË  ©t…iË  o_³¤      -   phpunit/Metadata/RequiresPhpunitExtension.phpe  ©t…ie  ŒÒ-¤      $   phpunit/Metadata/RequiresSetting.phpş  ©t…iş  Ç£lú¤      )   phpunit/Metadata/RunInSeparateProcess.phpD  ©t…iD  ÿŸi‹¤      0   phpunit/Metadata/RunTestsInSeparateProcesses.phpR  ©t…iR  Yß­s¤         phpunit/Metadata/Test.php$  ©t…i$  1Ñ¡¤         phpunit/Metadata/TestDox.phpÀ  ©t…iÀ  W½*¤      %   phpunit/Metadata/TestDoxFormatter.php)  ©t…i)  vßƒ¤         phpunit/Metadata/TestWith.phpò  ©t…iò  ÀNñ¤         phpunit/Metadata/UsesClass.phpÛ  ©t…iÛ  B3Ô¤      /   phpunit/Metadata/UsesClassesThatExtendClass.phpı  ©t…iı  §ZlI¤      6   phpunit/Metadata/UsesClassesThatImplementInterface.php'  ©t…i'  ğ,¤      !   phpunit/Metadata/UsesFunction.php  ©t…i  B€h‹¤         phpunit/Metadata/UsesMethod.php  ©t…i  ê¤      "   phpunit/Metadata/UsesNamespace.phpë  ©t…ië  ^öo¤         phpunit/Metadata/UsesTrait.phpÛ  ©t…iÛ  r@AÄ¤      2   phpunit/Metadata/Version/ComparisonRequirement.phpW  ©t…iW  ìÈ–?¤      2   phpunit/Metadata/Version/ConstraintRequirement.php  ©t…i  ^.8¤      (   phpunit/Metadata/Version/Requirement.phpş  ©t…iş  ¢âI¿¤      ,   phpunit/Metadata/WithEnvironmentVariable.php
+  ©t…i
+  .zu¤      (   phpunit/Metadata/WithoutErrorHandler.phpB  ©t…iB  %€W­¤      .   phpunit/Runner/BackedUpEnvironmentVariable.php«  ©t…i«  Ô#{°¤      $   phpunit/Runner/Baseline/Baseline.phpg  ©t…ig  Qá<Â¤      A   phpunit/Runner/Baseline/Exception/CannotLoadBaselineException.php~  ©t…i~  =)Sb¤      B   phpunit/Runner/Baseline/Exception/CannotWriteBaselineException.php  ©t…i  ¶ 4É¤      B   phpunit/Runner/Baseline/Exception/FileDoesNotHaveLineException.php1  ©t…i1  ü3€¤      %   phpunit/Runner/Baseline/Generator.phpñ  ©t…iñ  –öÖ¤      !   phpunit/Runner/Baseline/Issue.php)  ©t…i)  Û<É¤      "   phpunit/Runner/Baseline/Reader.phpÖ  ©t…iÖ  ´ÿÀ{¤      2   phpunit/Runner/Baseline/RelativePathCalculator.phpÎ
+  ©t…iÎ
+  íËe¥¤      1   phpunit/Runner/Baseline/Subscriber/Subscriber.phpH  ©t…iH  Ğ43¤      I   phpunit/Runner/Baseline/Subscriber/TestTriggeredDeprecationSubscriber.phpû  ©t…iû  ü_E¤      D   phpunit/Runner/Baseline/Subscriber/TestTriggeredNoticeSubscriber.phpâ  ©t…iâ  jâÄ¤      L   phpunit/Runner/Baseline/Subscriber/TestTriggeredPhpDeprecationSubscriber.php
+  ©t…i
+  Âk°±¤      G   phpunit/Runner/Baseline/Subscriber/TestTriggeredPhpNoticeSubscriber.phpñ  ©t…iñ  ÒîL¤      H   phpunit/Runner/Baseline/Subscriber/TestTriggeredPhpWarningSubscriber.phpö  ©t…iö  ´MŠ¤      E   phpunit/Runner/Baseline/Subscriber/TestTriggeredWarningSubscriber.phpç  ©t…iç  àQÌ½¤      "   phpunit/Runner/Baseline/Writer.phpj	  ©t…ij	  öı†q¤         phpunit/Runner/CodeCoverage.php®=  ©t…i®=  9·ûy¤      3   phpunit/Runner/CodeCoverageInitializationStatus.phpT  ©t…iT  ‰52q¤      1   phpunit/Runner/DeprecationCollector/Collector.phpZ  ©t…iZ  ì–c¤      .   phpunit/Runner/DeprecationCollector/Facade.phpô  ©t…iô  &¨I¤      <   phpunit/Runner/DeprecationCollector/InIsolationCollector.php"  ©t…i"  óß}È¤      =   phpunit/Runner/DeprecationCollector/Subscriber/Subscriber.php&  ©t…i&  ˜¬\¤      I   phpunit/Runner/DeprecationCollector/Subscriber/TestPreparedSubscriber.php/  ©t…i/  Kd€I¤      U   phpunit/Runner/DeprecationCollector/Subscriber/TestTriggeredDeprecationSubscriber.php}  ©t…i}  Yò¤         phpunit/Runner/ErrorHandler.phpº8  ©t…iº8  àÙÔl¤      8   phpunit/Runner/Exception/ClassCannotBeFoundException.php%  ©t…i%  uëX¤      @   phpunit/Runner/Exception/ClassDoesNotExtendTestCaseException.phpQ  ©t…iQ  ÎºYÀ¤      5   phpunit/Runner/Exception/ClassIsAbstractException.php'  ©t…i'  ƒìT¤      <   phpunit/Runner/Exception/CodeCoverageFileExistsException.phpk  ©t…ik  ƒÙŸ¤      ;   phpunit/Runner/Exception/DirectoryDoesNotExistException.php+  ©t…i+  EH¾-¤      +   phpunit/Runner/Exception/ErrorException.phpD  ©t…iD  i}Å¤      &   phpunit/Runner/Exception/Exception.php  ©t…i  úYŠK¤      6   phpunit/Runner/Exception/FileDoesNotExistException.phpş  ©t…iş  dfH!¤      2   phpunit/Runner/Exception/InvalidOrderException.phpa  ©t…ia  [Èt%¤      ;   phpunit/Runner/Exception/ParameterDoesNotExistException.php  ©t…i  Z­Ÿh¤      &   phpunit/Runner/Extension/Extension.php…  ©t…i…  sÆ²¤      2   phpunit/Runner/Extension/ExtensionBootstrapper.phpá	  ©t…iá	  .îÑL¤      #   phpunit/Runner/Extension/Facade.php‘	  ©t…i‘	  ÇŒ
+¤      0   phpunit/Runner/Extension/ParameterCollection.phpL  ©t…iL  pıñ(¤      '   phpunit/Runner/Extension/PharLoader.php  ©t…i  ¢Ã†s¤      4   phpunit/Runner/Filter/ExcludeGroupFilterIterator.phpQ  ©t…iQ  úFßİ¤      3   phpunit/Runner/Filter/ExcludeNameFilterIterator.php£  ©t…i£  BêÕ¤      !   phpunit/Runner/Filter/Factory.phpõ	  ©t…iõ	  Ä1¤      -   phpunit/Runner/Filter/GroupFilterIterator.php  ©t…i  <e³I¤      4   phpunit/Runner/Filter/IncludeGroupFilterIterator.phpP  ©t…iP  Iÿ £¤      3   phpunit/Runner/Filter/IncludeNameFilterIterator.php¢  ©t…i¢  jjÏ¤      ,   phpunit/Runner/Filter/NameFilterIterator.php/  ©t…i/  åoÕ¤      .   phpunit/Runner/Filter/TestIdFilterIterator.phpº  ©t…iº  JØİ,¤      =   phpunit/Runner/GarbageCollection/GarbageCollectionHandler.php   ©t…i    µÏ¤      K   phpunit/Runner/GarbageCollection/Subscriber/ExecutionFinishedSubscriber.php<  ©t…i<  /ëƒt¤      J   phpunit/Runner/GarbageCollection/Subscriber/ExecutionStartedSubscriber.php5  ©t…i5  òXê$¤      :   phpunit/Runner/GarbageCollection/Subscriber/Subscriber.php  ©t…i  l´Ñ¤      F   phpunit/Runner/GarbageCollection/Subscriber/TestFinishedSubscriber.phpÏ  ©t…iÏ  „g6¤      (   phpunit/Runner/HookMethod/HookMethod.php"  ©t…i"  é)¤      2   phpunit/Runner/HookMethod/HookMethodCollection.phpÅ	  ©t…iÅ	  ¥~„É¤         phpunit/Runner/IssueFilter.phpÂ  ©t…iÂ  ù-I¤      :   phpunit/Runner/Phpt/Exception/InvalidPhptFileException.php  ©t…i  úÁµÒ¤      I   phpunit/Runner/Phpt/Exception/PhptExternalFileCannotBeLoadedException.phpo  ©t…io  .Ğˆ¤      A   phpunit/Runner/Phpt/Exception/UnsupportedPhptSectionException.phpK  ©t…iK  #BÇ£¤         phpunit/Runner/Phpt/Parser.php<  ©t…i<  ‘ï6¤          phpunit/Runner/Phpt/Renderer.php-  ©t…i-  ‹”v×¤          phpunit/Runner/Phpt/TestCase.phpN  ©t…iN  Qí#¤      &   phpunit/Runner/Phpt/templates/phpt.tplÓ  ©t…iÓ  >Üßu¤      1   phpunit/Runner/ResultCache/DefaultResultCache.phpø  ©t…iø  ¸Ñ˜¤      .   phpunit/Runner/ResultCache/NullResultCache.php«  ©t…i«  ÿM¤      *   phpunit/Runner/ResultCache/ResultCache.phpó  ©t…ió  M¸˜¤      1   phpunit/Runner/ResultCache/ResultCacheHandler.php$  ©t…i$  ®yù…¤      ,   phpunit/Runner/ResultCache/ResultCacheId.php¢  ©t…i¢  ,ã¶¤      4   phpunit/Runner/ResultCache/Subscriber/Subscriber.phpc  ©t…ic  ·Ë¤      G   phpunit/Runner/ResultCache/Subscriber/TestConsideredRiskySubscriber.phpT  ©t…iT  ­_€¤      ?   phpunit/Runner/ResultCache/Subscriber/TestErroredSubscriber.php$  ©t…i$  “İ˜Î¤      >   phpunit/Runner/ResultCache/Subscriber/TestFailedSubscriber.php  ©t…i  Üú…†¤      @   phpunit/Runner/ResultCache/Subscriber/TestFinishedSubscriber.phpÉ  ©t…iÉ  íÎg¤      H   phpunit/Runner/ResultCache/Subscriber/TestMarkedIncompleteSubscriber.phpZ  ©t…iZ  ŸŞ¦v¤      @   phpunit/Runner/ResultCache/Subscriber/TestPreparedSubscriber.php*  ©t…i*  yÑ¤      ?   phpunit/Runner/ResultCache/Subscriber/TestSkippedSubscriber.phpÃ  ©t…iÃ  à.“Í¤      E   phpunit/Runner/ResultCache/Subscriber/TestSuiteFinishedSubscriber.php8  ©t…i8  Ê×/ı¤      D   phpunit/Runner/ResultCache/Subscriber/TestSuiteStartedSubscriber.php2  ©t…i2  ª/ªÂ¤      "   phpunit/Runner/ShutdownHandler.phpc  ©t…ic  ©Çeß¤      '   phpunit/Runner/TestResult/Collector.php¿L  ©t…i¿L  \L¤      $   phpunit/Runner/TestResult/Facade.php¼  ©t…i¼  U„ûM¤      #   phpunit/Runner/TestResult/Issue.phpà  ©t…ià  „9×=¤      )   phpunit/Runner/TestResult/PassedTests.phpÏ  ©t…iÏ  Ì8¤      N   phpunit/Runner/TestResult/Subscriber/AfterTestClassMethodErroredSubscriber.php˜  ©t…i˜  8)xº¤      M   phpunit/Runner/TestResult/Subscriber/AfterTestClassMethodFailedSubscriber.php’  ©t…i’  -ÀQR¤      O   phpunit/Runner/TestResult/Subscriber/BeforeTestClassMethodErroredSubscriber.php¢  ©t…i¢  U½E2¤      N   phpunit/Runner/TestResult/Subscriber/BeforeTestClassMethodFailedSubscriber.phpœ  ©t…iœ  [Æ=„¤      F   phpunit/Runner/TestResult/Subscriber/ChildProcessErroredSubscriber.phpV  ©t…iV  -4g­¤      C   phpunit/Runner/TestResult/Subscriber/ExecutionStartedSubscriber.php˜  ©t…i˜  XUÕ¤      3   phpunit/Runner/TestResult/Subscriber/Subscriber.php`  ©t…i`  T¹1{¤      F   phpunit/Runner/TestResult/Subscriber/TestConsideredRiskySubscriber.php\  ©t…i\  -ï½4¤      >   phpunit/Runner/TestResult/Subscriber/TestErroredSubscriber.php,  ©t…i,  ÿ;¦Ô¤      =   phpunit/Runner/TestResult/Subscriber/TestFailedSubscriber.php&  ©t…i&  ×0Ë¤      ?   phpunit/Runner/TestResult/Subscriber/TestFinishedSubscriber.php2  ©t…i2  Ş»İƒ¤      G   phpunit/Runner/TestResult/Subscriber/TestMarkedIncompleteSubscriber.phpb  ©t…ib  C•¬¿¤      ?   phpunit/Runner/TestResult/Subscriber/TestPreparedSubscriber.php,  ©t…i,  <Ú¸G¤      Q   phpunit/Runner/TestResult/Subscriber/TestRunnerTriggeredDeprecationSubscriber.php’  ©t…i’  šÅÍ<¤      L   phpunit/Runner/TestResult/Subscriber/TestRunnerTriggeredNoticeSubscriber.phpt  ©t…it  ‚½U"¤      M   phpunit/Runner/TestResult/Subscriber/TestRunnerTriggeredWarningSubscriber.phpz  ©t…iz  Ú+d¤      >   phpunit/Runner/TestResult/Subscriber/TestSkippedSubscriber.php,  ©t…i,  Û$ñ¤      D   phpunit/Runner/TestResult/Subscriber/TestSuiteFinishedSubscriber.phpF  ©t…iF  2Šá¼¤      C   phpunit/Runner/TestResult/Subscriber/TestSuiteSkippedSubscriber.php@  ©t…i@  OU&¤      C   phpunit/Runner/TestResult/Subscriber/TestSuiteStartedSubscriber.php@  ©t…i@  ƒˆi¤      K   phpunit/Runner/TestResult/Subscriber/TestTriggeredDeprecationSubscriber.phpz  ©t…iz  °|?¤      E   phpunit/Runner/TestResult/Subscriber/TestTriggeredErrorSubscriber.phpV  ©t…iV  ¶‘ï“¤      F   phpunit/Runner/TestResult/Subscriber/TestTriggeredNoticeSubscriber.php\  ©t…i\  ¡AU‹¤      N   phpunit/Runner/TestResult/Subscriber/TestTriggeredPhpDeprecationSubscriber.phpŒ  ©t…iŒ  B.XŞ¤      I   phpunit/Runner/TestResult/Subscriber/TestTriggeredPhpNoticeSubscriber.phpn  ©t…in  E…@¤      J   phpunit/Runner/TestResult/Subscriber/TestTriggeredPhpWarningSubscriber.phpt  ©t…it  ’ÈSÌ¤      R   phpunit/Runner/TestResult/Subscriber/TestTriggeredPhpunitDeprecationSubscriber.php¤  ©t…i¤  ù‘à/¤      L   phpunit/Runner/TestResult/Subscriber/TestTriggeredPhpunitErrorSubscriber.php€  ©t…i€  Ò)i2¤      M   phpunit/Runner/TestResult/Subscriber/TestTriggeredPhpunitNoticeSubscriber.php†  ©t…i†  lÆä¤      N   phpunit/Runner/TestResult/Subscriber/TestTriggeredPhpunitWarningSubscriber.phpŒ  ©t…iŒ  ,,ˆŒ¤      G   phpunit/Runner/TestResult/Subscriber/TestTriggeredWarningSubscriber.phpb  ©t…ib  Í8Ux¤      (   phpunit/Runner/TestResult/TestResult.php‘J  ©t…i‘J  ğ¸ôT¤      "   phpunit/Runner/TestSuiteLoader.php†  ©t…i†  Bï•¤      "   phpunit/Runner/TestSuiteSorter.php#  ©t…i#  Îª|¤         phpunit/Runner/Version.php.  ©t…i.  Y•Ï¤         phpunit/TextUI/Application.phpd  ©t…id  I·×É¤      "   phpunit/TextUI/Command/Command.phpH  ©t…iH  "Fò¤      9   phpunit/TextUI/Command/Commands/AtLeastVersionCommand.php5  ©t…i5  zĞ´¤      @   phpunit/TextUI/Command/Commands/CheckPhpConfigurationCommand.phpÑ  ©t…iÑ  ²n2ö¤      @   phpunit/TextUI/Command/Commands/GenerateConfigurationCommand.php#  ©t…i#  ã2® ¤      5   phpunit/TextUI/Command/Commands/ListGroupsCommand.php3  ©t…i3  ^Ø¤      8   phpunit/TextUI/Command/Commands/ListTestFilesCommand.php×  ©t…i×  eêj%¤      9   phpunit/TextUI/Command/Commands/ListTestSuitesCommand.php¦
+  ©t…i¦
+  *¶h¸¤      :   phpunit/TextUI/Command/Commands/ListTestsAsTextCommand.php$  ©t…i$  ŒeÏš¤      9   phpunit/TextUI/Command/Commands/ListTestsAsXmlCommand.phpg  ©t…ig  à+¤      ?   phpunit/TextUI/Command/Commands/MigrateConfigurationCommand.php  ©t…i  ¦—£#¤      3   phpunit/TextUI/Command/Commands/ShowHelpCommand.phpš  ©t…iš  ÿ§x¤      6   phpunit/TextUI/Command/Commands/ShowVersionCommand.phpÇ  ©t…iÇ  !n˜¤      7   phpunit/TextUI/Command/Commands/VersionCheckCommand.php]	  ©t…i]	  `}¤      @   phpunit/TextUI/Command/Commands/WarmCodeCoverageCacheCommand.phpÅ  ©t…iÅ  Ái¤      !   phpunit/TextUI/Command/Result.phpÍ  ©t…iÍ  P,0Š¤      0   phpunit/TextUI/Configuration/BootstrapLoader.phpr	  ©t…ir	  b,š£¤      (   phpunit/TextUI/Configuration/Builder.phpä  ©t…iä  ß• 5¤      ,   phpunit/TextUI/Configuration/Cli/Builder.phpZˆ  ©t…iZˆ  áØ¤      2   phpunit/TextUI/Configuration/Cli/Configuration.phpò ©t…iò ó\tw¤      .   phpunit/TextUI/Configuration/Cli/Exception.php[  ©t…i[  ¨æÎ'¤      ?   phpunit/TextUI/Configuration/Cli/XmlConfigurationFileFinder.phpÌ  ©t…iÌ  Dı±ü¤      ;   phpunit/TextUI/Configuration/CodeCoverageFilterRegistry.php¾  ©t…i¾  º™ò*¤      .   phpunit/TextUI/Configuration/Configuration.php¹  ©t…i¹  k’ê¤      O   phpunit/TextUI/Configuration/Exception/BootstrapScriptDoesNotExistException.php6  ©t…i6  Ö4Y¤      C   phpunit/TextUI/Configuration/Exception/BootstrapScriptException.php€  ©t…i€  {™’Ö¤      D   phpunit/TextUI/Configuration/Exception/CannotFindSchemaException.php’  ©t…i’  ¸«¢O¤      S   phpunit/TextUI/Configuration/Exception/CodeCoverageReportNotConfiguredException.php  ©t…i  ©ÙVF¤      N   phpunit/TextUI/Configuration/Exception/ConfigurationCannotBeBuiltException.php‹  ©t…i‹  6¯Õ¤      4   phpunit/TextUI/Configuration/Exception/Exception.php3  ©t…i3  ¿l´p¤      G   phpunit/TextUI/Configuration/Exception/FilterNotConfiguredException.php„  ©t…i„  ´]Ü9¤      H   phpunit/TextUI/Configuration/Exception/LoggingNotConfiguredException.php…  ©t…i…  N†¤      >   phpunit/TextUI/Configuration/Exception/NoBaselineException.php{  ©t…i{  %Iû¤      ?   phpunit/TextUI/Configuration/Exception/NoBootstrapException.php|  ©t…i|  eIÂæ¤      D   phpunit/TextUI/Configuration/Exception/NoCacheDirectoryException.php  ©t…i  ÍAŠ¤      G   phpunit/TextUI/Configuration/Exception/NoConfigurationFileException.php„  ©t…i„  ¡Ş@À¤      L   phpunit/TextUI/Configuration/Exception/NoCoverageCacheDirectoryException.php‰  ©t…i‰  æGt½¤      C   phpunit/TextUI/Configuration/Exception/NoCustomCssFileException.php€  ©t…i€  ¾İòÎ¤      F   phpunit/TextUI/Configuration/Exception/NoDefaultTestSuiteException.phpƒ  ©t…iƒ  àĞÃ¿¤      L   phpunit/TextUI/Configuration/Exception/NoPharExtensionDirectoryException.php‰  ©t…i‰  ™jÃ¤      C   phpunit/TextUI/Configuration/Exception/NoTestFilesFileException.php€  ©t…i€  ˆõ-õ¤      \   phpunit/TextUI/Configuration/Exception/SpecificDeprecationToStopOnNotConfiguredException.php™  ©t…i™  ì+Ì‡¤      '   phpunit/TextUI/Configuration/Merger.php	¦  ©t…i	¦  éø.¤      +   phpunit/TextUI/Configuration/PhpHandler.phpÉ  ©t…iÉ  à‘H¤      )   phpunit/TextUI/Configuration/Registry.phph  ©t…ih  ~Øó«¤      -   phpunit/TextUI/Configuration/SourceFilter.phpë  ©t…ië  Ü‚q¶¤      -   phpunit/TextUI/Configuration/SourceMapper.php„  ©t…i„  >sÊë¤      1   phpunit/TextUI/Configuration/TestSuiteBuilder.php  ©t…i  Íìwx¤      /   phpunit/TextUI/Configuration/Value/Constant.php-  ©t…i-  9âµ¤      9   phpunit/TextUI/Configuration/Value/ConstantCollection.php  ©t…i  š8ûÌ¤      A   phpunit/TextUI/Configuration/Value/ConstantCollectionIterator.phpY  ©t…iY  ÜBÏ¤      0   phpunit/TextUI/Configuration/Value/Directory.php‰  ©t…i‰  nÏØ%¤      :   phpunit/TextUI/Configuration/Value/DirectoryCollection.phpı  ©t…iı  Ûv|¤      B   phpunit/TextUI/Configuration/Value/DirectoryCollectionIterator.phpj  ©t…ij  '6¤      9   phpunit/TextUI/Configuration/Value/ExtensionBootstrap.php  ©t…i  „¤      C   phpunit/TextUI/Configuration/Value/ExtensionBootstrapCollection.php«  ©t…i«  ŒI¤      K   phpunit/TextUI/Configuration/Value/ExtensionBootstrapCollectionIterator.phpÇ  ©t…iÇ  DÒ9Æ¤      +   phpunit/TextUI/Configuration/Value/File.php  ©t…i  EÁğ¤      5   phpunit/TextUI/Configuration/Value/FileCollection.phpŸ  ©t…iŸ  %-Ã¤      =   phpunit/TextUI/Configuration/Value/FileCollectionIterator.php-  ©t…i-  (ÀÂ¤      6   phpunit/TextUI/Configuration/Value/FilterDirectory.phpY  ©t…iY  'Ùo‘¤      @   phpunit/TextUI/Configuration/Value/FilterDirectoryCollection.php3  ©t…i3  ÍJ±¤      H   phpunit/TextUI/Configuration/Value/FilterDirectoryCollectionIterator.phpˆ  ©t…iˆ  ĞÙa¿¤      ,   phpunit/TextUI/Configuration/Value/Group.php…  ©t…i…  šVÛ_¤      6   phpunit/TextUI/Configuration/Value/GroupCollection.php"  ©t…i"  5ÓnÛ¤      >   phpunit/TextUI/Configuration/Value/GroupCollectionIterator.php8  ©t…i8  <’	°¤      1   phpunit/TextUI/Configuration/Value/IniSetting.php   ©t…i   ­E¨Õ¤      ;   phpunit/TextUI/Configuration/Value/IniSettingCollection.php°  ©t…i°  ˆİn¤      C   phpunit/TextUI/Configuration/Value/IniSettingCollectionIterator.phpo  ©t…io  _»`n¤      *   phpunit/TextUI/Configuration/Value/Php.phpî  ©t…iî  ö¦«¤      -   phpunit/TextUI/Configuration/Value/Source.php=  ©t…i=  bIçå¤      4   phpunit/TextUI/Configuration/Value/TestDirectory.php‰  ©t…i‰  ©TÏ¤      >   phpunit/TextUI/Configuration/Value/TestDirectoryCollection.php  ©t…i  :Àë…¤      F   phpunit/TextUI/Configuration/Value/TestDirectoryCollectionIterator.php~  ©t…i~  ŸĞ…¤      /   phpunit/TextUI/Configuration/Value/TestFile.phpL  ©t…iL  ø—ìú¤      9   phpunit/TextUI/Configuration/Value/TestFileCollection.php¿  ©t…i¿  Æo¤      A   phpunit/TextUI/Configuration/Value/TestFileCollectionIterator.phpA  ©t…iA  PÙ6¤      0   phpunit/TextUI/Configuration/Value/TestSuite.phpŠ  ©t…iŠ  ùÇ»¤      :   phpunit/TextUI/Configuration/Value/TestSuiteCollection.phpô  ©t…iô  ‘dÎ‹¤      B   phpunit/TextUI/Configuration/Value/TestSuiteCollectionIterator.phpd  ©t…id  Í¸“¤      /   phpunit/TextUI/Configuration/Value/Variable.php«  ©t…i«  'z§3¤      9   phpunit/TextUI/Configuration/Value/VariableCollection.php  ©t…i  P]y¤      A   phpunit/TextUI/Configuration/Value/VariableCollectionIterator.phpY  ©t…iY  1cQH¤      >   phpunit/TextUI/Configuration/Xml/CodeCoverage/CodeCoverage.php€  ©t…i€   &¤      ?   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/Clover.php&  ©t…i&  á+­¤      B   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/Cobertura.php)  ©t…i)  ±‹ZÅ¤      ?   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/Crap4j.phpË  ©t…iË  âÌñ¤      =   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/Html.php  ©t…i  Ô{Oè¤      C   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/OpenClover.php*  ©t…i*  Õ	´/¤      <   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/Php.php#  ©t…i#  Hô3¤      =   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/Text.phpÎ  ©t…iÎ  VÉ^ƒ¤      <   phpunit/TextUI/Configuration/Xml/CodeCoverage/Report/Xml.php÷  ©t…i÷  xf„¤      2   phpunit/TextUI/Configuration/Xml/Configuration.php2  ©t…i2  ’”¤      9   phpunit/TextUI/Configuration/Xml/DefaultConfiguration.php]  ©t…i]  {}—u¤      .   phpunit/TextUI/Configuration/Xml/Exception.php_  ©t…i_  +øg3¤      .   phpunit/TextUI/Configuration/Xml/Generator.phpÏ  ©t…iÏ  bâ€¤      +   phpunit/TextUI/Configuration/Xml/Groups.php½  ©t…i½  mu’¤      @   phpunit/TextUI/Configuration/Xml/LoadedFromFileConfiguration.phpƒ  ©t…iƒ  aAÇr¤      +   phpunit/TextUI/Configuration/Xml/Loader.php#›  ©t…i#›  )éú¤      2   phpunit/TextUI/Configuration/Xml/Logging/Junit.php  ©t…i  OÙ¤      4   phpunit/TextUI/Configuration/Xml/Logging/Logging.php  ©t…i  Y8Œ•¤      0   phpunit/TextUI/Configuration/Xml/Logging/Otr.php  ©t…i  ±4.€¤      5   phpunit/TextUI/Configuration/Xml/Logging/TeamCity.php  ©t…i  &Sk¤      9   phpunit/TextUI/Configuration/Xml/Logging/TestDox/Html.php   ©t…i   *IòŒ¤      9   phpunit/TextUI/Configuration/Xml/Logging/TestDox/Text.php   ©t…i   ¬l¦¤      ?   phpunit/TextUI/Configuration/Xml/Migration/MigrationBuilder.phpƒ  ©t…iƒ  ıã9¤      A   phpunit/TextUI/Configuration/Xml/Migration/MigrationException.phpv  ©t…iv  Û[–r¤      I   phpunit/TextUI/Configuration/Xml/Migration/Migrations/ConvertLogTypes.php  ©t…i  < ëÙ¤      P   phpunit/TextUI/Configuration/Xml/Migration/Migrations/CoverageCloverToReport.phpË  ©t…iË  ³b5z¤      P   phpunit/TextUI/Configuration/Xml/Migration/Migrations/CoverageCrap4jToReport.php  ©t…i  ˆæ“¤      N   phpunit/TextUI/Configuration/Xml/Migration/Migrations/CoverageHtmlToReport.php  ©t…i  l;^©¤      M   phpunit/TextUI/Configuration/Xml/Migration/Migrations/CoveragePhpToReport.php¹  ©t…i¹  ™c'Ç¤      N   phpunit/TextUI/Configuration/Xml/Migration/Migrations/CoverageTextToReport.php  ©t…i  í*LĞ¤      M   phpunit/TextUI/Configuration/Xml/Migration/Migrations/CoverageXmlToReport.php¾  ©t…i¾  gºŠú¤      Z   phpunit/TextUI/Configuration/Xml/Migration/Migrations/IntroduceCacheDirectoryAttribute.phpĞ  ©t…iĞ  i¬"¤      R   phpunit/TextUI/Configuration/Xml/Migration/Migrations/IntroduceCoverageElement.phpU  ©t…iU  Fc¤      N   phpunit/TextUI/Configuration/Xml/Migration/Migrations/LogToReportMigration.php¬	  ©t…i¬	  CÜkí¤      C   phpunit/TextUI/Configuration/Xml/Migration/Migrations/Migration.php_  ©t…i_  *ÉŸ,¤      e   phpunit/TextUI/Configuration/Xml/Migration/Migrations/MoveAttributesFromFilterWhitelistToCoverage.php(  ©t…i(  ‘,«¤      Z   phpunit/TextUI/Configuration/Xml/Migration/Migrations/MoveAttributesFromRootToCoverage.phpù  ©t…iù  ["ı¤      Y   phpunit/TextUI/Configuration/Xml/Migration/Migrations/MoveCoverageDirectoriesToSource.php  ©t…i  *Vº¹¤      Y   phpunit/TextUI/Configuration/Xml/Migration/Migrations/MoveWhitelistExcludesToCoverage.php6	  ©t…i6	  !„À¤      Y   phpunit/TextUI/Configuration/Xml/Migration/Migrations/MoveWhitelistIncludesToCoverage.phpi  ©t…ii  )ìâ£¤      s   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveBeStrictAboutResourceUsageDuringSmallTestsAttribute.php  ©t…i  «ëÜ¤      h   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveBeStrictAboutTodoAnnotatedTestsAttribute.phpá  ©t…iá  P’ƒÅ¤      X   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveCacheResultFileAttribute.php±  ©t…i±  	1§¤      T   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveCacheTokensAttribute.php¥  ©t…i¥  1ªú¤      `   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveConversionToExceptionsAttributes.php€  ©t…i€  ¨:o¤      f   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveCoverageElementCacheDirectoryAttribute.phpı  ©t…iı  ¤ï¯ª¤      m   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveCoverageElementProcessUncoveredFilesAttribute.php  ©t…i  ì€>¤      K   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveEmptyFilter.phpî  ©t…iî  åRµƒ¤      I   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveListeners.php›  ©t…i›  Í'6ï¤      H   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveLogTypes.phpİ  ©t…iİ  ‡tRO¤      O   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveLoggingElements.php(  ©t…i(  '—¤      V   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveNoInteractionAttribute.php«  ©t…i«  n'°.¤      Q   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemovePrinterAttributes.php  ©t…i  ]ï2/¤      x   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveRegisterMockObjectsFromTestArgumentsRecursivelyAttribute.php  ©t…i  ¿ÕW¤      T   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveTestDoxGroupsElement.phpª  ©t…iª  ô×´š¤      Y   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveTestSuiteLoaderAttributes.php;  ©t…i;  )ó†¤      P   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RemoveVerboseAttribute.php™  ©t…i™  Õª”±¤      _   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RenameBackupStaticAttributesAttribute.php˜  ©t…i˜  "Zù¤      f   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RenameBeStrictAboutCoversAnnotationAttribute.phpÂ  ©t…iÂ  uÀË¤      ^   phpunit/TextUI/Configuration/Xml/Migration/Migrations/RenameForceCoversAnnotationAttribute.php–  ©t…i–  ƒ–¢U¤      k   phpunit/TextUI/Configuration/Xml/Migration/Migrations/ReplaceRestrictDeprecationsWithIgnoreDeprecations.php‰  ©t…i‰  t¯³7¤      N   phpunit/TextUI/Configuration/Xml/Migration/Migrations/UpdateSchemaLocation.phpÙ  ©t…iÙ  .P¦Ó¤      7   phpunit/TextUI/Configuration/Xml/Migration/Migrator.phpÑ  ©t…iÑ  Õ+§¼¤      ?   phpunit/TextUI/Configuration/Xml/Migration/SnapshotNodeList.php>  ©t…i>  ı+	¤      ,   phpunit/TextUI/Configuration/Xml/PHPUnit.phpB  ©t…iB  E}÷¤      O   phpunit/TextUI/Configuration/Xml/SchemaDetector/FailedSchemaDetectionResult.php}  ©t…i}  |¥€¤      I   phpunit/TextUI/Configuration/Xml/SchemaDetector/SchemaDetectionResult.php  ©t…i  (ù¯¤      B   phpunit/TextUI/Configuration/Xml/SchemaDetector/SchemaDetector.phpo  ©t…io  Ğc€ª¤      S   phpunit/TextUI/Configuration/Xml/SchemaDetector/SuccessfulSchemaDetectionResult.phpF  ©t…iF  kÚÎw¤      1   phpunit/TextUI/Configuration/Xml/SchemaFinder.phpy  ©t…iy  )}š3¤      4   phpunit/TextUI/Configuration/Xml/TestSuiteMapper.php<  ©t…i<  `gı£¤      ?   phpunit/TextUI/Configuration/Xml/Validator/ValidationResult.phpo  ©t…io  f²1¤      8   phpunit/TextUI/Configuration/Xml/Validator/Validator.phpù  ©t…iù  I‹ö`¤      6   phpunit/TextUI/Exception/CannotOpenSocketException.php  ©t…i  zçá¤      &   phpunit/TextUI/Exception/Exception.php$  ©t…i$  æ˜¤      3   phpunit/TextUI/Exception/InvalidSocketException.php  ©t…i  ÊI
+¤      -   phpunit/TextUI/Exception/RuntimeException.phpG  ©t…iG  ¾n	V¤      ;   phpunit/TextUI/Exception/TestDirectoryNotFoundException.php  ©t…i  HË²P¤      6   phpunit/TextUI/Exception/TestFileNotFoundException.phpş  ©t…iş  =ƒ|¤         phpunit/TextUI/Help.phprD  ©t…irD  ìqŒ?¤      A   phpunit/TextUI/Output/Default/ProgressPrinter/ProgressPrinter.php~4  ©t…i~4  N¹Åv¤      c   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/BeforeTestClassMethodErroredSubscriber.phpº  ©t…iº  PÏD×¤      Z   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/ChildProcessErroredSubscriber.phpt  ©t…it  ¸ O=¤      G   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/Subscriber.php¦  ©t…i¦  %¢¹ß¤      Z   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestConsideredRiskySubscriber.phpt  ©t…it  Üb¤      R   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestErroredSubscriber.phpJ  ©t…iJ  xmÇ¢¤      Q   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestFailedSubscriber.php>  ©t…i>  Y'¹‡¤      S   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestFinishedSubscriber.phpJ  ©t…iJ  zJ–é¤      [   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestMarkedIncompleteSubscriber.phpz  ©t…iz  Âjø\¤      S   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestPreparedSubscriber.phpJ  ©t…iJ  ùû¤      a   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestRunnerExecutionStartedSubscriber.php˜  ©t…i˜  ê¥j ¤      R   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestSkippedSubscriber.phpD  ©t…iD  …è¨š¤      W   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestSuiteSkippedSubscriber.phpt  ©t…it  ‘¨—e¤      _   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredDeprecationSubscriber.php˜  ©t…i˜  d¿Vé¤      Y   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredErrorSubscriber.phpt  ©t…it  y´‘Ñ¤      Z   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredNoticeSubscriber.phpz  ©t…iz  ­[¾Ó¤      b   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredPhpDeprecationSubscriber.phpª  ©t…iª  A”¤      ]   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredPhpNoticeSubscriber.phpŒ  ©t…iŒ  ¸•‚è¤      ^   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredPhpWarningSubscriber.php’  ©t…i’  ¦Ú+¤      f   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredPhpunitDeprecationSubscriber.php¼  ©t…i¼  ?ï>f¤      a   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredPhpunitNoticeSubscriber.php  ©t…i  ØMä¤      b   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredPhpunitWarningSubscriber.phpª  ©t…iª  ëuı¤      [   phpunit/TextUI/Output/Default/ProgressPrinter/Subscriber/TestTriggeredWarningSubscriber.php€  ©t…i€  ëİ´¤      /   phpunit/TextUI/Output/Default/ResultPrinter.phpxR  ©t…ixR  &7Õv¤      9   phpunit/TextUI/Output/Default/UnexpectedOutputPrinter.phpØ  ©t…iØ  qp‘¤          phpunit/TextUI/Output/Facade.php{#  ©t…i{#  2XO¤      0   phpunit/TextUI/Output/Printer/DefaultPrinter.phpˆ  ©t…iˆ  ¯"$¤      -   phpunit/TextUI/Output/Printer/NullPrinter.php§  ©t…i§  &W„ş¤      )   phpunit/TextUI/Output/Printer/Printer.php\  ©t…i\  gD“ß¤      (   phpunit/TextUI/Output/SummaryPrinter.phpÍ  ©t…iÍ  ”‰e¿¤      /   phpunit/TextUI/Output/TestDox/ResultPrinter.phpÛ1  ©t…iÛ1  °3¤      *   phpunit/TextUI/ShellExitCodeCalculator.phpF  ©t…iF  öë©å¤         phpunit/TextUI/TestRunner.php×  ©t…i×  m/$Ø¤      +   phpunit/TextUI/TestSuiteFilterProcessor.phpF
+  ©t…iF
+  œî5¶¤         phpunit/Util/Color.phpí  ©t…ií  M4“¤      $   phpunit/Util/Exception/Exception.php"  ©t…i"  ğ‘Ò¤      4   phpunit/Util/Exception/InvalidDirectoryException.php  ©t…i  ¦ç3¤      /   phpunit/Util/Exception/InvalidJsonException.php\  ©t…i\  ÷nt¤      :   phpunit/Util/Exception/InvalidVersionOperatorException.php  ©t…i  p2ïÙ¤      .   phpunit/Util/Exception/PhpProcessException.phpm  ©t…im  Z|¤      '   phpunit/Util/Exception/XmlException.phpf  ©t…if  Î;´Q¤         phpunit/Util/ExcludeList.php‘  ©t…i‘  {"Ş¤         phpunit/Util/Exporter.phpV  ©t…iV  ÔMRç¤         phpunit/Util/Filesystem.phpR  ©t…iR  ñ]â_¤         phpunit/Util/Filter.php¦  ©t…i¦  óu¤         phpunit/Util/GlobalState.php#  ©t…i#  ‰Â?¤          phpunit/Util/Http/Downloader.phpt  ©t…it  .Ø=Ã¤      #   phpunit/Util/Http/PhpDownloader.php  ©t…i  KÃ>Æ¤         phpunit/Util/Json.php  ©t…i  â¢o¤      %   phpunit/Util/PHP/DefaultJobRunner.php  ©t…i  —x¤         phpunit/Util/PHP/Job.php  ©t…i  QPğ¤         phpunit/Util/PHP/JobRunner.phpe  ©t…ie  É<pT¤      &   phpunit/Util/PHP/JobRunnerRegistry.phpc  ©t…ic  ğoÎò¤         phpunit/Util/PHP/Result.php~  ©t…i~  šsœB¤         phpunit/Util/Reflection.phpu  ©t…iu  .Ë¤         phpunit/Util/Test.phpˆ  ©t…iˆ  šnàÛ¤      (   phpunit/Util/ThrowableToStringMapper.php´  ©t…i´  Øø½Í¤      *   phpunit/Util/VersionComparisonOperator.php  ©t…i  Şâ«¤         phpunit/Util/Xml/Loader.php+	  ©t…i+	  4?CR¤         phpunit/Util/Xml/Xml.php…  ©t…i…  ¾dü¤         sbom.xml#  ©t…i#  ½wúñ¤         schema/10.0.xsd=  ©t…i=  |H¤         schema/10.1.xsd«B  ©t…i«B  Ü­r—¤         schema/10.2.xsdQE  ©t…iQE  ¸çÿn¤         schema/10.3.xsdF  ©t…iF  ›¶3&¤         schema/10.4.xsdGF  ©t…iGF  ?”ñÁ¤         schema/10.5.xsdÛG  ©t…iÛG  ÔaÈI¤         schema/11.0.xsdTF  ©t…iTF  ÷É?z¤         schema/11.1.xsd®H  ©t…i®H  !Êgè¤         schema/11.2.xsdH  ©t…iH  ëÍæ¤         schema/11.3.xsdyI  ©t…iyI  “ô¹¤         schema/11.4.xsd#I  ©t…i#I  î0$”¤         schema/11.5.xsdK  ©t…iK  sÄH±¤         schema/12.0.xsdzI  ©t…izI  fªGj¤         schema/12.1.xsdÛJ  ©t…iÛJ  Šºb¤         schema/12.2.xsdÒL  ©t…iÒL  s$˜¢¤         schema/12.3.xsdM  ©t…iM  Ê—>º¤         schema/12.4.xsdM  ©t…iM  Û¢ığ¤         schema/12.5.xsdXN  ©t…iXN  ç#õ¤         schema/8.5.xsdÓB  ©t…iÓB  2A[­¤         schema/9.0.xsd4B  ©t…i4B  •¨7w¤         schema/9.1.xsdÕB  ©t…iÕB  ßq'8¤         schema/9.2.xsdÜB  ©t…iÜB  c·Á-¤         schema/9.3.xsd¼E  ©t…i¼E  ¿ùq¤         schema/9.4.xsd
+F  ©t…i
+F  DOFI¤         schema/9.5.xsdDF  ©t…iDF  ûùs|¤         sebastian-cli-parser/LICENSEû  ©t…iû  ¬D¤         sebastian-cli-parser/Parser.phpÇ  ©t…iÇ  Ì’f’¤      <   sebastian-cli-parser/exceptions/AmbiguousOptionException.phpİ  ©t…iİ  +Mó…¤      -   sebastian-cli-parser/exceptions/Exception.phpy  ©t…iy  >€±¤      G   sebastian-cli-parser/exceptions/OptionDoesNotAllowArgumentException.phpc  ©t…ic  ŠRjY¤      J   sebastian-cli-parser/exceptions/RequiredOptionArgumentMissingException.phpl  ©t…il  zQ¢¤      :   sebastian-cli-parser/exceptions/UnknownOptionException.phpv  ©t…iv  ëÛÿä¤      (   sebastian-comparator/ArrayComparator.phpi  ©t…ii  cT±_¤      *   sebastian-comparator/ClosureComparator.phpI  ©t…iI  ~6 ¤      #   sebastian-comparator/Comparator.phpĞ  ©t…iĞ  'bŸ¤      *   sebastian-comparator/ComparisonFailure.php“  ©t…i“  ›‹ÕD¤      *   sebastian-comparator/DOMNodeComparator.php
 
-  EN„i
+  ©t…i
 
-  çz~¤      +   sebastian-comparator/DateTimeComparator.php–  EN„i–  A@7!¤      .   sebastian-comparator/EnumerationComparator.php§  EN„i§  †ß
-X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤          sebastian-comparator/Factory.phpÌ  EN„iÌ  à‚²¤         sebastian-comparator/LICENSEû  EN„iû  9fo¤      -   sebastian-comparator/MockObjectComparator.phpÿ  EN„iÿ  Â©~¤      )   sebastian-comparator/NumberComparator.php  EN„i  Êãı¤      *   sebastian-comparator/NumericComparator.phpâ  EN„iâ  ¢ÒO}¤      )   sebastian-comparator/ObjectComparator.phpY  EN„iY  Ö©è¤      +   sebastian-comparator/ResourceComparator.phpi  EN„ii  k€¢¤      )   sebastian-comparator/ScalarComparator.php›  EN„i›  ”’ü¤      3   sebastian-comparator/SplObjectStorageComparator.php  EN„i  ¯r÷p¤      '   sebastian-comparator/TypeComparator.phpm  EN„im  jÌ-¤      -   sebastian-comparator/exceptions/Exception.phpø  EN„iø  )d¹J¤      4   sebastian-comparator/exceptions/RuntimeException.php  EN„i  ¨âµï¤      #   sebastian-complexity/Calculator.php
-  EN„i
-  ä}V¤      .   sebastian-complexity/Complexity/Complexity.php  EN„i  w¸Š¤      8   sebastian-complexity/Complexity/ComplexityCollection.php8
-  EN„i8
-  ÍürÁ¤      @   sebastian-complexity/Complexity/ComplexityCollectionIterator.phpR  EN„iR  +ÂVù¤      ,   sebastian-complexity/Exception/Exception.phpz  EN„iz  È¬Ë¤      3   sebastian-complexity/Exception/RuntimeException.php‘  EN„i‘  ¼Ìé¤         sebastian-complexity/LICENSEû  EN„iû  z60¤      =   sebastian-complexity/Visitor/ComplexityCalculatingVisitor.php<  EN„i<  [»aï¤      G   sebastian-complexity/Visitor/CyclomaticComplexityCalculatingVisitor.phph  EN„ih  ¨µŸ®¤         sebastian-diff/Chunk.php„  EN„i„  ³Á	$¤         sebastian-diff/Diff.phpH  EN„iH  ƒ¯€æ¤         sebastian-diff/Differ.php§  EN„i§  ¼PŠİ¤      3   sebastian-diff/Exception/ConfigurationException.php,  EN„i,  û>tñ¤      &   sebastian-diff/Exception/Exception.phpn  EN„in  šÀ/\¤      5   sebastian-diff/Exception/InvalidArgumentException.php  EN„i  æ$y¤         sebastian-diff/LICENSEû  EN„iû  ^2Â¤         sebastian-diff/Line.php<  EN„i<  ïa ¤      5   sebastian-diff/LongestCommonSubsequenceCalculator.phpô  EN„iô  ep€6¤      D   sebastian-diff/MemoryEfficientLongestCommonSubsequenceCalculator.phpê  EN„iê  K˜º¤      4   sebastian-diff/Output/AbstractChunkOutputBuilder.php(  EN„i(  —¤      /   sebastian-diff/Output/DiffOnlyOutputBuilder.phpÕ  EN„iÕ  |í
-¤      4   sebastian-diff/Output/DiffOutputBuilderInterface.php  EN„i  pmö¤      8   sebastian-diff/Output/StrictUnifiedDiffOutputBuilder.php¨(  EN„i¨(  K¯L(¤      2   sebastian-diff/Output/UnifiedDiffOutputBuilder.php$  EN„i$   ¶s¢¤         sebastian-diff/Parser.php)  EN„i)  Pİ€M¤      B   sebastian-diff/TimeEfficientLongestCommonSubsequenceCalculator.phpç  EN„iç  i¢šØ¤      !   sebastian-environment/Console.phpÜ  EN„iÜ  „?+T¤         sebastian-environment/LICENSEû  EN„iû  ÀÉƒ¤      !   sebastian-environment/Runtime.phpâ  EN„iâ  õµ²µ¤         sebastian-exporter/Exporter.php21  EN„i21  ,p¤         sebastian-exporter/LICENSEû  EN„iû  ^2Â¤      '   sebastian-global-state/CodeExporter.php™	  EN„i™	  l¤¤      &   sebastian-global-state/ExcludeList.php  EN„i  Vÿeu¤         sebastian-global-state/LICENSEû  EN„iû  ‡lG¤      #   sebastian-global-state/Restorer.phpÁ  EN„iÁ  –ìŸ¨¤      #   sebastian-global-state/Snapshot.phpS-  EN„iS-  »¯âÈ¤      /   sebastian-global-state/exceptions/Exception.php}  EN„i}  ¶µâ´¤      6   sebastian-global-state/exceptions/RuntimeException.php”  EN„i”  #Ú™¤      #   sebastian-lines-of-code/Counter.phpå  EN„iå  jíª¤      /   sebastian-lines-of-code/Exception/Exception.php~  EN„i~  %>²ú¤      >   sebastian-lines-of-code/Exception/IllogicalValuesException.php®  EN„i®  Êårÿ¤      6   sebastian-lines-of-code/Exception/RuntimeException.php•  EN„i•  Ñ)Ï¹¤         sebastian-lines-of-code/LICENSEû  EN„iû  z60¤      /   sebastian-lines-of-code/LineCountingVisitor.phpï  EN„iï  òuóù¤      '   sebastian-lines-of-code/LinesOfCode.php|	  EN„i|	  LSèı¤      *   sebastian-object-enumerator/Enumerator.phpD  EN„iD  Ñ4õÂ¤      .   sebastian-object-reflector/ObjectReflector.phpû  EN„iû  ŸŸMl¤      '   sebastian-recursion-context/Context.phpX  EN„iX  ·:uë¤      #   sebastian-recursion-context/LICENSEû  EN„iû  ^2Â¤         sebastian-type/LICENSEû  EN„iû  Å‰±¤         sebastian-type/Parameter.php¦  EN„i¦  ÓòR7¤      #   sebastian-type/ReflectionMapper.php©  EN„i©  G™Ü¤         sebastian-type/TypeName.php=	  EN„i=	  `Y/m¤      &   sebastian-type/exception/Exception.phpä  EN„iä  }¥«¤      -   sebastian-type/exception/RuntimeException.phpû  EN„iû  Ãu†¤      $   sebastian-type/type/CallableType.php´  EN„i´  wRt\¤      !   sebastian-type/type/FalseType.phpÂ  EN„iÂ  ³X ]¤      )   sebastian-type/type/GenericObjectType.phpy  EN„iy  ‰#¸„¤      (   sebastian-type/type/IntersectionType.phpJ  EN„iJ  VÜD¤      $   sebastian-type/type/IterableType.phpI  EN„iI  Z«ŸÀ¤      !   sebastian-type/type/MixedType.php­  EN„i­  jÿ¦¤      !   sebastian-type/type/NeverType.php7  EN„i7  }‘š¤          sebastian-type/type/NullType.php§  EN„i§  #²n¤      "   sebastian-type/type/ObjectType.phpŒ  EN„iŒ  "Ç?Õ¤      "   sebastian-type/type/SimpleType.phpP  EN„iP  gË·»¤      "   sebastian-type/type/StaticType.php"  EN„i"  OaĞ³¤          sebastian-type/type/TrueType.php½  EN„i½  ,šiú¤         sebastian-type/type/Type.phpÍ  EN„iÍ   øe¤      !   sebastian-type/type/UnionType.phpæ  EN„iæ  ·Qbù¤      #   sebastian-type/type/UnknownType.phpŸ  EN„iŸ  yWk=¤          sebastian-type/type/VoidType.php3  EN„i3  õó¤         sebastian-version/LICENSEû  EN„iû  L0'¤         sebastian-version/Version.php 
-  EN„i 
-  êË´¤      $   staabm-side-effects-detector/LICENSE-  EN„i-  ßâj-¤      +   staabm-side-effects-detector/SideEffect.phpF  EN„iF   p×¤      4   staabm-side-effects-detector/SideEffectsDetector.phpÒ$  EN„iÒ$  ÅÌÅ©¤      1   staabm-side-effects-detector/functionMetadata.phpŸs EN„iŸs Ôä!s¤         theseer-tokenizer/Exception.phpr   EN„ir   ÊÂmœ¤         theseer-tokenizer/LICENSEü  EN„iü  ïR(¤      "   theseer-tokenizer/NamespaceUri.phps  EN„is  ¯cå²¤      +   theseer-tokenizer/NamespaceUriException.php}   EN„i}   aÕ“¤         theseer-tokenizer/Token.php—  EN„i—  K•`Â¤      %   theseer-tokenizer/TokenCollection.phpt  EN„it  ê»Ñ¤      .   theseer-tokenizer/TokenCollectionException.php€   EN„i€   5É¤         theseer-tokenizer/Tokenizer.php‚  EN„i‚  bä•¤      #   theseer-tokenizer/XMLSerializer.phpZ	  EN„iZ	  ”N5ô¤      {
+  çz~¤      +   sebastian-comparator/DateTimeComparator.php–  ©t…i–  A@7!¤      .   sebastian-comparator/EnumerationComparator.php§  ©t…i§  †ß
+X¤      ,   sebastian-comparator/ExceptionComparator.phpp  ©t…ip  0CW¤          sebastian-comparator/Factory.phpÌ  ©t…iÌ  à‚²¤         sebastian-comparator/LICENSEû  ©t…iû  9fo¤      -   sebastian-comparator/MockObjectComparator.phpÿ  ©t…iÿ  Â©~¤      )   sebastian-comparator/NumberComparator.phpj  ©t…ij  F(Ö¤      *   sebastian-comparator/NumericComparator.phpâ  ©t…iâ  ¢ÒO}¤      )   sebastian-comparator/ObjectComparator.phpY  ©t…iY  Ö©è¤      +   sebastian-comparator/ResourceComparator.phpi  ©t…ii  k€¢¤      )   sebastian-comparator/ScalarComparator.php›  ©t…i›  ”’ü¤      3   sebastian-comparator/SplObjectStorageComparator.php  ©t…i  ¯r÷p¤      '   sebastian-comparator/TypeComparator.phpm  ©t…im  jÌ-¤      -   sebastian-comparator/exceptions/Exception.phpø  ©t…iø  )d¹J¤      4   sebastian-comparator/exceptions/RuntimeException.php  ©t…i  ¨âµï¤      #   sebastian-complexity/Calculator.php
+  ©t…i
+  ä}V¤      .   sebastian-complexity/Complexity/Complexity.php  ©t…i  w¸Š¤      8   sebastian-complexity/Complexity/ComplexityCollection.php8
+  ©t…i8
+  íµÔD¤      @   sebastian-complexity/Complexity/ComplexityCollectionIterator.phpR  ©t…iR  +ÂVù¤      ,   sebastian-complexity/Exception/Exception.phpz  ©t…iz  È¬Ë¤      3   sebastian-complexity/Exception/RuntimeException.php‘  ©t…i‘  ¼Ìé¤         sebastian-complexity/LICENSEû  ©t…iû  ¬D¤      =   sebastian-complexity/Visitor/ComplexityCalculatingVisitor.php<  ©t…i<  [»aï¤      G   sebastian-complexity/Visitor/CyclomaticComplexityCalculatingVisitor.phph  ©t…ih  ¨µŸ®¤         sebastian-diff/Chunk.php„  ©t…i„  ³Á	$¤         sebastian-diff/Diff.phpH  ©t…iH  ƒ¯€æ¤         sebastian-diff/Differ.php~  ©t…i~  oıB¤      3   sebastian-diff/Exception/ConfigurationException.phpQ  ©t…iQ   ®¶T¤      &   sebastian-diff/Exception/Exception.phpn  ©t…in  šÀ/\¤         sebastian-diff/LICENSEû  ©t…iû  9fo¤         sebastian-diff/Line.php<  ©t…i<  ïa ¤      5   sebastian-diff/LongestCommonSubsequenceCalculator.phpô  ©t…iô  ep€6¤      D   sebastian-diff/MemoryEfficientLongestCommonSubsequenceCalculator.phpê  ©t…iê  K˜º¤      4   sebastian-diff/Output/AbstractChunkOutputBuilder.php(  ©t…i(  —¤      /   sebastian-diff/Output/DiffOnlyOutputBuilder.phpÕ  ©t…iÕ  |í
+¤      4   sebastian-diff/Output/DiffOutputBuilderInterface.php  ©t…i  pmö¤      8   sebastian-diff/Output/StrictUnifiedDiffOutputBuilder.phpı(  ©t…iı(  É–¤      2   sebastian-diff/Output/UnifiedDiffOutputBuilder.php¾  ©t…i¾  ?Ù}¤         sebastian-diff/Parser.phpÆ  ©t…iÆ  |·™¤      B   sebastian-diff/TimeEfficientLongestCommonSubsequenceCalculator.phpç  ©t…iç  i¢šØ¤      !   sebastian-environment/Console.phpŸ  ©t…iŸ  ¨»©¤         sebastian-environment/LICENSEû  ©t…iû  §ú»÷¤      !   sebastian-environment/Runtime.phpy  ©t…iy  MH~¤         sebastian-exporter/Exporter.php21  ©t…i21  ,p¤         sebastian-exporter/LICENSEû  ©t…iû  9fo¤      '   sebastian-global-state/CodeExporter.php™	  ©t…i™	  l¤¤      &   sebastian-global-state/ExcludeList.php  ©t…i  Vÿeu¤         sebastian-global-state/LICENSEû  ©t…iû  e´È3¤      #   sebastian-global-state/Restorer.phph  ©t…ih  Ï^o(¤      #   sebastian-global-state/Snapshot.phpS-  ©t…iS-  »¯âÈ¤      /   sebastian-global-state/exceptions/Exception.php}  ©t…i}  ¶µâ´¤      6   sebastian-global-state/exceptions/RuntimeException.php”  ©t…i”  #Ú™¤      #   sebastian-lines-of-code/Counter.phpä  ©t…iä  õd²®¤      /   sebastian-lines-of-code/Exception/Exception.php~  ©t…i~  %>²ú¤      >   sebastian-lines-of-code/Exception/IllogicalValuesException.php®  ©t…i®  Êårÿ¤      6   sebastian-lines-of-code/Exception/RuntimeException.php•  ©t…i•  Ñ)Ï¹¤         sebastian-lines-of-code/LICENSEû  ©t…iû  ¬D¤      /   sebastian-lines-of-code/LineCountingVisitor.phpï  ©t…iï  òuóù¤      '   sebastian-lines-of-code/LinesOfCode.php|	  ©t…i|	  LSèı¤      *   sebastian-object-enumerator/Enumerator.phpO  ©t…iO  'ßìX¤      .   sebastian-object-reflector/ObjectReflector.phpû  ©t…iû  ŸŸMl¤      '   sebastian-recursion-context/Context.phpX  ©t…iX  ·:uë¤      #   sebastian-recursion-context/LICENSEû  ©t…iû  9fo¤         sebastian-type/LICENSEû  ©t…iû  ¢ºj¤         sebastian-type/Parameter.php¦  ©t…i¦  ÓòR7¤      #   sebastian-type/ReflectionMapper.php©  ©t…i©  G™Ü¤         sebastian-type/TypeName.php=	  ©t…i=	  `Y/m¤      &   sebastian-type/exception/Exception.phpä  ©t…iä  }¥«¤      -   sebastian-type/exception/RuntimeException.phpû  ©t…iû  Ãu†¤      $   sebastian-type/type/CallableType.php´  ©t…i´  wRt\¤      !   sebastian-type/type/FalseType.phpÂ  ©t…iÂ  ³X ]¤      )   sebastian-type/type/GenericObjectType.phpy  ©t…iy  ‰#¸„¤      (   sebastian-type/type/IntersectionType.phpJ  ©t…iJ  VÜD¤      $   sebastian-type/type/IterableType.phpI  ©t…iI  Z«ŸÀ¤      !   sebastian-type/type/MixedType.php­  ©t…i­  jÿ¦¤      !   sebastian-type/type/NeverType.php7  ©t…i7  }‘š¤          sebastian-type/type/NullType.php§  ©t…i§  #²n¤      "   sebastian-type/type/ObjectType.phpŒ  ©t…iŒ  "Ç?Õ¤      "   sebastian-type/type/SimpleType.phpP  ©t…iP  gË·»¤      "   sebastian-type/type/StaticType.php"  ©t…i"  OaĞ³¤          sebastian-type/type/TrueType.php½  ©t…i½  ,šiú¤         sebastian-type/type/Type.phpÍ  ©t…iÍ   øe¤      !   sebastian-type/type/UnionType.php&  ©t…i&  _€â[¤      #   sebastian-type/type/UnknownType.phpŸ  ©t…iŸ  yWk=¤          sebastian-type/type/VoidType.php3  ©t…i3  õó¤         sebastian-version/LICENSEû  ©t…iû  +ƒz¤         sebastian-version/Version.php
+  ©t…i
+  ÎZ¦¤      $   staabm-side-effects-detector/LICENSE-  ©t…i-  ßâj-¤      +   staabm-side-effects-detector/SideEffect.phpF  ©t…iF   p×¤      4   staabm-side-effects-detector/SideEffectsDetector.phpÒ$  ©t…iÒ$  ÅÌÅ©¤      1   staabm-side-effects-detector/functionMetadata.phpŸs ©t…iŸs Ôä!s¤         theseer-tokenizer/Exception.phpr   ©t…ir   ÊÂmœ¤         theseer-tokenizer/LICENSEü  ©t…iü  ïR(¤      "   theseer-tokenizer/NamespaceUri.phps  ©t…is  ¯cå²¤      +   theseer-tokenizer/NamespaceUriException.php}   ©t…i}   aÕ“¤         theseer-tokenizer/Token.php—  ©t…i—  K•`Â¤      %   theseer-tokenizer/TokenCollection.phpt  ©t…it  ê»Ñ¤      .   theseer-tokenizer/TokenCollectionException.php€   ©t…i€   5É¤         theseer-tokenizer/Tokenizer.php‚  ©t…i‚  bä•¤      #   theseer-tokenizer/XMLSerializer.phpZ	  ©t…iZ	  ”N5ô¤      {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5416a369cfe5fccc42fb58ad3a1808e9",
+    "content-hash": "16b6d94b1a30fdaec500bd6f26e69a94",
     "packages": [
         {
             "name": "myclabs/deep-copy",
@@ -3642,16 +3669,16 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.2",
+            "version": "13.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "4a9739b51cbcb355f6e95659612f92e282a7077b"
+                "reference": "fde966eeb2a9dded5c3bec81650f97fd7abeda0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4a9739b51cbcb355f6e95659612f92e282a7077b",
-                "reference": "4a9739b51cbcb355f6e95659612f92e282a7077b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/fde966eeb2a9dded5c3bec81650f97fd7abeda0f",
+                "reference": "fde966eeb2a9dded5c3bec81650f97fd7abeda0f",
                 "shasum": ""
             },
             "require": {
@@ -3659,17 +3686,17 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^5.7.0",
-                "php": ">=8.3",
-                "phpunit/php-file-iterator": "^6.0",
-                "phpunit/php-text-template": "^5.0",
-                "sebastian/complexity": "^5.0",
-                "sebastian/environment": "^8.0.3",
-                "sebastian/lines-of-code": "^4.0",
-                "sebastian/version": "^6.0",
+                "php": ">=8.4",
+                "phpunit/php-file-iterator": "^7.0",
+                "phpunit/php-text-template": "^6.0",
+                "sebastian/complexity": "^6.0",
+                "sebastian/environment": "^9.0",
+                "sebastian/lines-of-code": "^5.0",
+                "sebastian/version": "^7.0",
                 "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.5.1"
+                "phpunit/phpunit": "^13.0"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -3678,7 +3705,7 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "12.5.x-dev"
+                    "dev-main": "13.0.x-dev"
                 }
             },
             "autoload": {
@@ -3707,7 +3734,7 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.2"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/13.0.0"
             },
             "funding": [
                 {
@@ -3727,32 +3754,32 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-24T07:03:04+00:00"
+            "time": "2026-02-06T04:53:55+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "6.0.1",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5"
+                "reference": "6e5aa1fb0a95b1703d83e721299ee18bb4e2de50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
-                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6e5aa1fb0a95b1703d83e721299ee18bb4e2de50",
+                "reference": "6e5aa1fb0a95b1703d83e721299ee18bb4e2de50",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -3780,7 +3807,7 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/7.0.0"
             },
             "funding": [
                 {
@@ -3800,28 +3827,28 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-02T14:04:18+00:00"
+            "time": "2026-02-06T04:33:26+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "6.0.0",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406"
+                "reference": "42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/12b54e689b07a25a9b41e57736dfab6ec9ae5406",
-                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88",
+                "reference": "42e5c5cae0c65df12d1b1a3ab52bf3f50f244d88",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -3829,7 +3856,7 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -3856,40 +3883,52 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
                 "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/6.0.0"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/7.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-invoker",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:58:58+00:00"
+            "time": "2026-02-06T04:34:47+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "5.0.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53"
+                "reference": "a47af19f93f76aa3368303d752aa5272ca3299f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/e1367a453f0eda562eedb4f659e13aa900d66c53",
-                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/a47af19f93f76aa3368303d752aa5272ca3299f4",
+                "reference": "a47af19f93f76aa3368303d752aa5272ca3299f4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3916,40 +3955,52 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
                 "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/5.0.0"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/6.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-text-template",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:59:16+00:00"
+            "time": "2026-02-06T04:36:37+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "8.0.0",
+            "version": "9.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc"
+                "reference": "a0e12065831f6ab0d83120dc61513eb8d9a966f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
-                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/a0e12065831f6ab0d83120dc61513eb8d9a966f6",
+                "reference": "a0e12065831f6ab0d83120dc61513eb8d9a966f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.0-dev"
+                    "dev-main": "9.0-dev"
                 }
             },
             "autoload": {
@@ -3976,40 +4027,52 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
                 "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/8.0.0"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/9.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-timer",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:59:38+00:00"
+            "time": "2026-02-06T04:37:53+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "4.2.0",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04"
+                "reference": "48a4654fa5e48c1c81214e9930048a572d4b23ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/90f41072d220e5c40df6e8635f5dafba2d9d4d04",
-                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/48a4654fa5e48c1c81214e9930048a572d4b23ca",
+                "reference": "48a4654fa5e48c1c81214e9930048a572d4b23ca",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.2-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4033,7 +4096,7 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.0"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/5.0.0"
             },
             "funding": [
                 {
@@ -4053,31 +4116,31 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-14T09:36:45+00:00"
+            "time": "2026-02-06T04:39:44+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "7.1.4",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "6a7de5df2e094f9a80b40a522391a7e6022df5f6"
+                "reference": "29b232ddc29c2b114c0358c69b3084e7c3da0d58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a7de5df2e094f9a80b40a522391a7e6022df5f6",
-                "reference": "6a7de5df2e094f9a80b40a522391a7e6022df5f6",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/29b232ddc29c2b114c0358c69b3084e7c3da0d58",
+                "reference": "29b232ddc29c2b114c0358c69b3084e7c3da0d58",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
-                "php": ">=8.3",
-                "sebastian/diff": "^7.0",
-                "sebastian/exporter": "^7.0"
+                "php": ">=8.4",
+                "sebastian/diff": "^8.0",
+                "sebastian/exporter": "^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.2"
+                "phpunit/phpunit": "^13.0"
             },
             "suggest": {
                 "ext-bcmath": "For comparing BcMath\\Number objects"
@@ -4085,7 +4148,7 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.1-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -4125,7 +4188,7 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.4"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/8.0.0"
             },
             "funding": [
                 {
@@ -4145,33 +4208,33 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:28:48+00:00"
+            "time": "2026-02-06T04:40:39+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "5.0.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb"
+                "reference": "c5651c795c98093480df79350cb050813fc7a2f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/bad4316aba5303d0221f43f8cee37eb58d384bbb",
-                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/c5651c795c98093480df79350cb050813fc7a2f3",
+                "reference": "c5651c795c98093480df79350cb050813fc7a2f3",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^5.0",
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -4195,41 +4258,53 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/5.0.0"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/6.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/complexity",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:55:25+00:00"
+            "time": "2026-02-06T04:41:32+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "7.0.0",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
+                "reference": "a2b6d09d7729ee87d605a439469f9dcc39be5ea3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
-                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/a2b6d09d7729ee87d605a439469f9dcc39be5ea3",
+                "reference": "a2b6d09d7729ee87d605a439469f9dcc39be5ea3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0",
+                "phpunit/phpunit": "^13.0",
                 "symfony/process": "^7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -4262,35 +4337,47 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
+                "source": "https://github.com/sebastianbergmann/diff/tree/8.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/diff",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:55:46+00:00"
+            "time": "2026-02-06T04:42:27+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "8.0.3",
+            "version": "9.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68"
+                "reference": "bb64d08145b021b67d5f253308a498b73ab0461e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
-                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/bb64d08145b021b67d5f253308a498b73ab0461e",
+                "reference": "bb64d08145b021b67d5f253308a498b73ab0461e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -4298,7 +4385,7 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.0-dev"
+                    "dev-main": "9.0-dev"
                 }
             },
             "autoload": {
@@ -4326,7 +4413,7 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.3"
+                "source": "https://github.com/sebastianbergmann/environment/tree/9.0.0"
             },
             "funding": [
                 {
@@ -4346,34 +4433,34 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-12T14:11:56+00:00"
+            "time": "2026-02-06T04:43:29+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "7.0.2",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "016951ae10980765e4e7aee491eb288c64e505b7"
+                "reference": "dc31f1f8e0186c8f0bb3e48fd4d51421d8905fea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/016951ae10980765e4e7aee491eb288c64e505b7",
-                "reference": "016951ae10980765e4e7aee491eb288c64e505b7",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/dc31f1f8e0186c8f0bb3e48fd4d51421d8905fea",
+                "reference": "dc31f1f8e0186c8f0bb3e48fd4d51421d8905fea",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.3",
-                "sebastian/recursion-context": "^7.0"
+                "php": ">=8.4",
+                "sebastian/recursion-context": "^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -4416,7 +4503,7 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/8.0.0"
             },
             "funding": [
                 {
@@ -4436,35 +4523,35 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:16:11+00:00"
+            "time": "2026-02-06T04:44:28+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "8.0.2",
+            "version": "9.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "ef1377171613d09edd25b7816f05be8313f9115d"
+                "reference": "e52e3dc22441e6218c710afe72c3042f8fc41ea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ef1377171613d09edd25b7816f05be8313f9115d",
-                "reference": "ef1377171613d09edd25b7816f05be8313f9115d",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e52e3dc22441e6218c710afe72c3042f8fc41ea7",
+                "reference": "e52e3dc22441e6218c710afe72c3042f8fc41ea7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3",
-                "sebastian/object-reflector": "^5.0",
-                "sebastian/recursion-context": "^7.0"
+                "php": ">=8.4",
+                "sebastian/object-reflector": "^6.0",
+                "sebastian/recursion-context": "^8.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.0-dev"
+                    "dev-main": "9.0-dev"
                 }
             },
             "autoload": {
@@ -4490,7 +4577,7 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/9.0.0"
             },
             "funding": [
                 {
@@ -4510,33 +4597,33 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-29T11:29:25+00:00"
+            "time": "2026-02-06T04:45:13+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "4.0.0",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f"
+                "reference": "4f21bb7768e1c997722ccc7efb1d6b5c11bfd471"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/97ffee3bcfb5805568d6af7f0f893678fc076d2f",
-                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/4f21bb7768e1c997722ccc7efb1d6b5c11bfd471",
+                "reference": "4f21bb7768e1c997722ccc7efb1d6b5c11bfd471",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^5.0",
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4560,42 +4647,54 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.0"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/5.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/lines-of-code",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:57:28+00:00"
+            "time": "2026-02-06T04:45:54+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "7.0.0",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894"
+                "reference": "b39ab125fd9a7434b0ecbc4202eebce11a98cfc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1effe8e9b8e068e9ae228e542d5d11b5d16db894",
-                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/b39ab125fd9a7434b0ecbc4202eebce11a98cfc5",
+                "reference": "b39ab125fd9a7434b0ecbc4202eebce11a98cfc5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3",
-                "sebastian/object-reflector": "^5.0",
-                "sebastian/recursion-context": "^7.0"
+                "php": ">=8.4",
+                "sebastian/object-reflector": "^6.0",
+                "sebastian/recursion-context": "^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -4618,40 +4717,52 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
                 "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/7.0.0"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/8.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/object-enumerator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:57:48+00:00"
+            "time": "2026-02-06T04:46:36+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "5.0.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "4bfa827c969c98be1e527abd576533293c634f6a"
+                "reference": "3ca042c2c60b0eab094f8a1b6a7093f4d4c72200"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/4bfa827c969c98be1e527abd576533293c634f6a",
-                "reference": "4bfa827c969c98be1e527abd576533293c634f6a",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/3ca042c2c60b0eab094f8a1b6a7093f4d4c72200",
+                "reference": "3ca042c2c60b0eab094f8a1b6a7093f4d4c72200",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -4674,40 +4785,52 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
                 "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/5.0.0"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/6.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/object-reflector",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:58:17+00:00"
+            "time": "2026-02-06T04:47:13+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "7.0.1",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
+                "reference": "74c5af21f6a5833e91767ca068c4d3dfec15317e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
-                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/74c5af21f6a5833e91767ca068c4d3dfec15317e",
+                "reference": "74c5af21f6a5833e91767ca068c4d3dfec15317e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -4738,7 +4861,7 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
                 "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/8.0.0"
             },
             "funding": [
                 {
@@ -4758,32 +4881,32 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T04:44:59+00:00"
+            "time": "2026-02-06T04:51:28+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "6.0.3",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d"
+                "reference": "42412224607bd3931241bbd17f38e0f972f5a916"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/e549163b9760b8f71f191651d22acf32d56d6d4d",
-                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/42412224607bd3931241bbd17f38e0f972f5a916",
+                "reference": "42412224607bd3931241bbd17f38e0f972f5a916",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^13.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -4807,7 +4930,7 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/6.0.3"
+                "source": "https://github.com/sebastianbergmann/type/tree/7.0.0"
             },
             "funding": [
                 {
@@ -4827,29 +4950,29 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-09T06:57:12+00:00"
+            "time": "2026-02-06T04:52:09+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "6.0.0",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c"
+                "reference": "ad37a5552c8e2b88572249fdc19b6da7792e021b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3e6ccf7657d4f0a59200564b08cead899313b53c",
-                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/ad37a5552c8e2b88572249fdc19b6da7792e021b",
+                "reference": "ad37a5552c8e2b88572249fdc19b6da7792e021b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": ">=8.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -4873,15 +4996,27 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
                 "security": "https://github.com/sebastianbergmann/version/security/policy",
-                "source": "https://github.com/sebastianbergmann/version/tree/6.0.0"
+                "source": "https://github.com/sebastianbergmann/version/tree/7.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/version",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T05:00:38+00:00"
+            "time": "2026-02-06T04:52:52+00:00"
         },
         {
             "name": "staabm/side-effects-detector",
@@ -4993,7 +5128,7 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.3",
+        "php": ">=8.4.1",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",
@@ -5003,33 +5138,33 @@ X¤      ,   sebastian-comparator/ExceptionComparator.phpp  EN„ip  0CW¤     
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.3.0"
+        "php": "8.4.1"
     },
     "plugin-api-version": "2.9.0"
 }
-phpunit/phpunit: 12.5.9
+phpunit/phpunit: 13.0.0
 myclabs/deep-copy: 1.13.4
 nikic/php-parser: v5.7.0
 phar-io/manifest: 2.0.4
 phar-io/version: 3.2.1
-phpunit/php-code-coverage: 12.5.2
-phpunit/php-file-iterator: 6.0.1
-phpunit/php-invoker: 6.0.0
-phpunit/php-text-template: 5.0.0
-phpunit/php-timer: 8.0.0
-sebastian/cli-parser: 4.2.0
-sebastian/comparator: 7.1.4
-sebastian/complexity: 5.0.0
-sebastian/diff: 7.0.0
-sebastian/environment: 8.0.3
-sebastian/exporter: 7.0.2
-sebastian/global-state: 8.0.2
-sebastian/lines-of-code: 4.0.0
-sebastian/object-enumerator: 7.0.0
-sebastian/object-reflector: 5.0.0
-sebastian/recursion-context: 7.0.1
-sebastian/type: 6.0.3
-sebastian/version: 6.0.0
+phpunit/php-code-coverage: 13.0.0
+phpunit/php-file-iterator: 7.0.0
+phpunit/php-invoker: 7.0.0
+phpunit/php-text-template: 6.0.0
+phpunit/php-timer: 9.0.0
+sebastian/cli-parser: 5.0.0
+sebastian/comparator: 8.0.0
+sebastian/complexity: 6.0.0
+sebastian/diff: 8.0.0
+sebastian/environment: 9.0.0
+sebastian/exporter: 8.0.0
+sebastian/global-state: 9.0.0
+sebastian/lines-of-code: 5.0.0
+sebastian/object-enumerator: 8.0.0
+sebastian/object-reflector: 6.0.0
+sebastian/recursion-context: 8.0.0
+sebastian/type: 7.0.0
+sebastian/version: 7.0.0
 staabm/side-effects-detector: 1.0.5
 theseer/tokenizer: 2.0.1
 <?php
@@ -25281,7 +25416,7 @@ if (!\function_exists('PHPUnitPHAR\PhpParser\defineCompatibilityTokens')) {
 }
 BSD 3-Clause License
 
-Copyright (c) 2016-2025, Sebastian Bergmann
+Copyright (c) 2016-2026, Sebastian Bergmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -25310,7 +25445,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 BSD 3-Clause License
 
-Copyright (c) 2017-2025, Sebastian Bergmann
+Copyright (c) 2017-2026, Sebastian Bergmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -30339,7 +30474,7 @@ final class Filter
 }
 BSD 3-Clause License
 
-Copyright (c) 2009-2025, Sebastian Bergmann
+Copyright (c) 2009-2026, Sebastian Bergmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -35138,16 +35273,16 @@ use function strlen;
 use PHPUnitPHAR\SebastianBergmann\CodeCoverage\CodeCoverage;
 use PHPUnitPHAR\SebastianBergmann\CodeCoverage\Node\File;
 use PHPUnitPHAR\SebastianBergmann\CodeCoverage\Util\Percentage;
-final class Text
+final readonly class Text
 {
     private const string COLOR_GREEN = "\x1b[30;42m";
     private const string COLOR_YELLOW = "\x1b[30;43m";
     private const string COLOR_RED = "\x1b[37;41m";
     private const string COLOR_HEADER = "\x1b[1;37;40m";
     private const string COLOR_RESET = "\x1b[0m";
-    private readonly Thresholds $thresholds;
-    private readonly bool $showUncoveredFiles;
-    private readonly bool $showOnlySummary;
+    private Thresholds $thresholds;
+    private bool $showUncoveredFiles;
+    private bool $showOnlySummary;
     public function __construct(Thresholds $thresholds, bool $showUncoveredFiles = \false, bool $showOnlySummary = \false)
     {
         $this->thresholds = $thresholds;
@@ -35178,7 +35313,7 @@ final class Text
             $branches = sprintf('  Branches:   %6s (%d/%d)', Percentage::fromFractionAndTotal($report->numberOfExecutedBranches(), $report->numberOfExecutableBranches())->asString(), $report->numberOfExecutedBranches(), $report->numberOfExecutableBranches());
         }
         $lines = sprintf('  Lines:   %6s (%d/%d)', Percentage::fromFractionAndTotal($report->numberOfExecutedLines(), $report->numberOfExecutableLines())->asString(), $report->numberOfExecutedLines(), $report->numberOfExecutableLines());
-        $padding = max(array_map('strlen', [$classes, $methods, $lines]));
+        $padding = max(array_map(strlen(...), [$classes, $methods, $lines]));
         if ($this->showOnlySummary) {
             $title = 'Code Coverage Report Summary:';
             $padding = max($padding, strlen($title));
@@ -35390,10 +35525,10 @@ use XMLWriter;
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-code-coverage
  */
-final class Coverage
+final readonly class Coverage
 {
-    private readonly XMLWriter $xmlWriter;
-    private readonly string $line;
+    private XMLWriter $xmlWriter;
+    private string $line;
     public function __construct(XMLWriter $xmlWriter, string $line)
     {
         $this->xmlWriter = $xmlWriter;
@@ -39558,7 +39693,7 @@ final class Version
     public static function id(): string
     {
         if (self::$version === '') {
-            self::$version = (new VersionId('12.5.2', dirname(__DIR__)))->asString();
+            self::$version = (new VersionId('13.0.0', dirname(__DIR__)))->asString();
         }
         return self::$version;
     }
@@ -39576,6 +39711,7 @@ declare (strict_types=1);
  */
 namespace PHPUnitPHAR\SebastianBergmann\FileIterator;
 
+use function array_all;
 use function assert;
 use function str_starts_with;
 use RecursiveDirectoryIterator;
@@ -39606,12 +39742,7 @@ final class ExcludeIterator extends RecursiveFilterIterator
         if ($path === \false) {
             return \false;
         }
-        foreach ($this->exclude as $exclude) {
-            if (str_starts_with($path, $exclude)) {
-                return \false;
-            }
-        }
-        return \true;
+        return array_all($this->exclude, static fn(string $exclude) => !str_starts_with($path, $exclude));
     }
     public function hasChildren(): bool
     {
@@ -39758,7 +39889,8 @@ final class Factory
         $_paths = [[]];
         foreach ($paths as $path) {
             $pathEndsWithDirectorySeparator = str_ends_with($path, '/') || str_ends_with($path, DIRECTORY_SEPARATOR);
-            if ($locals = $this->globstar($path)) {
+            $locals = $this->globstar($path);
+            if ($locals !== []) {
                 $_paths[] = array_map(static function (string $local) use ($pathEndsWithDirectorySeparator): string|false {
                     $realPath = realpath($local);
                     if ($realPath !== \false && $pathEndsWithDirectorySeparator && is_dir($realPath)) {
@@ -39828,6 +39960,7 @@ declare (strict_types=1);
  */
 namespace PHPUnitPHAR\SebastianBergmann\FileIterator;
 
+use function array_any;
 use function preg_match;
 use function realpath;
 use function str_ends_with;
@@ -39900,12 +40033,7 @@ final class Iterator extends FilterIterator
         if ($subStrings === []) {
             return \true;
         }
-        foreach ($subStrings as $string) {
-            if ($type === self::PREFIX && str_starts_with($filename, $string) || $type === self::SUFFIX && str_ends_with($filename, $string)) {
-                return \true;
-            }
-        }
-        return \false;
+        return array_any($subStrings, static fn(string $string) => $type === self::PREFIX && str_starts_with($filename, $string) || $type === self::SUFFIX && str_ends_with($filename, $string));
     }
 }
 BSD 3-Clause License
@@ -40063,7 +40191,7 @@ final class TimeoutException extends RuntimeException implements Exception
 }
 BSD 3-Clause License
 
-Copyright (c) 2009-2025, Sebastian Bergmann
+Copyright (c) 2009-2026, Sebastian Bergmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -40147,7 +40275,7 @@ final class Template
      */
     public function setVar(array $values, bool $merge = \true): void
     {
-        if (!$merge || empty($this->values)) {
+        if (!$merge || $this->values === []) {
             $this->values = $values;
             return;
         }
@@ -40166,7 +40294,7 @@ final class Template
      */
     public function renderTo(string $target): void
     {
-        if (!@file_put_contents($target, $this->render())) {
+        if (@file_put_contents($target, $this->render()) === \false) {
             throw new RuntimeException(sprintf('Writing rendered result to "%s" failed', $target));
         }
     }
@@ -40181,14 +40309,14 @@ final class Template
     {
         if (is_file($file)) {
             $template = file_get_contents($file);
-            if (is_string($template) && !empty($template)) {
+            if (is_string($template) && $template !== '') {
                 return $template;
             }
         }
         $distFile = $file . '.dist';
         if (is_file($distFile)) {
             $template = file_get_contents($distFile);
-            if (is_string($template) && !empty($template)) {
+            if (is_string($template) && $template !== '') {
                 return $template;
             }
         }
@@ -40326,7 +40454,7 @@ final readonly class Duration
 }
 BSD 3-Clause License
 
-Copyright (c) 2010-2025, Sebastian Bergmann
+Copyright (c) 2010-2026, Sebastian Bergmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -40435,7 +40563,7 @@ final class Timer
      */
     public function stop(): Duration
     {
-        if (empty($this->startTimes)) {
+        if ($this->startTimes === []) {
             throw new NoActiveTimerException('Timer::start() has to be called before Timer::stop()');
         }
         return Duration::fromNanoseconds((float) hrtime(\true) - array_pop($this->startTimes));
@@ -40496,7 +40624,7 @@ final class TimeSinceStartOfRequestNotAvailableException extends RuntimeExceptio
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:annotation>
         <xs:documentation source="https://phpunit.de/documentation.html">
-            This Schema file defines the rules by which the XML configuration file of PHPUnit 12.5 may be structured.
+            This Schema file defines the rules by which the XML configuration file of PHPUnit 13.0 may be structured.
         </xs:documentation>
         <xs:appinfo source="https://phpunit.de/documentation.html"/>
     </xs:annotation>
@@ -40673,6 +40801,7 @@ final class TimeSinceStartOfRequestNotAvailableException extends RuntimeExceptio
         <xs:attribute name="controlGarbageCollector" type="xs:boolean" default="false"/>
         <xs:attribute name="numberOfTestsBeforeGarbageCollection" type="xs:integer" default="100"/>
         <xs:attribute name="requireCoverageMetadata" type="xs:boolean" default="false"/>
+        <xs:attribute name="requireSealedMockObjects" type="xs:boolean" default="false"/>
         <xs:attribute name="processIsolation" type="xs:boolean" default="false"/>
         <xs:attribute name="failOnAllIssues" type="xs:boolean" default="false"/>
         <xs:attribute name="failOnDeprecation" type="xs:boolean" default="false"/>
@@ -41461,6 +41590,10 @@ final class DispatchingEmitter implements \PHPUnit\Event\Emitter
     {
         $this->dispatcher->dispatch(new \PHPUnit\Event\Test\ComparatorRegistered($this->telemetryInfo(), $className));
     }
+    public function testUsedCustomMethodInvocation(TestMethod $test, ClassMethod $customTestMethodInvocation): void
+    {
+        $this->dispatcher->dispatch(new \PHPUnit\Event\Test\CustomTestMethodInvocationUsed($this->telemetryInfo(), $test, $customTestMethodInvocation));
+    }
     /**
      * @param class-string $className
      *
@@ -42048,6 +42181,7 @@ interface Emitter
      * @param class-string<Comparator> $className
      */
     public function testRegisteredComparator(string $className): void;
+    public function testUsedCustomMethodInvocation(TestMethod $test, ClassMethod $customTestMethodInvocation): void;
     /**
      * @param class-string $className
      */
@@ -42432,7 +42566,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\Event;
 
-use function count;
 use Iterator;
 /**
  * @template-implements Iterator<non-negative-int, Event>
@@ -42459,7 +42592,7 @@ final class EventCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->events);
+        return isset($this->events[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -42637,6 +42770,80 @@ use PHPUnit\Event\Subscriber;
 interface ComparatorRegisteredSubscriber extends Subscriber
 {
     public function notify(\PHPUnit\Event\Test\ComparatorRegistered $event): void;
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\Test;
+
+use function sprintf;
+use PHPUnit\Event\Code;
+use PHPUnit\Event\Event;
+use PHPUnit\Event\Telemetry;
+/**
+ * @immutable
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final readonly class CustomTestMethodInvocationUsed implements Event
+{
+    private Telemetry\Info $telemetryInfo;
+    private Code\TestMethod $test;
+    private Code\ClassMethod $customTestMethodInvocation;
+    public function __construct(Telemetry\Info $telemetryInfo, Code\TestMethod $test, Code\ClassMethod $customTestMethodInvocation)
+    {
+        $this->telemetryInfo = $telemetryInfo;
+        $this->test = $test;
+        $this->customTestMethodInvocation = $customTestMethodInvocation;
+    }
+    public function telemetryInfo(): Telemetry\Info
+    {
+        return $this->telemetryInfo;
+    }
+    public function test(): Code\TestMethod
+    {
+        return $this->test;
+    }
+    public function customTestMethodInvocation(): Code\ClassMethod
+    {
+        return $this->customTestMethodInvocation;
+    }
+    /**
+     * @return non-empty-string
+     */
+    public function asString(): string
+    {
+        return sprintf('Custom Test Method Invocation Used (%s::%s)', $this->customTestMethodInvocation->className(), $this->customTestMethodInvocation->methodName());
+    }
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Event\Test;
+
+use PHPUnit\Event\Subscriber;
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+interface CustomTestMethodInvocationUsedSubscriber extends Subscriber
+{
+    public function notify(\PHPUnit\Event\Test\CustomTestMethodInvocationUsed $event): void;
 }
 <?php
 
@@ -43050,15 +43257,6 @@ final readonly class AfterTestMethodCalled implements Event
     {
         return $this->test;
     }
-    /**
-     * @return class-string
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
-     */
-    public function testClassName(): string
-    {
-        return $this->test->className();
-    }
     public function calledMethod(): Code\ClassMethod
     {
         return $this->calledMethod;
@@ -43136,15 +43334,6 @@ final readonly class AfterTestMethodErrored implements Event
     public function test(): Code\TestMethod
     {
         return $this->test;
-    }
-    /**
-     * @return class-string
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
-     */
-    public function testClassName(): string
-    {
-        return $this->test->className();
     }
     public function calledMethod(): Code\ClassMethod
     {
@@ -43317,15 +43506,6 @@ final readonly class AfterTestMethodFinished implements Event
     public function test(): Code\TestMethod
     {
         return $this->test;
-    }
-    /**
-     * @return class-string
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
-     */
-    public function testClassName(): string
-    {
-        return $this->test->className();
     }
     /**
      * @return list<Code\ClassMethod>
@@ -43779,15 +43959,6 @@ final readonly class BeforeTestMethodCalled implements Event
     {
         return $this->test;
     }
-    /**
-     * @return class-string
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
-     */
-    public function testClassName(): string
-    {
-        return $this->test->className();
-    }
     public function calledMethod(): Code\ClassMethod
     {
         return $this->calledMethod;
@@ -43865,15 +44036,6 @@ final readonly class BeforeTestMethodErrored implements Event
     public function test(): Code\TestMethod
     {
         return $this->test;
-    }
-    /**
-     * @return class-string
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
-     */
-    public function testClassName(): string
-    {
-        return $this->test->className();
     }
     public function calledMethod(): Code\ClassMethod
     {
@@ -44048,15 +44210,6 @@ final readonly class BeforeTestMethodFinished implements Event
         return $this->test;
     }
     /**
-     * @return class-string
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
-     */
-    public function testClassName(): string
-    {
-        return $this->test->className();
-    }
-    /**
      * @return list<Code\ClassMethod>
      */
     public function calledMethods(): array
@@ -44137,15 +44290,6 @@ final readonly class PostConditionCalled implements Event
     {
         return $this->test;
     }
-    /**
-     * @return class-string
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
-     */
-    public function testClassName(): string
-    {
-        return $this->test->className();
-    }
     public function calledMethod(): Code\ClassMethod
     {
         return $this->calledMethod;
@@ -44223,15 +44367,6 @@ final readonly class PostConditionErrored implements Event
     public function test(): Code\TestMethod
     {
         return $this->test;
-    }
-    /**
-     * @return class-string
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
-     */
-    public function testClassName(): string
-    {
-        return $this->test->className();
     }
     public function calledMethod(): Code\ClassMethod
     {
@@ -44406,15 +44541,6 @@ final readonly class PostConditionFinished implements Event
         return $this->test;
     }
     /**
-     * @return class-string
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
-     */
-    public function testClassName(): string
-    {
-        return $this->test->className();
-    }
-    /**
      * @return list<Code\ClassMethod>
      */
     public function calledMethods(): array
@@ -44495,15 +44621,6 @@ final readonly class PreConditionCalled implements Event
     {
         return $this->test;
     }
-    /**
-     * @return class-string
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
-     */
-    public function testClassName(): string
-    {
-        return $this->test->className();
-    }
     public function calledMethod(): Code\ClassMethod
     {
         return $this->calledMethod;
@@ -44581,15 +44698,6 @@ final readonly class PreConditionErrored implements Event
     public function test(): Code\TestMethod
     {
         return $this->test;
-    }
-    /**
-     * @return class-string
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
-     */
-    public function testClassName(): string
-    {
-        return $this->test->className();
     }
     public function calledMethod(): Code\ClassMethod
     {
@@ -44762,15 +44870,6 @@ final readonly class PreConditionFinished implements Event
     public function test(): Code\TestMethod
     {
         return $this->test;
-    }
-    /**
-     * @return class-string
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6140
-     */
-    public function testClassName(): string
-    {
-        return $this->test->className();
     }
     /**
      * @return list<Code\ClassMethod>
@@ -49987,7 +50086,7 @@ final class Facade
     }
     private function registerDefaultTypes(\PHPUnit\Event\TypeMap $typeMap): void
     {
-        $defaultEvents = [\PHPUnit\Event\Application\Started::class, \PHPUnit\Event\Application\Finished::class, \PHPUnit\Event\Test\DataProviderMethodCalled::class, \PHPUnit\Event\Test\DataProviderMethodFinished::class, \PHPUnit\Event\Test\MarkedIncomplete::class, \PHPUnit\Event\Test\AfterLastTestMethodCalled::class, \PHPUnit\Event\Test\AfterLastTestMethodErrored::class, \PHPUnit\Event\Test\AfterLastTestMethodFailed::class, \PHPUnit\Event\Test\AfterLastTestMethodFinished::class, \PHPUnit\Event\Test\AfterTestMethodCalled::class, \PHPUnit\Event\Test\AfterTestMethodErrored::class, \PHPUnit\Event\Test\AfterTestMethodFailed::class, \PHPUnit\Event\Test\AfterTestMethodFinished::class, \PHPUnit\Event\Test\BeforeFirstTestMethodCalled::class, \PHPUnit\Event\Test\BeforeFirstTestMethodErrored::class, \PHPUnit\Event\Test\BeforeFirstTestMethodFailed::class, \PHPUnit\Event\Test\BeforeFirstTestMethodFinished::class, \PHPUnit\Event\Test\BeforeTestMethodCalled::class, \PHPUnit\Event\Test\BeforeTestMethodErrored::class, \PHPUnit\Event\Test\BeforeTestMethodFailed::class, \PHPUnit\Event\Test\BeforeTestMethodFinished::class, \PHPUnit\Event\Test\AdditionalInformationProvided::class, \PHPUnit\Event\Test\ComparatorRegistered::class, \PHPUnit\Event\Test\ConsideredRisky::class, \PHPUnit\Event\Test\DeprecationTriggered::class, \PHPUnit\Event\Test\Errored::class, \PHPUnit\Event\Test\ErrorTriggered::class, \PHPUnit\Event\Test\Failed::class, \PHPUnit\Event\Test\Finished::class, \PHPUnit\Event\Test\NoticeTriggered::class, \PHPUnit\Event\Test\Passed::class, \PHPUnit\Event\Test\PhpDeprecationTriggered::class, \PHPUnit\Event\Test\PhpNoticeTriggered::class, \PHPUnit\Event\Test\PhpunitDeprecationTriggered::class, \PHPUnit\Event\Test\PhpunitNoticeTriggered::class, \PHPUnit\Event\Test\PhpunitErrorTriggered::class, \PHPUnit\Event\Test\PhpunitWarningTriggered::class, \PHPUnit\Event\Test\PhpWarningTriggered::class, \PHPUnit\Event\Test\PostConditionCalled::class, \PHPUnit\Event\Test\PostConditionErrored::class, \PHPUnit\Event\Test\PostConditionFailed::class, \PHPUnit\Event\Test\PostConditionFinished::class, \PHPUnit\Event\Test\PreConditionCalled::class, \PHPUnit\Event\Test\PreConditionErrored::class, \PHPUnit\Event\Test\PreConditionFailed::class, \PHPUnit\Event\Test\PreConditionFinished::class, \PHPUnit\Event\Test\PreparationStarted::class, \PHPUnit\Event\Test\Prepared::class, \PHPUnit\Event\Test\PreparationErrored::class, \PHPUnit\Event\Test\PreparationFailed::class, \PHPUnit\Event\Test\PrintedUnexpectedOutput::class, \PHPUnit\Event\Test\Skipped::class, \PHPUnit\Event\Test\WarningTriggered::class, \PHPUnit\Event\Test\MockObjectCreated::class, \PHPUnit\Event\Test\MockObjectForIntersectionOfInterfacesCreated::class, \PHPUnit\Event\Test\PartialMockObjectCreated::class, \PHPUnit\Event\Test\TestStubCreated::class, \PHPUnit\Event\Test\TestStubForIntersectionOfInterfacesCreated::class, \PHPUnit\Event\TestRunner\BootstrapFinished::class, \PHPUnit\Event\TestRunner\Configured::class, \PHPUnit\Event\TestRunner\EventFacadeSealed::class, \PHPUnit\Event\TestRunner\ExecutionAborted::class, \PHPUnit\Event\TestRunner\ExecutionFinished::class, \PHPUnit\Event\TestRunner\ExecutionStarted::class, \PHPUnit\Event\TestRunner\ExtensionLoadedFromPhar::class, \PHPUnit\Event\TestRunner\ExtensionBootstrapped::class, \PHPUnit\Event\TestRunner\Finished::class, \PHPUnit\Event\TestRunner\Started::class, \PHPUnit\Event\TestRunner\DeprecationTriggered::class, \PHPUnit\Event\TestRunner\NoticeTriggered::class, \PHPUnit\Event\TestRunner\WarningTriggered::class, \PHPUnit\Event\TestRunner\GarbageCollectionDisabled::class, \PHPUnit\Event\TestRunner\GarbageCollectionTriggered::class, \PHPUnit\Event\TestRunner\GarbageCollectionEnabled::class, \PHPUnit\Event\TestRunner\ChildProcessStarted::class, \PHPUnit\Event\TestRunner\ChildProcessErrored::class, \PHPUnit\Event\TestRunner\ChildProcessFinished::class, \PHPUnit\Event\TestRunner\StaticAnalysisForCodeCoverageFinished::class, \PHPUnit\Event\TestRunner\StaticAnalysisForCodeCoverageStarted::class, \PHPUnit\Event\TestSuite\Filtered::class, \PHPUnit\Event\TestSuite\Finished::class, \PHPUnit\Event\TestSuite\Loaded::class, \PHPUnit\Event\TestSuite\Skipped::class, \PHPUnit\Event\TestSuite\Sorted::class, \PHPUnit\Event\TestSuite\Started::class];
+        $defaultEvents = [\PHPUnit\Event\Application\Started::class, \PHPUnit\Event\Application\Finished::class, \PHPUnit\Event\Test\DataProviderMethodCalled::class, \PHPUnit\Event\Test\DataProviderMethodFinished::class, \PHPUnit\Event\Test\MarkedIncomplete::class, \PHPUnit\Event\Test\AfterLastTestMethodCalled::class, \PHPUnit\Event\Test\AfterLastTestMethodErrored::class, \PHPUnit\Event\Test\AfterLastTestMethodFailed::class, \PHPUnit\Event\Test\AfterLastTestMethodFinished::class, \PHPUnit\Event\Test\AfterTestMethodCalled::class, \PHPUnit\Event\Test\AfterTestMethodErrored::class, \PHPUnit\Event\Test\AfterTestMethodFailed::class, \PHPUnit\Event\Test\AfterTestMethodFinished::class, \PHPUnit\Event\Test\BeforeFirstTestMethodCalled::class, \PHPUnit\Event\Test\BeforeFirstTestMethodErrored::class, \PHPUnit\Event\Test\BeforeFirstTestMethodFailed::class, \PHPUnit\Event\Test\BeforeFirstTestMethodFinished::class, \PHPUnit\Event\Test\BeforeTestMethodCalled::class, \PHPUnit\Event\Test\BeforeTestMethodErrored::class, \PHPUnit\Event\Test\BeforeTestMethodFailed::class, \PHPUnit\Event\Test\BeforeTestMethodFinished::class, \PHPUnit\Event\Test\AdditionalInformationProvided::class, \PHPUnit\Event\Test\ComparatorRegistered::class, \PHPUnit\Event\Test\CustomTestMethodInvocationUsed::class, \PHPUnit\Event\Test\ConsideredRisky::class, \PHPUnit\Event\Test\DeprecationTriggered::class, \PHPUnit\Event\Test\Errored::class, \PHPUnit\Event\Test\ErrorTriggered::class, \PHPUnit\Event\Test\Failed::class, \PHPUnit\Event\Test\Finished::class, \PHPUnit\Event\Test\NoticeTriggered::class, \PHPUnit\Event\Test\Passed::class, \PHPUnit\Event\Test\PhpDeprecationTriggered::class, \PHPUnit\Event\Test\PhpNoticeTriggered::class, \PHPUnit\Event\Test\PhpunitDeprecationTriggered::class, \PHPUnit\Event\Test\PhpunitNoticeTriggered::class, \PHPUnit\Event\Test\PhpunitErrorTriggered::class, \PHPUnit\Event\Test\PhpunitWarningTriggered::class, \PHPUnit\Event\Test\PhpWarningTriggered::class, \PHPUnit\Event\Test\PostConditionCalled::class, \PHPUnit\Event\Test\PostConditionErrored::class, \PHPUnit\Event\Test\PostConditionFailed::class, \PHPUnit\Event\Test\PostConditionFinished::class, \PHPUnit\Event\Test\PreConditionCalled::class, \PHPUnit\Event\Test\PreConditionErrored::class, \PHPUnit\Event\Test\PreConditionFailed::class, \PHPUnit\Event\Test\PreConditionFinished::class, \PHPUnit\Event\Test\PreparationStarted::class, \PHPUnit\Event\Test\Prepared::class, \PHPUnit\Event\Test\PreparationErrored::class, \PHPUnit\Event\Test\PreparationFailed::class, \PHPUnit\Event\Test\PrintedUnexpectedOutput::class, \PHPUnit\Event\Test\Skipped::class, \PHPUnit\Event\Test\WarningTriggered::class, \PHPUnit\Event\Test\MockObjectCreated::class, \PHPUnit\Event\Test\MockObjectForIntersectionOfInterfacesCreated::class, \PHPUnit\Event\Test\PartialMockObjectCreated::class, \PHPUnit\Event\Test\TestStubCreated::class, \PHPUnit\Event\Test\TestStubForIntersectionOfInterfacesCreated::class, \PHPUnit\Event\TestRunner\BootstrapFinished::class, \PHPUnit\Event\TestRunner\Configured::class, \PHPUnit\Event\TestRunner\EventFacadeSealed::class, \PHPUnit\Event\TestRunner\ExecutionAborted::class, \PHPUnit\Event\TestRunner\ExecutionFinished::class, \PHPUnit\Event\TestRunner\ExecutionStarted::class, \PHPUnit\Event\TestRunner\ExtensionLoadedFromPhar::class, \PHPUnit\Event\TestRunner\ExtensionBootstrapped::class, \PHPUnit\Event\TestRunner\Finished::class, \PHPUnit\Event\TestRunner\Started::class, \PHPUnit\Event\TestRunner\DeprecationTriggered::class, \PHPUnit\Event\TestRunner\NoticeTriggered::class, \PHPUnit\Event\TestRunner\WarningTriggered::class, \PHPUnit\Event\TestRunner\GarbageCollectionDisabled::class, \PHPUnit\Event\TestRunner\GarbageCollectionTriggered::class, \PHPUnit\Event\TestRunner\GarbageCollectionEnabled::class, \PHPUnit\Event\TestRunner\ChildProcessStarted::class, \PHPUnit\Event\TestRunner\ChildProcessErrored::class, \PHPUnit\Event\TestRunner\ChildProcessFinished::class, \PHPUnit\Event\TestRunner\StaticAnalysisForCodeCoverageFinished::class, \PHPUnit\Event\TestRunner\StaticAnalysisForCodeCoverageStarted::class, \PHPUnit\Event\TestSuite\Filtered::class, \PHPUnit\Event\TestSuite\Finished::class, \PHPUnit\Event\TestSuite\Loaded::class, \PHPUnit\Event\TestSuite\Skipped::class, \PHPUnit\Event\TestSuite\Sorted::class, \PHPUnit\Event\TestSuite\Started::class];
         foreach ($defaultEvents as $eventClass) {
             $subscriberInterface = $eventClass . 'Subscriber';
             assert(interface_exists($subscriberInterface));
@@ -50048,6 +50147,7 @@ declare (strict_types=1);
  */
 namespace PHPUnit\Event;
 
+use function array_any;
 use function array_key_exists;
 use function class_exists;
 use function class_implements;
@@ -50088,12 +50188,7 @@ final class TypeMap
     }
     public function isKnownSubscriberType(\PHPUnit\Event\Subscriber $subscriber): bool
     {
-        foreach (class_implements($subscriber) as $interface) {
-            if (array_key_exists($interface, $this->mapping)) {
-                return \true;
-            }
-        }
-        return \false;
+        return array_any(class_implements($subscriber), fn(string $interface) => array_key_exists($interface, $this->mapping));
     }
     public function isKnownEventType(\PHPUnit\Event\Event $event): bool
     {
@@ -51637,7 +51732,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\Event\Code;
 
-use function count;
 use Iterator;
 /**
  * @template-implements Iterator<non-negative-int, Test>
@@ -51664,7 +51758,7 @@ final class TestCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->tests);
+        return isset($this->tests[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -51895,7 +51989,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\Event\TestData;
 
-use function count;
 use Iterator;
 /**
  * @template-implements Iterator<non-negative-int, TestData>
@@ -51922,7 +52015,7 @@ final class TestDataCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->data);
+        return isset($this->data[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -52693,12 +52786,12 @@ use function count;
 use function file_get_contents;
 use function interface_exists;
 use function is_bool;
-use function sprintf;
 use ArrayAccess;
 use Countable;
 use Generator;
-use PHPUnit\Event\Facade as EventFacade;
 use PHPUnit\Framework\Constraint\ArrayHasKey;
+use PHPUnit\Framework\Constraint\ArraysAreEqual;
+use PHPUnit\Framework\Constraint\ArraysAreIdentical;
 use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\Count;
@@ -52863,6 +52956,114 @@ abstract class Assert
         self::assertThat($array, new IsList(), $message);
     }
     /**
+     * Assert that two arrays are identical.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array matters, and keys as well as values are compared strictly.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArraysAreIdentical(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat($actual, new ArraysAreIdentical($expected, \true, \true), $message);
+    }
+    /**
+     * Assert that two arrays are identical while ignoring the order of their values.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array does not matter, and keys as well as values are compared strictly.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArraysAreIdenticalIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat($actual, new ArraysAreIdentical($expected, \true, \false), $message);
+    }
+    /**
+     * Assert that two arrays have identical values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array matters, and values are compared strictly.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArraysHaveIdenticalValues(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat($actual, new ArraysAreIdentical($expected, \false, \true), $message);
+    }
+    /**
+     * Assert that two arrays have identical values while ignoring the order of these values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array does not matter, and values are compared strictly.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArraysHaveIdenticalValuesIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat($actual, new ArraysAreIdentical($expected, \false, \false), $message);
+    }
+    /**
+     * Assert that two arrays are equal.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array matters, and keys as well as values are compared loosely.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     */
+    final public static function assertArraysAreEqual(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat($actual, new ArraysAreEqual($expected, \true, \true), $message);
+    }
+    /**
+     * Assert that two arrays are equal while ignoring the order of their values.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array does not matter, and keys as well as values are compared loosely.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArraysAreEqualIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat($actual, new ArraysAreEqual($expected, \true, \false), $message);
+    }
+    /**
+     * Assert that two arrays have equal values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array matters, and values are compared loosely.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     */
+    final public static function assertArraysHaveEqualValues(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat($actual, new ArraysAreEqual($expected, \false, \true), $message);
+    }
+    /**
+     * Assert that two arrays have equal values while ignoring the order of these values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array does not matter, and values are compared loosely.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertArraysHaveEqualValuesIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        self::assertThat($actual, new ArraysAreEqual($expected, \false, \false), $message);
+    }
+    /**
      * Asserts that a haystack contains a needle.
      *
      * @param iterable<mixed> $haystack
@@ -52906,51 +53107,6 @@ abstract class Assert
     final public static function assertNotContainsEquals(mixed $needle, iterable $haystack, string $message = ''): void
     {
         $constraint = new LogicalNot(new TraversableContainsEqual($needle));
-        self::assertThat($haystack, $constraint, $message);
-    }
-    /**
-     * Asserts that a haystack contains only values of a given type.
-     *
-     * @param 'array'|'bool'|'boolean'|'callable'|'double'|'float'|'int'|'integer'|'iterable'|'null'|'numeric'|'object'|'real'|'resource (closed)'|'resource'|'scalar'|'string' $type
-     * @param iterable<mixed>                                                                                                                                                   $haystack
-     *
-     * @throws Exception
-     * @throws ExpectationFailedException
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6056
-     */
-    final public static function assertContainsOnly(string $type, iterable $haystack, ?bool $isNativeType = null, string $message = ''): void
-    {
-        if ($isNativeType === null) {
-            $isNativeType = self::isNativeType($type);
-        }
-        if ($isNativeType) {
-            $replacement = match ($type) {
-                'array' => 'assertContainsOnlyArray',
-                'bool' => 'assertContainsOnlyBool',
-                'boolean' => 'assertContainsOnlyBool',
-                'callable' => 'assertContainsOnlyCallable',
-                'double' => 'assertContainsOnlyFloat',
-                'float' => 'assertContainsOnlyFloat',
-                'int' => 'assertContainsOnlyInt',
-                'integer' => 'assertContainsOnlyInt',
-                'iterable' => 'assertContainsOnlyIterable',
-                'null' => 'assertContainsOnlyNull',
-                'numeric' => 'assertContainsOnlyNumeric',
-                'object' => 'assertContainsOnlyObject',
-                'real' => 'assertContainsOnlyFloat',
-                'resource' => 'assertContainsOnlyResource',
-                'resource (closed)' => 'assertContainsOnlyClosedResource',
-                'scalar' => 'assertContainsOnlyScalar',
-                'string' => 'assertContainsOnlyString',
-            };
-            EventFacade::emitter()->testTriggeredPhpunitDeprecation(null, sprintf('assertContainsOnly() is deprecated and will be removed in PHPUnit 13. ' . 'Please use %s($haystack) instead of assertContainsOnly(\'%s\', $haystack).', $replacement, $type));
-            $constraint = TraversableContainsOnly::forNativeType(self::mapNativeType($type));
-        } else {
-            EventFacade::emitter()->testTriggeredPhpunitDeprecation(null, sprintf('assertContainsOnly() is deprecated and will be removed in PHPUnit 13. ' . 'Please use assertContainsOnlyInstancesOf(\'%s\', $haystack) instead of assertContainsOnly(\'%s\', $haystack).', $type, $type));
-            /** @phpstan-ignore argument.type */
-            $constraint = TraversableContainsOnly::forClassOrInterface($type);
-        }
         self::assertThat($haystack, $constraint, $message);
     }
     /**
@@ -53138,51 +53294,6 @@ abstract class Assert
     final public static function assertContainsOnlyInstancesOf(string $className, iterable $haystack, string $message = ''): void
     {
         self::assertThat($haystack, TraversableContainsOnly::forClassOrInterface($className), $message);
-    }
-    /**
-     * Asserts that a haystack does not contain only values of a given type.
-     *
-     * @param 'array'|'bool'|'boolean'|'callable'|'double'|'float'|'int'|'integer'|'iterable'|'null'|'numeric'|'object'|'real'|'resource (closed)'|'resource'|'scalar'|'string' $type
-     * @param iterable<mixed>                                                                                                                                                   $haystack
-     *
-     * @throws Exception
-     * @throws ExpectationFailedException
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6056
-     */
-    final public static function assertNotContainsOnly(string $type, iterable $haystack, ?bool $isNativeType = null, string $message = ''): void
-    {
-        if ($isNativeType === null) {
-            $isNativeType = self::isNativeType($type);
-        }
-        if ($isNativeType) {
-            $replacement = match ($type) {
-                'array' => 'assertContainsNotOnlyArray',
-                'bool' => 'assertContainsNotOnlyBool',
-                'boolean' => 'assertContainsNotOnlyBool',
-                'callable' => 'assertContainsNotOnlyCallable',
-                'double' => 'assertContainsNotOnlyFloat',
-                'float' => 'assertContainsNotOnlyFloat',
-                'int' => 'assertContainsNotOnlyInt',
-                'integer' => 'assertContainsNotOnlyInt',
-                'iterable' => 'assertContainsNotOnlyIterable',
-                'null' => 'assertContainsNotOnlyNull',
-                'numeric' => 'assertContainsNotOnlyNumeric',
-                'object' => 'assertContainsNotOnlyObject',
-                'real' => 'assertContainsNotOnlyFloat',
-                'resource' => 'assertContainsNotOnlyResource',
-                'resource (closed)' => 'assertContainsNotOnlyClosedResource',
-                'scalar' => 'assertContainsNotOnlyScalar',
-                'string' => 'assertContainsNotOnlyString',
-            };
-            EventFacade::emitter()->testTriggeredPhpunitDeprecation(null, sprintf('assertNotContainsOnly() is deprecated and will be removed in PHPUnit 13. ' . 'Please use %s($haystack) instead of assertNotContainsOnly(\'%s\', $haystack).', $replacement, $type));
-            $constraint = TraversableContainsOnly::forNativeType(self::mapNativeType($type));
-        } else {
-            EventFacade::emitter()->testTriggeredPhpunitDeprecation(null, sprintf('assertNotContainsOnly() is deprecated and will be removed in PHPUnit 13. ' . 'Please use assertContainsNotOnlyInstancesOf(\'%s\', $haystack) instead of assertNotContainsOnly(\'%s\', $haystack).', $type, $type));
-            /** @phpstan-ignore argument.type */
-            $constraint = TraversableContainsOnly::forClassOrInterface($type);
-        }
-        self::assertThat($haystack, new LogicalNot($constraint), $message);
     }
     /**
      * Asserts that a haystack does not contain only values of type array.
@@ -54746,17 +54857,6 @@ abstract class Assert
     {
         return new TraversableContainsIdentical($value);
     }
-    /**
-     * @param 'array'|'bool'|'boolean'|'callable'|'double'|'float'|'int'|'integer'|'iterable'|'null'|'numeric'|'object'|'real'|'resource (closed)'|'resource'|'scalar'|'string' $type
-     *
-     * @throws Exception
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6060
-     */
-    final public static function containsOnly(string $type): TraversableContainsOnly
-    {
-        return TraversableContainsOnly::forNativeType(self::mapNativeType($type));
-    }
     final public static function containsOnlyArray(): TraversableContainsOnly
     {
         return TraversableContainsOnly::forNativeType(\PHPUnit\Framework\NativeType::Array);
@@ -54929,38 +55029,6 @@ abstract class Assert
     {
         return new IsType(\PHPUnit\Framework\NativeType::String);
     }
-    /**
-     * @param 'array'|'bool'|'boolean'|'callable'|'double'|'float'|'int'|'integer'|'iterable'|'null'|'numeric'|'object'|'real'|'resource (closed)'|'resource'|'scalar'|'string' $type
-     *
-     * @throws UnknownNativeTypeException
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6053
-     */
-    final public static function isType(string $type): IsType
-    {
-        $constraint = new IsType(self::mapNativeType($type));
-        $replacement = match ($type) {
-            'array' => 'isArray',
-            'bool' => 'isBool',
-            'boolean' => 'isBool',
-            'callable' => 'isCallable',
-            'double' => 'isFloat',
-            'float' => 'isFloat',
-            'int' => 'isInt',
-            'integer' => 'isInt',
-            'iterable' => 'isIterable',
-            'null' => 'isNull',
-            'numeric' => 'isNumeric',
-            'object' => 'isObject',
-            'real' => 'isFloat',
-            'resource' => 'isResource',
-            'resource (closed)' => 'isClosedResource',
-            'scalar' => 'isScalar',
-            'string' => 'isString',
-        };
-        EventFacade::emitter()->testTriggeredPhpunitDeprecation(null, sprintf('isType(\'%s\') is deprecated and will be removed in PHPUnit 13. ' . 'Please use the %s() method instead.', $type, $replacement));
-        return $constraint;
-    }
     final public static function lessThan(mixed $value): LessThan
     {
         return new LessThan($value);
@@ -55052,39 +55120,6 @@ abstract class Assert
     final public static function resetCount(): void
     {
         self::$count = 0;
-    }
-    private static function isNativeType(string $type): bool
-    {
-        return $type === 'array' || $type === 'bool' || $type === 'boolean' || $type === 'callable' || $type === 'double' || $type === 'float' || $type === 'int' || $type === 'integer' || $type === 'iterable' || $type === 'null' || $type === 'numeric' || $type === 'object' || $type === 'real' || $type === 'resource' || $type === 'resource (closed)' || $type === 'scalar' || $type === 'string';
-    }
-    /**
-     * @throws UnknownNativeTypeException
-     */
-    private static function mapNativeType(string $type): \PHPUnit\Framework\NativeType
-    {
-        if (!self::isNativeType($type)) {
-            throw new \PHPUnit\Framework\UnknownNativeTypeException($type);
-        }
-        /** @phpstan-ignore match.unhandled */
-        return match ($type) {
-            'array' => \PHPUnit\Framework\NativeType::Array,
-            'bool' => \PHPUnit\Framework\NativeType::Bool,
-            'boolean' => \PHPUnit\Framework\NativeType::Bool,
-            'callable' => \PHPUnit\Framework\NativeType::Callable,
-            'double' => \PHPUnit\Framework\NativeType::Float,
-            'float' => \PHPUnit\Framework\NativeType::Float,
-            'int' => \PHPUnit\Framework\NativeType::Int,
-            'integer' => \PHPUnit\Framework\NativeType::Int,
-            'iterable' => \PHPUnit\Framework\NativeType::Iterable,
-            'null' => \PHPUnit\Framework\NativeType::Null,
-            'numeric' => \PHPUnit\Framework\NativeType::Numeric,
-            'object' => \PHPUnit\Framework\NativeType::Object,
-            'real' => \PHPUnit\Framework\NativeType::Float,
-            'resource' => \PHPUnit\Framework\NativeType::Resource,
-            'resource (closed)' => \PHPUnit\Framework\NativeType::ClosedResource,
-            'scalar' => \PHPUnit\Framework\NativeType::Scalar,
-            'string' => \PHPUnit\Framework\NativeType::String,
-        };
     }
 }
 <?php
@@ -55284,6 +55319,168 @@ if (!function_exists('PHPUnit\Framework\assertIsList')) {
         \PHPUnit\Framework\Assert::assertIsList(...func_get_args());
     }
 }
+if (!function_exists('PHPUnit\Framework\assertArraysAreIdentical')) {
+    /**
+     * Assert that two arrays are identical.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array matters, and keys as well as values are compared strictly.
+     * This is essentially an alias for assertSame().
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysAreIdentical
+     */
+    function assertArraysAreIdentical(array $expected, array $actual, string $message = ''): void
+    {
+        \PHPUnit\Framework\Assert::assertArraysAreIdentical(...func_get_args());
+    }
+}
+if (!function_exists('PHPUnit\Framework\assertArraysAreEqual')) {
+    /**
+     * Assert that two arrays are equal.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array matters, and keys as well as values are compared loosely.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysAreEqual
+     */
+    function assertArraysAreEqual(array $expected, array $actual, string $message = ''): void
+    {
+        \PHPUnit\Framework\Assert::assertArraysAreEqual(...func_get_args());
+    }
+}
+if (!function_exists('PHPUnit\Framework\assertArraysAreIdenticalIgnoringOrder')) {
+    /**
+     * Assert that two arrays are identical while ignoring the order of their values.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array does not matter, and keys as well as values are compared strictly.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysAreIdenticalIgnoringOrder
+     */
+    function assertArraysAreIdenticalIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        \PHPUnit\Framework\Assert::assertArraysAreIdenticalIgnoringOrder(...func_get_args());
+    }
+}
+if (!function_exists('PHPUnit\Framework\assertArraysAreEqualIgnoringOrder')) {
+    /**
+     * Assert that two arrays are equal while ignoring the order of their values.
+     *
+     * The (key, value) relationship matters, the order of the (key, value) pairs in the array does not matter, and keys as well as values are compared loosely.
+     * This is essentially an alias for assertEquals().
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysAreEqualIgnoringOrder
+     */
+    function assertArraysAreEqualIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        \PHPUnit\Framework\Assert::assertArraysAreEqualIgnoringOrder(...func_get_args());
+    }
+}
+if (!function_exists('PHPUnit\Framework\assertArraysHaveIdenticalValues')) {
+    /**
+     * Assert that two arrays have identical values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array matters, and values are compared strictly.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysHaveIdenticalValues
+     */
+    function assertArraysHaveIdenticalValues(array $expected, array $actual, string $message = ''): void
+    {
+        \PHPUnit\Framework\Assert::assertArraysHaveIdenticalValues(...func_get_args());
+    }
+}
+if (!function_exists('PHPUnit\Framework\assertArraysHaveEqualValues')) {
+    /**
+     * Assert that two arrays have equal values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array matters, and values are compared loosely.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysHaveEqualValues
+     */
+    function assertArraysHaveEqualValues(array $expected, array $actual, string $message = ''): void
+    {
+        \PHPUnit\Framework\Assert::assertArraysHaveEqualValues(...func_get_args());
+    }
+}
+if (!function_exists('PHPUnit\Framework\assertArraysHaveIdenticalValuesIgnoringOrder')) {
+    /**
+     * Assert that two arrays have identical values while ignoring the order of these values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array does not matter, and values are compared strictly.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysHaveIdenticalValuesIgnoringOrder
+     */
+    function assertArraysHaveIdenticalValuesIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        \PHPUnit\Framework\Assert::assertArraysHaveIdenticalValuesIgnoringOrder(...func_get_args());
+    }
+}
+if (!function_exists('PHPUnit\Framework\assertArraysHaveEqualValuesIgnoringOrder')) {
+    /**
+     * Assert that two arrays have equal values while ignoring the order of these values.
+     *
+     * The (key, value) relationship does not matter, the order of the (key, value) pairs in the array does not matter, and values are compared loosely.
+     *
+     * @param array<mixed> $expected
+     * @param array<mixed> $actual
+     *
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertArraysHaveEqualValuesIgnoringOrder
+     */
+    function assertArraysHaveEqualValuesIgnoringOrder(array $expected, array $actual, string $message = ''): void
+    {
+        \PHPUnit\Framework\Assert::assertArraysHaveEqualValuesIgnoringOrder(...func_get_args());
+    }
+}
 if (!function_exists('PHPUnit\Framework\assertContains')) {
     /**
      * Asserts that a haystack contains a needle.
@@ -55348,27 +55545,6 @@ if (!function_exists('PHPUnit\Framework\assertNotContainsEquals')) {
     function assertNotContainsEquals(mixed $needle, iterable $haystack, string $message = ''): void
     {
         \PHPUnit\Framework\Assert::assertNotContainsEquals(...func_get_args());
-    }
-}
-if (!function_exists('PHPUnit\Framework\assertContainsOnly')) {
-    /**
-     * Asserts that a haystack contains only values of a given type.
-     *
-     * @param 'array'|'bool'|'boolean'|'callable'|'double'|'float'|'int'|'integer'|'iterable'|'null'|'numeric'|'object'|'real'|'resource (closed)'|'resource'|'scalar'|'string' $type
-     * @param iterable<mixed>                                                                                                                                                   $haystack
-     *
-     * @throws Exception
-     * @throws ExpectationFailedException
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6056
-     *
-     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
-     *
-     * @see Assert::assertContainsOnly
-     */
-    function assertContainsOnly(string $type, iterable $haystack, ?bool $isNativeType = null, string $message = ''): void
-    {
-        \PHPUnit\Framework\Assert::assertContainsOnly(...func_get_args());
     }
 }
 if (!function_exists('PHPUnit\Framework\assertContainsOnlyArray')) {
@@ -55639,27 +55815,6 @@ if (!function_exists('PHPUnit\Framework\assertContainsOnlyInstancesOf')) {
     function assertContainsOnlyInstancesOf(string $className, iterable $haystack, string $message = ''): void
     {
         \PHPUnit\Framework\Assert::assertContainsOnlyInstancesOf(...func_get_args());
-    }
-}
-if (!function_exists('PHPUnit\Framework\assertNotContainsOnly')) {
-    /**
-     * Asserts that a haystack does not contain only values of a given type.
-     *
-     * @param 'array'|'bool'|'boolean'|'callable'|'double'|'float'|'int'|'integer'|'iterable'|'null'|'numeric'|'object'|'real'|'resource (closed)'|'resource'|'scalar'|'string' $type
-     * @param iterable<mixed>                                                                                                                                                   $haystack
-     *
-     * @throws Exception
-     * @throws ExpectationFailedException
-     *
-     * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6056
-     *
-     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
-     *
-     * @see Assert::assertNotContainsOnly
-     */
-    function assertNotContainsOnly(string $type, iterable $haystack, ?bool $isNativeType = null, string $message = ''): void
-    {
-        \PHPUnit\Framework\Assert::assertNotContainsOnly(...func_get_args());
     }
 }
 if (!function_exists('PHPUnit\Framework\assertContainsNotOnlyArray')) {
@@ -57889,12 +58044,6 @@ if (!function_exists('PHPUnit\Framework\containsIdentical')) {
         return \PHPUnit\Framework\Assert::containsIdentical(...func_get_args());
     }
 }
-if (!function_exists('PHPUnit\Framework\containsOnly')) {
-    function containsOnly(string $type): TraversableContainsOnly
-    {
-        return \PHPUnit\Framework\Assert::containsOnly(...func_get_args());
-    }
-}
 if (!function_exists('PHPUnit\Framework\containsOnlyArray')) {
     function containsOnlyArray(): TraversableContainsOnly
     {
@@ -58139,12 +58288,6 @@ if (!function_exists('PHPUnit\Framework\isString')) {
     function isString(): IsType
     {
         return \PHPUnit\Framework\Assert::isString(...func_get_args());
-    }
-}
-if (!function_exists('PHPUnit\Framework\isType')) {
-    function isType(string $type): IsType
-    {
-        return \PHPUnit\Framework\Assert::isType(...func_get_args());
     }
 }
 if (!function_exists('PHPUnit\Framework\lessThan')) {
@@ -60240,31 +60383,6 @@ use Attribute;
  * @immutable
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- *
- * @deprecated https://github.com/sebastianbergmann/phpunit/issues/6284
- */
-#[Attribute(Attribute::TARGET_CLASS)]
-final readonly class RunClassInSeparateProcess
-{
-}
-<?php
-
-declare (strict_types=1);
-/*
- * This file is part of PHPUnit.
- *
- * (c) Sebastian Bergmann <sebastian@phpunit.de>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-namespace PHPUnit\Framework\Attributes;
-
-use Attribute;
-/**
- * @immutable
- *
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
 #[Attribute(Attribute::TARGET_METHOD)]
 final readonly class RunInSeparateProcess
@@ -60993,6 +61111,302 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD)]
 final readonly class WithoutErrorHandler
 {
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use function array_keys;
+use function array_values;
+use function is_array;
+use function ksort;
+use function sort;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Util\Exporter;
+use PHPUnitPHAR\SebastianBergmann\Comparator\ComparisonFailure;
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+abstract class ArrayComparison extends \PHPUnit\Framework\Constraint\Constraint
+{
+    /**
+     * @var array<mixed>
+     */
+    protected readonly array $expected;
+    protected readonly bool $keysMatter;
+    protected readonly bool $orderMatters;
+    /**
+     * @param array<mixed> $expected
+     */
+    public function __construct(array $expected, bool $keysMatter, bool $orderMatters)
+    {
+        $this->expected = $expected;
+        $this->keysMatter = $keysMatter;
+        $this->orderMatters = $orderMatters;
+    }
+    /**
+     * Evaluates the constraint for parameter $other.
+     *
+     * If $returnResult is set to false (the default), an exception is thrown
+     * in case of a failure. null is returned otherwise.
+     *
+     * If $returnResult is true, the result of the evaluation is returned as
+     * a boolean value instead: true in case of success, false in case of a
+     * failure.
+     *
+     * @throws ExpectationFailedException
+     */
+    public function evaluate(mixed $other, string $description = '', bool $returnResult = \false): ?bool
+    {
+        if (!is_array($other)) {
+            return \false;
+        }
+        $expected = $this->expected;
+        $actual = $other;
+        if ($this->keysMatter && !$this->orderMatters) {
+            $expectedKeys = array_keys($expected);
+            $actualKeys = array_keys($actual);
+            sort($expectedKeys);
+            sort($actualKeys);
+            if ($expectedKeys === $actualKeys) {
+                sort($expected);
+                sort($actual);
+            } else {
+                ksort($expected);
+                ksort($actual);
+            }
+        }
+        if (!$this->keysMatter) {
+            $expected = array_values($expected);
+            $actual = array_values($actual);
+            if (!$this->orderMatters) {
+                sort($expected);
+                sort($actual);
+            }
+        }
+        $success = $this->compareArrays($expected, $actual);
+        if ($returnResult) {
+            return $success;
+        }
+        if (!$success) {
+            $this->fail($other, $description, new ComparisonFailure($this->expected, $other, Exporter::export($this->expected), Exporter::export($other)));
+        }
+        // @codeCoverageIgnoreStart
+        return null;
+        // @codeCoverageIgnoreEnd
+    }
+    /**
+     * Returns a string representation of the constraint.
+     */
+    public function toString(): string
+    {
+        if ($this->keysMatter && $this->orderMatters) {
+            return 'two arrays are ' . $this->comparisonType();
+        }
+        if (!$this->keysMatter && !$this->orderMatters) {
+            return 'two arrays are ' . $this->comparisonType() . ' while ignoring keys and order';
+        }
+        if (!$this->keysMatter) {
+            return 'two arrays are ' . $this->comparisonType() . ' while ignoring keys';
+        }
+        return 'two arrays are ' . $this->comparisonType() . ' while ignoring order';
+    }
+    /**
+     * Returns the description of the failure.
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     */
+    protected function failureDescription(mixed $other): string
+    {
+        return $this->toString();
+    }
+    /**
+     * Compares two arrays using the appropriate comparison method.
+     */
+    abstract protected function compareArrays(mixed $expected, mixed $actual): bool;
+    /**
+     * @return 'equal'|'identical'
+     */
+    abstract protected function comparisonType(): string;
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use function array_key_exists;
+use function is_array;
+use ArrayAccess;
+use PHPUnit\Util\Exporter;
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final class ArrayHasKey extends \PHPUnit\Framework\Constraint\Constraint
+{
+    private readonly mixed $key;
+    public function __construct(mixed $key)
+    {
+        $this->key = $key;
+    }
+    /**
+     * Returns a string representation of the constraint.
+     */
+    public function toString(): string
+    {
+        return 'has the key ' . Exporter::export($this->key);
+    }
+    /**
+     * Evaluates the constraint for parameter $other. Returns true if the
+     * constraint is met, false otherwise.
+     */
+    protected function matches(mixed $other): bool
+    {
+        if (is_array($other)) {
+            return array_key_exists($this->key, $other);
+        }
+        if ($other instanceof ArrayAccess) {
+            return $other->offsetExists($this->key);
+        }
+        return \false;
+    }
+    /**
+     * Returns the description of the failure.
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     */
+    protected function failureDescription(mixed $other): string
+    {
+        return 'an array ' . $this->toString();
+    }
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final class ArraysAreEqual extends \PHPUnit\Framework\Constraint\ArrayComparison
+{
+    protected function compareArrays(mixed $expected, mixed $actual): bool
+    {
+        /** @phpstan-ignore equal.notAllowed */
+        return $expected == $actual;
+    }
+    /**
+     * @return 'equal'
+     */
+    protected function comparisonType(): string
+    {
+        return 'equal';
+    }
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final class ArraysAreIdentical extends \PHPUnit\Framework\Constraint\ArrayComparison
+{
+    protected function compareArrays(mixed $expected, mixed $actual): bool
+    {
+        return $expected === $actual;
+    }
+    /**
+     * @return 'identical'
+     */
+    protected function comparisonType(): string
+    {
+        return 'identical';
+    }
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\Constraint;
+
+use function array_is_list;
+use function is_array;
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ */
+final class IsList extends \PHPUnit\Framework\Constraint\Constraint
+{
+    /**
+     * Returns a string representation of the constraint.
+     */
+    public function toString(): string
+    {
+        return 'is a list';
+    }
+    /**
+     * Evaluates the constraint for parameter $other. Returns true if the
+     * constraint is met, false otherwise.
+     */
+    protected function matches(mixed $other): bool
+    {
+        if (!is_array($other)) {
+            return \false;
+        }
+        return array_is_list($other);
+    }
+    /**
+     * Returns the description of the failure.
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     */
+    protected function failureDescription(mixed $other): string
+    {
+        return $this->valueToTypeStringFragment($other) . $this->toString();
+    }
 }
 <?php
 
@@ -62713,6 +63127,7 @@ namespace PHPUnit\Framework\Constraint;
 
 use function assert;
 use function count;
+use function is_bool;
 use function is_object;
 use PHPUnit\Framework\ActualValueIsNotAnObjectException;
 use PHPUnit\Framework\ComparisonMethodDoesNotAcceptParameterTypeException;
@@ -62789,7 +63204,9 @@ final class ObjectEquals extends \PHPUnit\Framework\Constraint\Constraint
             throw new ComparisonMethodDoesNotAcceptParameterTypeException($other::class, $this->method, $this->expected::class);
         }
         /** @phpstan-ignore method.dynamicName */
-        return $other->{$this->method}($this->expected);
+        $result = $other->{$this->method}($this->expected);
+        assert(is_bool($result));
+        return $result;
     }
     protected function failureDescription(mixed $other): string
     {
@@ -62885,7 +63302,7 @@ abstract class BinaryOperator extends \PHPUnit\Framework\Constraint\Operator
     private readonly array $constraints;
     protected function __construct(mixed ...$constraints)
     {
-        $this->constraints = array_map(fn(mixed $constraint): \PHPUnit\Framework\Constraint\Constraint => $this->checkConstraint($constraint), $constraints);
+        $this->constraints = array_map($this->checkConstraint(...), $constraints);
     }
     /**
      * Returns the number of operands (constraints).
@@ -63034,6 +63451,7 @@ declare (strict_types=1);
 namespace PHPUnit\Framework\Constraint;
 
 use function array_map;
+use function assert;
 use function count;
 use function preg_match;
 use function preg_quote;
@@ -63044,6 +63462,11 @@ use PHPUnit\Framework\ExpectationFailedException;
  */
 final class LogicalNot extends \PHPUnit\Framework\Constraint\UnaryOperator
 {
+    /**
+     * @param non-empty-string $string
+     *
+     * @return non-empty-string
+     */
     public static function negate(string $string): string
     {
         $positives = ['contains ', 'exists', 'has ', 'is ', 'are ', 'matches ', 'starts with ', 'ends with ', 'reference ', 'not not '];
@@ -63059,6 +63482,8 @@ final class LogicalNot extends \PHPUnit\Framework\Constraint\UnaryOperator
         } else {
             $negatedString = preg_replace($positives, $negatives, $string);
         }
+        assert($negatedString !== null);
+        assert($negatedString !== '');
         return $negatedString;
     }
     /**
@@ -63124,6 +63549,7 @@ declare (strict_types=1);
  */
 namespace PHPUnit\Framework\Constraint;
 
+use function array_any;
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  */
@@ -63155,12 +63581,7 @@ final class LogicalOr extends \PHPUnit\Framework\Constraint\BinaryOperator
      */
     public function matches(mixed $other): bool
     {
-        foreach ($this->constraints() as $constraint) {
-            if ($constraint->evaluate($other, '', \true)) {
-                return \true;
-            }
-        }
-        return \false;
+        return array_any($this->constraints(), static fn(\PHPUnit\Framework\Constraint\Constraint $constraint) => $constraint->evaluate($other, '', \true));
     }
 }
 <?php
@@ -63178,6 +63599,8 @@ namespace PHPUnit\Framework\Constraint;
 
 use function array_reduce;
 use function array_shift;
+use function assert;
+use function is_bool;
 use PHPUnit\Framework\ExpectationFailedException;
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -63217,7 +63640,9 @@ final class LogicalXor extends \PHPUnit\Framework\Constraint\BinaryOperator
         if ($initial === null) {
             return \false;
         }
-        return array_reduce($constraints, static fn(?bool $matches, \PHPUnit\Framework\Constraint\Constraint $constraint): bool => $matches xor $constraint->evaluate($other, '', \true), $initial->evaluate($other, '', \true));
+        $result = array_reduce($constraints, static fn(?bool $matches, \PHPUnit\Framework\Constraint\Constraint $constraint): bool => $matches xor $constraint->evaluate($other, '', \true), $initial->evaluate($other, '', \true));
+        assert(is_bool($result));
+        return $result;
     }
 }
 <?php
@@ -63727,6 +64152,7 @@ namespace PHPUnit\Framework\Constraint;
 
 use const DIRECTORY_SEPARATOR;
 use const PHP_EOL;
+use function assert;
 use function explode;
 use function implode;
 use function preg_match;
@@ -63804,7 +64230,9 @@ final class StringMatchesFormatDescription extends \PHPUnit\Framework\Constraint
     }
     private function convertNewlines(string $text): string
     {
-        return preg_replace('/\r\n/', "\n", $text);
+        $result = preg_replace('/\r\n/', "\n", $text);
+        assert($result !== null);
+        return $result;
     }
     private function differ(): Differ
     {
@@ -63856,114 +64284,6 @@ final class StringStartsWith extends \PHPUnit\Framework\Constraint\Constraint
     protected function matches(mixed $other): bool
     {
         return str_starts_with((string) $other, $this->prefix);
-    }
-}
-<?php
-
-declare (strict_types=1);
-/*
- * This file is part of PHPUnit.
- *
- * (c) Sebastian Bergmann <sebastian@phpunit.de>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-namespace PHPUnit\Framework\Constraint;
-
-use function array_key_exists;
-use function is_array;
-use ArrayAccess;
-use PHPUnit\Util\Exporter;
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- */
-final class ArrayHasKey extends \PHPUnit\Framework\Constraint\Constraint
-{
-    private readonly mixed $key;
-    public function __construct(mixed $key)
-    {
-        $this->key = $key;
-    }
-    /**
-     * Returns a string representation of the constraint.
-     */
-    public function toString(): string
-    {
-        return 'has the key ' . Exporter::export($this->key);
-    }
-    /**
-     * Evaluates the constraint for parameter $other. Returns true if the
-     * constraint is met, false otherwise.
-     */
-    protected function matches(mixed $other): bool
-    {
-        if (is_array($other)) {
-            return array_key_exists($this->key, $other);
-        }
-        if ($other instanceof ArrayAccess) {
-            return $other->offsetExists($this->key);
-        }
-        return \false;
-    }
-    /**
-     * Returns the description of the failure.
-     *
-     * The beginning of failure messages is "Failed asserting that" in most
-     * cases. This method should return the second part of that sentence.
-     */
-    protected function failureDescription(mixed $other): string
-    {
-        return 'an array ' . $this->toString();
-    }
-}
-<?php
-
-declare (strict_types=1);
-/*
- * This file is part of PHPUnit.
- *
- * (c) Sebastian Bergmann <sebastian@phpunit.de>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-namespace PHPUnit\Framework\Constraint;
-
-use function array_is_list;
-use function is_array;
-/**
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- */
-final class IsList extends \PHPUnit\Framework\Constraint\Constraint
-{
-    /**
-     * Returns a string representation of the constraint.
-     */
-    public function toString(): string
-    {
-        return 'is a list';
-    }
-    /**
-     * Evaluates the constraint for parameter $other. Returns true if the
-     * constraint is met, false otherwise.
-     */
-    protected function matches(mixed $other): bool
-    {
-        if (!is_array($other)) {
-            return \false;
-        }
-        return array_is_list($other);
-    }
-    /**
-     * Returns the description of the failure.
-     *
-     * The beginning of failure messages is "Failed asserting that" in most
-     * cases. This method should return the second part of that sentence.
-     */
-    protected function failureDescription(mixed $other): string
-    {
-        return $this->valueToTypeStringFragment($other) . $this->toString();
     }
 }
 <?php
@@ -65648,6 +65968,32 @@ use function sprintf;
  *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
+final class NoMoreParameterSetsConfiguredException extends \PHPUnit\Framework\Exception implements \PHPUnit\Framework\MockObject\Exception
+{
+    public function __construct(\PHPUnit\Framework\MockObject\Invocation $invocation, int $numberOfConfiguredParameterSets)
+    {
+        parent::__construct(sprintf('Not enough parameter sets configured, only %d parameter sets given for %s::%s()', $numberOfConfiguredParameterSets, $invocation->className(), $invocation->methodName()));
+    }
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+use function sprintf;
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
 final class NoMoreReturnValuesConfiguredException extends \PHPUnit\Framework\Exception implements \PHPUnit\Framework\MockObject\Exception
 {
     public function __construct(\PHPUnit\Framework\MockObject\Invocation $invocation, int $numberOfConfiguredReturnValues)
@@ -65701,6 +66047,31 @@ namespace PHPUnit\Framework\MockObject;
  */
 final class RuntimeException extends \RuntimeException implements \PHPUnit\Framework\MockObject\Exception
 {
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class TestDoubleSealedException extends \PHPUnit\Framework\Exception implements \PHPUnit\Framework\MockObject\Exception
+{
+    public function __construct()
+    {
+        parent::__construct('This test double has been sealed and cannot be configured further');
+    }
 }
 <?php
 
@@ -66471,7 +66842,7 @@ final class Generator
         $this->ensureValidMethods($methods);
         $this->ensureNameForTestDoubleClassIsAvailable($mockClassName);
         $mock = $this->generate($type, $mockObject, $methods, $mockClassName, $callOriginalClone);
-        $object = $this->instantiate($mock, $callOriginalConstructor, $arguments, $returnValueGeneration);
+        $object = $this->instantiate($mock, $callOriginalConstructor, $arguments, $returnValueGeneration, $mockObject);
         assert($object instanceof $type);
         if ($mockObject) {
             assert($object instanceof MockObject);
@@ -66586,7 +66957,7 @@ final class Generator
      * @throws ReflectionException
      * @throws RuntimeException
      */
-    private function instantiate(\PHPUnit\Framework\MockObject\Generator\DoubledClass $mockClass, bool $callOriginalConstructor = \false, array $arguments = [], bool $returnValueGeneration = \true): object
+    private function instantiate(\PHPUnit\Framework\MockObject\Generator\DoubledClass $mockClass, bool $callOriginalConstructor, array $arguments, bool $returnValueGeneration, bool $isMockObject): object
     {
         $className = $mockClass->generate();
         try {
@@ -66600,7 +66971,7 @@ final class Generator
         /**
          * @noinspection PhpUnhandledExceptionInspection
          */
-        $reflector->getProperty('__phpunit_state')->setValue($object, new TestDoubleState($mockClass->configurableMethods(), $returnValueGeneration));
+        $reflector->getProperty('__phpunit_state')->setValue($object, new TestDoubleState($mockClass->configurableMethods(), $returnValueGeneration, $isMockObject));
         if ($callOriginalConstructor && $reflector->getConstructor() !== null) {
             try {
                 $reflector->getConstructor()->invokeArgs($object, $arguments);
@@ -66941,11 +67312,6 @@ final class Generator
      */
     private function properties(?ReflectionClass $class): array
     {
-        if (version_compare('8.4.1', PHP_VERSION, '>')) {
-            // @codeCoverageIgnoreStart
-            return [];
-            // @codeCoverageIgnoreEnd
-        }
         if ($class === null) {
             return [];
         }
@@ -67035,8 +67401,14 @@ final readonly class HookedProperty
     {
         return $this->setHook;
     }
+    /**
+     * @throws RuntimeException
+     */
     public function setterType(): Type
     {
+        if ($this->setterType === null) {
+            throw new \PHPUnit\Framework\MockObject\Generator\RuntimeException();
+        }
         return $this->setterType;
     }
 }
@@ -67289,6 +67661,223 @@ declare (strict_types=1);
  */
 namespace PHPUnit\Framework\MockObject;
 
+use function array_flip;
+use function array_key_exists;
+use function array_map;
+use function array_merge;
+use function array_pop;
+use function assert;
+use function count;
+use function is_string;
+use function range;
+use function strtolower;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\InvalidArgumentException;
+use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
+use PHPUnit\Framework\MockObject\Stub\ConsecutiveCalls;
+use PHPUnit\Framework\MockObject\Stub\Exception;
+use PHPUnit\Framework\MockObject\Stub\ReturnArgument;
+use PHPUnit\Framework\MockObject\Stub\ReturnCallback;
+use PHPUnit\Framework\MockObject\Stub\ReturnReference;
+use PHPUnit\Framework\MockObject\Stub\ReturnSelf;
+use PHPUnit\Framework\MockObject\Stub\ReturnStub;
+use PHPUnit\Framework\MockObject\Stub\ReturnValueMap;
+use PHPUnit\Framework\MockObject\Stub\Stub;
+use Throwable;
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+abstract class AbstractInvocationImplementation implements \PHPUnit\Framework\MockObject\InvocationStubber
+{
+    protected readonly \PHPUnit\Framework\MockObject\InvocationHandler $invocationHandler;
+    protected readonly \PHPUnit\Framework\MockObject\Matcher $matcher;
+    /**
+     * @var list<ConfigurableMethod>
+     */
+    protected readonly array $configurableMethods;
+    /**
+     * @var ?array<string, int>
+     */
+    protected ?array $configurableMethodNames = null;
+    final public function __construct(\PHPUnit\Framework\MockObject\InvocationHandler $handler, \PHPUnit\Framework\MockObject\Matcher $matcher, \PHPUnit\Framework\MockObject\ConfigurableMethod ...$configurableMethods)
+    {
+        $this->invocationHandler = $handler;
+        $this->matcher = $matcher;
+        $this->configurableMethods = $configurableMethods;
+    }
+    /**
+     * @param Constraint|non-empty-string|PropertyHook $constraint
+     *
+     * @throws InvalidArgumentException
+     * @throws MethodCannotBeConfiguredException
+     * @throws MethodNameAlreadyConfiguredException
+     *
+     * @return $this
+     */
+    final public function method(Constraint|PropertyHook|string $constraint): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+        if ($this->matcher->hasMethodNameRule()) {
+            throw new \PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException();
+        }
+        if ($constraint instanceof PropertyHook) {
+            $constraint = $constraint->asString();
+        }
+        if (is_string($constraint)) {
+            $this->configurableMethodNames ??= array_flip(array_map(static fn(\PHPUnit\Framework\MockObject\ConfigurableMethod $configurable) => strtolower($configurable->name()), $this->configurableMethods));
+            if (!array_key_exists(strtolower($constraint), $this->configurableMethodNames)) {
+                throw new \PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException($constraint);
+            }
+        }
+        $this->matcher->setMethodNameRule(new \PHPUnit\Framework\MockObject\Rule\MethodName($constraint));
+        return $this;
+    }
+    /**
+     * @return $this
+     */
+    final public function will(Stub $stub): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+        $this->matcher->setStub($stub);
+        return $this;
+    }
+    /**
+     * @throws IncompatibleReturnValueException
+     */
+    final public function willReturn(mixed $value, mixed ...$nextValues): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+        if (count($nextValues) === 0) {
+            $this->ensureTypeOfReturnValues([$value]);
+            $stub = $value instanceof Stub ? $value : new ReturnStub($value);
+            return $this->will($stub);
+        }
+        $values = array_merge([$value], $nextValues);
+        $this->ensureTypeOfReturnValues($values);
+        $stub = new ConsecutiveCalls($values);
+        return $this->will($stub);
+    }
+    final public function willReturnReference(mixed &$reference): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+        $stub = new ReturnReference($reference);
+        return $this->will($stub);
+    }
+    final public function willReturnMap(array $valueMap): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+        $method = $this->configuredMethod();
+        assert($method instanceof \PHPUnit\Framework\MockObject\ConfigurableMethod);
+        $numberOfParameters = $method->numberOfParameters();
+        $defaultValues = $method->defaultParameterValues();
+        $hasDefaultValues = $defaultValues !== [];
+        $_valueMap = [];
+        foreach ($valueMap as $mapping) {
+            $numberOfConfiguredParameters = count($mapping) - 1;
+            if ($numberOfConfiguredParameters === $numberOfParameters || !$hasDefaultValues) {
+                $_valueMap[] = $mapping;
+                continue;
+            }
+            $_mapping = [];
+            $returnValue = array_pop($mapping);
+            foreach (range(0, $numberOfParameters - 1) as $i) {
+                if (array_key_exists($i, $mapping)) {
+                    $_mapping[] = $mapping[$i];
+                    continue;
+                }
+                if (array_key_exists($i, $defaultValues)) {
+                    $_mapping[] = $defaultValues[$i];
+                }
+            }
+            $_mapping[] = $returnValue;
+            $_valueMap[] = $_mapping;
+        }
+        $stub = new ReturnValueMap($_valueMap);
+        return $this->will($stub);
+    }
+    final public function willReturnArgument(int $argumentIndex): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+        $stub = new ReturnArgument($argumentIndex);
+        return $this->will($stub);
+    }
+    final public function willReturnCallback(callable $callback): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+        $stub = new ReturnCallback($callback);
+        return $this->will($stub);
+    }
+    final public function willReturnSelf(): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+        $stub = new ReturnSelf();
+        return $this->will($stub);
+    }
+    final public function willReturnOnConsecutiveCalls(mixed ...$values): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+        $stub = new ConsecutiveCalls($values);
+        return $this->will($stub);
+    }
+    final public function willThrowException(Throwable $exception): \PHPUnit\Framework\MockObject\InvocationStubber
+    {
+        $stub = new Exception($exception);
+        return $this->will($stub);
+    }
+    final public function seal(): void
+    {
+        $this->invocationHandler->seal($this->invocationHandler->isMockObject());
+    }
+    /**
+     * @throws MethodNameNotConfiguredException
+     * @throws MethodParametersAlreadyConfiguredException
+     */
+    final protected function ensureParametersCanBeConfigured(): void
+    {
+        if (!$this->matcher->hasMethodNameRule()) {
+            throw new \PHPUnit\Framework\MockObject\MethodNameNotConfiguredException();
+        }
+        if ($this->matcher->hasParametersRule()) {
+            throw new \PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException();
+        }
+    }
+    private function configuredMethod(): ?\PHPUnit\Framework\MockObject\ConfigurableMethod
+    {
+        $configuredMethod = null;
+        foreach ($this->configurableMethods as $configurableMethod) {
+            if ($this->matcher->methodNameRule()->matchesName($configurableMethod->name())) {
+                if ($configuredMethod !== null) {
+                    return null;
+                }
+                $configuredMethod = $configurableMethod;
+            }
+        }
+        return $configuredMethod;
+    }
+    /**
+     * @param array<mixed> $values
+     *
+     * @throws IncompatibleReturnValueException
+     */
+    private function ensureTypeOfReturnValues(array $values): void
+    {
+        $configuredMethod = $this->configuredMethod();
+        if ($configuredMethod === null) {
+            return;
+        }
+        foreach ($values as $value) {
+            if (!$configuredMethod->mayReturn($value)) {
+                throw new \PHPUnit\Framework\MockObject\IncompatibleReturnValueException($configuredMethod, $value);
+            }
+        }
+    }
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  *
@@ -67369,7 +67958,7 @@ trait MockObjectApi
     abstract public function __phpunit_state(): \PHPUnit\Framework\MockObject\TestDoubleState;
     abstract public function __phpunit_getInvocationHandler(): \PHPUnit\Framework\MockObject\InvocationHandler;
     abstract public function __phpunit_unsetInvocationMocker(): void;
-    public function expects(InvocationOrder $matcher): \PHPUnit\Framework\MockObject\InvocationStubber
+    public function expects(InvocationOrder $matcher): \PHPUnit\Framework\MockObject\InvocationMocker
     {
         return $this->__phpunit_getInvocationHandler()->expects($matcher);
     }
@@ -67463,21 +68052,23 @@ final class TestDoubleState
      */
     private readonly array $configurableMethods;
     private readonly bool $generateReturnValues;
+    private readonly bool $isMockObject;
     private ?\PHPUnit\Framework\MockObject\InvocationHandler $invocationHandler = null;
     /**
      * @param list<ConfigurableMethod> $configurableMethods
      */
-    public function __construct(array $configurableMethods, bool $generateReturnValues)
+    public function __construct(array $configurableMethods, bool $generateReturnValues, bool $isMockObject = \false)
     {
         $this->configurableMethods = $configurableMethods;
         $this->generateReturnValues = $generateReturnValues;
+        $this->isMockObject = $isMockObject;
     }
     public function invocationHandler(): \PHPUnit\Framework\MockObject\InvocationHandler
     {
         if ($this->invocationHandler !== null) {
             return $this->invocationHandler;
         }
-        $this->invocationHandler = new \PHPUnit\Framework\MockObject\InvocationHandler($this->configurableMethods, $this->generateReturnValues);
+        $this->invocationHandler = new \PHPUnit\Framework\MockObject\InvocationHandler($this->configurableMethods, $this->generateReturnValues, $this->isMockObject);
         return $this->invocationHandler;
     }
     public function cloneInvocationHandler(): void
@@ -67516,20 +68107,26 @@ declare (strict_types=1);
  */
 namespace PHPUnit\Framework\MockObject;
 
-use PHPUnit\Framework\Constraint\Constraint;
-use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
-use PHPUnit\Framework\MockObject\Stub\Stub;
-use Throwable;
-interface InvocationStubber
+interface InvocationMocker extends \PHPUnit\Framework\MockObject\InvocationStubber
 {
+    /**
+     * @return $this
+     */
+    public function with(mixed ...$arguments): self;
+    /**
+     * @return $this
+     */
+    public function withParameterSetsInOrder(mixed ...$arguments): self;
+    /**
+     * @return $this
+     */
+    public function withParameterSetsInAnyOrder(mixed ...$arguments): self;
     /**
      * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *
-     * @param Constraint|non-empty-string|PropertyHook $constraint
-     *
      * @return $this
      */
-    public function method(Constraint|PropertyHook|string $constraint): self;
+    public function withAnyParameters(): self;
     /**
      * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *
@@ -67546,16 +68143,34 @@ interface InvocationStubber
      * @return $this
      */
     public function after(string $id): self;
-    /**
-     * @return $this
-     */
-    public function with(mixed ...$arguments): self;
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
+use PHPUnit\Framework\MockObject\Stub\Stub;
+use Throwable;
+interface InvocationStubber
+{
     /**
      * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *
+     * @param Constraint|non-empty-string|PropertyHook $constraint
+     *
      * @return $this
      */
-    public function withAnyParameters(): self;
+    public function method(Constraint|PropertyHook|string $constraint): self;
     /**
      * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *
@@ -67612,6 +68227,7 @@ interface InvocationStubber
      * @return $this
      */
     public function willThrowException(Throwable $exception): self;
+    public function seal(): void;
 }
 <?php
 
@@ -67632,7 +68248,7 @@ use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
  */
 interface MockObject extends \PHPUnit\Framework\MockObject\Stub
 {
-    public function expects(InvocationOrder $invocationRule): \PHPUnit\Framework\MockObject\InvocationStubber;
+    public function expects(InvocationOrder $invocationRule): \PHPUnit\Framework\MockObject\InvocationMocker;
 }
 <?php
 
@@ -67804,7 +68420,7 @@ final readonly class Invocation implements SelfDescribing
     }
     public function toString(): string
     {
-        return sprintf('%s::%s(%s)%s', $this->className, $this->methodName, implode(', ', array_map([Exporter::class, 'shortenedExport'], $this->parameters)), $this->returnType !== '' ? sprintf(': %s', $this->returnType) : '');
+        return sprintf('%s::%s(%s)%s', $this->className, $this->methodName, implode(', ', array_map(Exporter::shortenedExport(...), $this->parameters)), $this->returnType !== '' ? sprintf(': %s', $this->returnType) : '');
     }
     public function object(): \PHPUnit\Framework\MockObject\MockObjectInternal|\PHPUnit\Framework\MockObject\StubInternal
     {
@@ -67824,9 +68440,15 @@ declare (strict_types=1);
  */
 namespace PHPUnit\Framework\MockObject;
 
+use function array_any;
+use function array_unique;
+use function array_values;
+use function in_array;
 use function strtolower;
 use Exception;
 use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
+use PHPUnit\Framework\MockObject\Rule\InvokedCount;
+use PHPUnit\Framework\MockObject\Rule\MethodName;
 use Throwable;
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -67848,22 +68470,24 @@ final class InvocationHandler
      */
     private readonly array $configurableMethods;
     private readonly bool $returnValueGeneration;
+    private readonly bool $isMockObject;
+    private bool $sealed = \false;
     /**
      * @param list<ConfigurableMethod> $configurableMethods
      */
-    public function __construct(array $configurableMethods, bool $returnValueGeneration)
+    public function __construct(array $configurableMethods, bool $returnValueGeneration, bool $isMockObject = \false)
     {
         $this->configurableMethods = $configurableMethods;
         $this->returnValueGeneration = $returnValueGeneration;
+        $this->isMockObject = $isMockObject;
+    }
+    public function isMockObject(): bool
+    {
+        return $this->isMockObject;
     }
     public function hasMatchers(): bool
     {
-        foreach ($this->matchers as $matcher) {
-            if ($matcher->hasMatchers()) {
-                return \true;
-            }
-        }
-        return \false;
+        return array_any($this->matchers, static fn(\PHPUnit\Framework\MockObject\Matcher $matcher) => $matcher->hasMatchers());
     }
     /**
      * Looks up the match builder with identification $id and returns it.
@@ -67889,11 +68513,17 @@ final class InvocationHandler
         }
         $this->matcherMap[$id] = $matcher;
     }
-    public function expects(InvocationOrder $rule): \PHPUnit\Framework\MockObject\InvocationStubber
+    /**
+     * @throws TestDoubleSealedException
+     */
+    public function expects(InvocationOrder $rule): \PHPUnit\Framework\MockObject\InvocationMocker
     {
+        if ($this->sealed) {
+            throw new \PHPUnit\Framework\MockObject\TestDoubleSealedException();
+        }
         $matcher = new \PHPUnit\Framework\MockObject\Matcher($rule);
         $this->addMatcher($matcher);
-        return new \PHPUnit\Framework\MockObject\InvocationStubberImplementation($this, $matcher, ...$this->configurableMethods);
+        return new \PHPUnit\Framework\MockObject\InvocationMockerImplementation($this, $matcher, ...$this->configurableMethods);
     }
     /**
      * @throws \PHPUnit\Framework\MockObject\Exception
@@ -67940,9 +68570,53 @@ final class InvocationHandler
             $matcher->verify();
         }
     }
+    public function seal(bool $isMockObject): void
+    {
+        if ($this->sealed) {
+            return;
+        }
+        $this->sealed = \true;
+        if (!$isMockObject) {
+            return;
+        }
+        $configuredMethods = $this->configuredMethodNames();
+        foreach ($this->configurableMethods as $method) {
+            if (!in_array($method->name(), $configuredMethods, \true)) {
+                $matcher = new \PHPUnit\Framework\MockObject\Matcher(new InvokedCount(0));
+                $matcher->setMethodNameRule(new MethodName($method->name()));
+                $this->addMatcher($matcher);
+            }
+        }
+    }
+    public function isSealed(): bool
+    {
+        return $this->sealed;
+    }
     private function addMatcher(\PHPUnit\Framework\MockObject\Matcher $matcher): void
     {
         $this->matchers[] = $matcher;
+    }
+    /**
+     * Returns the list of method names that have been configured with expectations.
+     * Only considers exact string matches for method names.
+     * Methods with any() expectation are considered configured.
+     *
+     * @return list<non-empty-string>
+     */
+    private function configuredMethodNames(): array
+    {
+        $names = [];
+        foreach ($this->matchers as $matcher) {
+            if (!$matcher->hasMethodNameRule()) {
+                continue;
+            }
+            foreach ($this->configurableMethods as $method) {
+                if ($matcher->methodNameRule()->matchesName($method->name())) {
+                    $names[] = $method->name();
+                }
+            }
+        }
+        return array_values(array_unique($names));
     }
 }
 <?php
@@ -67958,76 +68632,49 @@ declare (strict_types=1);
  */
 namespace PHPUnit\Framework\MockObject;
 
-use function array_flip;
-use function array_key_exists;
-use function array_map;
-use function array_merge;
-use function array_pop;
-use function assert;
-use function count;
-use function is_string;
-use function range;
-use function strtolower;
-use PHPUnit\Framework\Constraint\Constraint;
-use PHPUnit\Framework\InvalidArgumentException;
-use PHPUnit\Framework\MockObject\Runtime\PropertyHook;
-use PHPUnit\Framework\MockObject\Stub\ConsecutiveCalls;
-use PHPUnit\Framework\MockObject\Stub\Exception;
-use PHPUnit\Framework\MockObject\Stub\ReturnArgument;
-use PHPUnit\Framework\MockObject\Stub\ReturnCallback;
-use PHPUnit\Framework\MockObject\Stub\ReturnReference;
-use PHPUnit\Framework\MockObject\Stub\ReturnSelf;
-use PHPUnit\Framework\MockObject\Stub\ReturnStub;
-use PHPUnit\Framework\MockObject\Stub\ReturnValueMap;
-use PHPUnit\Framework\MockObject\Stub\Stub;
-use Throwable;
+use PHPUnit\Framework\Exception;
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
-final class InvocationStubberImplementation implements \PHPUnit\Framework\MockObject\InvocationStubber
+final class InvocationMockerImplementation extends \PHPUnit\Framework\MockObject\AbstractInvocationImplementation implements \PHPUnit\Framework\MockObject\InvocationMocker
 {
-    private readonly \PHPUnit\Framework\MockObject\InvocationHandler $invocationHandler;
-    private readonly \PHPUnit\Framework\MockObject\Matcher $matcher;
     /**
-     * @var list<ConfigurableMethod>
-     */
-    private readonly array $configurableMethods;
-    /**
-     * @var ?array<string, int>
-     */
-    private ?array $configurableMethodNames = null;
-    public function __construct(\PHPUnit\Framework\MockObject\InvocationHandler $handler, \PHPUnit\Framework\MockObject\Matcher $matcher, \PHPUnit\Framework\MockObject\ConfigurableMethod ...$configurableMethods)
-    {
-        $this->invocationHandler = $handler;
-        $this->matcher = $matcher;
-        $this->configurableMethods = $configurableMethods;
-    }
-    /**
-     * @param Constraint|non-empty-string|PropertyHook $constraint
-     *
-     * @throws InvalidArgumentException
-     * @throws MethodCannotBeConfiguredException
-     * @throws MethodNameAlreadyConfiguredException
+     * @throws Exception
+     * @throws MethodNameNotConfiguredException
+     * @throws MethodParametersAlreadyConfiguredException
      *
      * @return $this
      */
-    public function method(Constraint|PropertyHook|string $constraint): \PHPUnit\Framework\MockObject\InvocationStubber
+    public function with(mixed ...$arguments): \PHPUnit\Framework\MockObject\InvocationMocker
     {
-        if ($this->matcher->hasMethodNameRule()) {
-            throw new \PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException();
-        }
-        if ($constraint instanceof PropertyHook) {
-            $constraint = $constraint->asString();
-        }
-        if (is_string($constraint)) {
-            $this->configurableMethodNames ??= array_flip(array_map(static fn(\PHPUnit\Framework\MockObject\ConfigurableMethod $configurable) => strtolower($configurable->name()), $this->configurableMethods));
-            if (!array_key_exists(strtolower($constraint), $this->configurableMethodNames)) {
-                throw new \PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException($constraint);
-            }
-        }
-        $this->matcher->setMethodNameRule(new \PHPUnit\Framework\MockObject\Rule\MethodName($constraint));
+        $this->ensureParametersCanBeConfigured();
+        $this->matcher->setParametersRule(new \PHPUnit\Framework\MockObject\Rule\Parameters($arguments));
+        return $this;
+    }
+    public function withParameterSetsInOrder(mixed ...$arguments): \PHPUnit\Framework\MockObject\InvocationMocker
+    {
+        $this->ensureParametersCanBeConfigured();
+        $this->matcher->setParametersRule(new \PHPUnit\Framework\MockObject\Rule\OrderedParameterSets($arguments));
+        return $this;
+    }
+    public function withParameterSetsInAnyOrder(mixed ...$arguments): \PHPUnit\Framework\MockObject\InvocationMocker
+    {
+        $this->ensureParametersCanBeConfigured();
+        $this->matcher->setParametersRule(new \PHPUnit\Framework\MockObject\Rule\UnorderedParameterSets($arguments));
+        return $this;
+    }
+    /**
+     * @throws MethodNameNotConfiguredException
+     * @throws MethodParametersAlreadyConfiguredException
+     *
+     * @return $this
+     */
+    public function withAnyParameters(): \PHPUnit\Framework\MockObject\InvocationMocker
+    {
+        $this->ensureParametersCanBeConfigured();
+        $this->matcher->setParametersRule(new \PHPUnit\Framework\MockObject\Rule\AnyParameters());
         return $this;
     }
     /**
@@ -68037,7 +68684,7 @@ final class InvocationStubberImplementation implements \PHPUnit\Framework\MockOb
      *
      * @return $this
      */
-    public function id(string $id): \PHPUnit\Framework\MockObject\InvocationStubber
+    public function id(string $id): \PHPUnit\Framework\MockObject\InvocationMocker
     {
         $this->invocationHandler->registerMatcher($id, $this->matcher);
         return $this;
@@ -68047,163 +68694,32 @@ final class InvocationStubberImplementation implements \PHPUnit\Framework\MockOb
      *
      * @return $this
      */
-    public function after(string $id): \PHPUnit\Framework\MockObject\InvocationStubber
+    public function after(string $id): \PHPUnit\Framework\MockObject\InvocationMocker
     {
         $this->matcher->setAfterMatchBuilderId($id);
         return $this;
     }
-    /**
-     * @throws \PHPUnit\Framework\Exception
-     * @throws MethodNameNotConfiguredException
-     * @throws MethodParametersAlreadyConfiguredException
-     *
-     * @return $this
-     */
-    public function with(mixed ...$arguments): \PHPUnit\Framework\MockObject\InvocationStubber
-    {
-        $this->ensureParametersCanBeConfigured();
-        $this->matcher->setParametersRule(new \PHPUnit\Framework\MockObject\Rule\Parameters($arguments));
-        return $this;
-    }
-    /**
-     * @throws MethodNameNotConfiguredException
-     * @throws MethodParametersAlreadyConfiguredException
-     *
-     * @return $this
-     */
-    public function withAnyParameters(): \PHPUnit\Framework\MockObject\InvocationStubber
-    {
-        $this->ensureParametersCanBeConfigured();
-        $this->matcher->setParametersRule(new \PHPUnit\Framework\MockObject\Rule\AnyParameters());
-        return $this;
-    }
-    /**
-     * @return $this
-     */
-    public function will(Stub $stub): \PHPUnit\Framework\MockObject\InvocationStubber
-    {
-        $this->matcher->setStub($stub);
-        return $this;
-    }
-    /**
-     * @throws IncompatibleReturnValueException
-     */
-    public function willReturn(mixed $value, mixed ...$nextValues): \PHPUnit\Framework\MockObject\InvocationStubber
-    {
-        if (count($nextValues) === 0) {
-            $this->ensureTypeOfReturnValues([$value]);
-            $stub = $value instanceof Stub ? $value : new ReturnStub($value);
-            return $this->will($stub);
-        }
-        $values = array_merge([$value], $nextValues);
-        $this->ensureTypeOfReturnValues($values);
-        $stub = new ConsecutiveCalls($values);
-        return $this->will($stub);
-    }
-    public function willReturnReference(mixed &$reference): \PHPUnit\Framework\MockObject\InvocationStubber
-    {
-        $stub = new ReturnReference($reference);
-        return $this->will($stub);
-    }
-    public function willReturnMap(array $valueMap): \PHPUnit\Framework\MockObject\InvocationStubber
-    {
-        $method = $this->configuredMethod();
-        assert($method instanceof \PHPUnit\Framework\MockObject\ConfigurableMethod);
-        $numberOfParameters = $method->numberOfParameters();
-        $defaultValues = $method->defaultParameterValues();
-        $hasDefaultValues = $defaultValues !== [];
-        $_valueMap = [];
-        foreach ($valueMap as $mapping) {
-            $numberOfConfiguredParameters = count($mapping) - 1;
-            if ($numberOfConfiguredParameters === $numberOfParameters || !$hasDefaultValues) {
-                $_valueMap[] = $mapping;
-                continue;
-            }
-            $_mapping = [];
-            $returnValue = array_pop($mapping);
-            foreach (range(0, $numberOfParameters - 1) as $i) {
-                if (array_key_exists($i, $mapping)) {
-                    $_mapping[] = $mapping[$i];
-                    continue;
-                }
-                if (array_key_exists($i, $defaultValues)) {
-                    $_mapping[] = $defaultValues[$i];
-                }
-            }
-            $_mapping[] = $returnValue;
-            $_valueMap[] = $_mapping;
-        }
-        $stub = new ReturnValueMap($_valueMap);
-        return $this->will($stub);
-    }
-    public function willReturnArgument(int $argumentIndex): \PHPUnit\Framework\MockObject\InvocationStubber
-    {
-        $stub = new ReturnArgument($argumentIndex);
-        return $this->will($stub);
-    }
-    public function willReturnCallback(callable $callback): \PHPUnit\Framework\MockObject\InvocationStubber
-    {
-        $stub = new ReturnCallback($callback);
-        return $this->will($stub);
-    }
-    public function willReturnSelf(): \PHPUnit\Framework\MockObject\InvocationStubber
-    {
-        $stub = new ReturnSelf();
-        return $this->will($stub);
-    }
-    public function willReturnOnConsecutiveCalls(mixed ...$values): \PHPUnit\Framework\MockObject\InvocationStubber
-    {
-        $stub = new ConsecutiveCalls($values);
-        return $this->will($stub);
-    }
-    public function willThrowException(Throwable $exception): \PHPUnit\Framework\MockObject\InvocationStubber
-    {
-        $stub = new Exception($exception);
-        return $this->will($stub);
-    }
-    /**
-     * @throws MethodNameNotConfiguredException
-     * @throws MethodParametersAlreadyConfiguredException
-     */
-    private function ensureParametersCanBeConfigured(): void
-    {
-        if (!$this->matcher->hasMethodNameRule()) {
-            throw new \PHPUnit\Framework\MockObject\MethodNameNotConfiguredException();
-        }
-        if ($this->matcher->hasParametersRule()) {
-            throw new \PHPUnit\Framework\MockObject\MethodParametersAlreadyConfiguredException();
-        }
-    }
-    private function configuredMethod(): ?\PHPUnit\Framework\MockObject\ConfigurableMethod
-    {
-        $configuredMethod = null;
-        foreach ($this->configurableMethods as $configurableMethod) {
-            if ($this->matcher->methodNameRule()->matchesName($configurableMethod->name())) {
-                if ($configuredMethod !== null) {
-                    return null;
-                }
-                $configuredMethod = $configurableMethod;
-            }
-        }
-        return $configuredMethod;
-    }
-    /**
-     * @param array<mixed> $values
-     *
-     * @throws IncompatibleReturnValueException
-     */
-    private function ensureTypeOfReturnValues(array $values): void
-    {
-        $configuredMethod = $this->configuredMethod();
-        if ($configuredMethod === null) {
-            return;
-        }
-        foreach ($values as $value) {
-            if (!$configuredMethod->mayReturn($value)) {
-                throw new \PHPUnit\Framework\MockObject\IncompatibleReturnValueException($configuredMethod, $value);
-            }
-        }
-    }
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class InvocationStubberImplementation extends \PHPUnit\Framework\MockObject\AbstractInvocationImplementation implements \PHPUnit\Framework\MockObject\InvocationStubber
+{
 }
 <?php
 
@@ -68252,18 +68768,30 @@ final class Matcher
     {
         return !$this->invocationRule instanceof AnyInvokedCount;
     }
+    /**
+     * @phpstan-assert-if-true !null $this->methodNameRule
+     */
     public function hasMethodNameRule(): bool
     {
         return $this->methodNameRule !== null;
     }
+    /**
+     * @throws MethodNameNotConfiguredException
+     */
     public function methodNameRule(): MethodName
     {
+        if (!$this->hasMethodNameRule()) {
+            throw new \PHPUnit\Framework\MockObject\MethodNameNotConfiguredException();
+        }
         return $this->methodNameRule;
     }
     public function setMethodNameRule(MethodName $rule): void
     {
         $this->methodNameRule = $rule;
     }
+    /**
+     * @phpstan-assert-if-true !null $this->parametersRule
+     */
     public function hasParametersRule(): bool
     {
         return $this->parametersRule !== null;
@@ -68534,6 +69062,7 @@ declare (strict_types=1);
  */
 namespace PHPUnit\Framework\MockObject;
 
+use function array_all;
 use function array_map;
 use function explode;
 use function in_array;
@@ -68580,7 +69109,7 @@ final class ReturnValueGenerator
             $types = [$returnType];
         }
         if (!$intersection) {
-            $lowerTypes = array_map('strtolower', $types);
+            $lowerTypes = array_map(strtolower(...), $types);
             if (in_array('', $lowerTypes, \true) || in_array('null', $lowerTypes, \true) || in_array('mixed', $lowerTypes, \true) || in_array('void', $lowerTypes, \true)) {
                 return null;
             }
@@ -68648,12 +69177,7 @@ final class ReturnValueGenerator
      */
     private function onlyInterfaces(array $types): bool
     {
-        foreach ($types as $type) {
-            if (!interface_exists($type)) {
-                return \false;
-            }
-        }
-        return \true;
+        return array_all($types, static fn(string $type) => interface_exists($type));
     }
     /**
      * @param class-string     $className
@@ -69102,6 +69626,78 @@ declare (strict_types=1);
  */
 namespace PHPUnit\Framework\MockObject\Rule;
 
+use function array_shift;
+use function count;
+use function is_array;
+use function sprintf;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\MockObject\Invocation as BaseInvocation;
+use PHPUnit\Framework\MockObject\NoMoreParameterSetsConfiguredException;
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+final class OrderedParameterSets implements \PHPUnit\Framework\MockObject\Rule\ParametersRule
+{
+    /**
+     * @var list<Parameters>
+     */
+    private array $stack = [];
+    /**
+     * @var list<Parameters>
+     */
+    private array $applied = [];
+    private int $numberOfConfiguredParameterSets;
+    /**
+     * @param list<Parameters> $stack
+     */
+    public function __construct(array $stack)
+    {
+        foreach ($stack as $parameters) {
+            $this->stack[] = new \PHPUnit\Framework\MockObject\Rule\Parameters(is_array($parameters) ? $parameters : [$parameters]);
+        }
+        $this->numberOfConfiguredParameterSets = count($stack);
+    }
+    public function apply(BaseInvocation $invocation): void
+    {
+        if ($this->stack === []) {
+            throw new NoMoreParameterSetsConfiguredException($invocation, $this->numberOfConfiguredParameterSets);
+        }
+        $parameters = array_shift($this->stack);
+        $this->applied[] = $parameters;
+        $parameters->apply($invocation);
+    }
+    /**
+     * Checks if the invocation $invocation matches the current rules. If it
+     * does the rule will get the invoked() method called which should check
+     * if an expectation is met.
+     *
+     * @throws ExpectationFailedException
+     */
+    public function verify(): void
+    {
+        if (count($this->applied) !== $this->numberOfConfiguredParameterSets && count($this->stack) > 0) {
+            throw new ExpectationFailedException(sprintf('Too many parameter sets given, %d out of %d expected parameter set%s %s been called.', count($this->applied), $this->numberOfConfiguredParameterSets, $this->numberOfConfiguredParameterSets !== 1 ? 's' : '', count($this->applied) !== 1 ? 'have' : 'has'));
+        }
+        foreach ($this->applied as $parameters) {
+            $parameters->verify();
+        }
+    }
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject\Rule;
+
 use function count;
 use function sprintf;
 use Exception;
@@ -69125,6 +69721,7 @@ final class Parameters implements \PHPUnit\Framework\MockObject\Rule\ParametersR
     private array $parameters = [];
     private ?BaseInvocation $invocation = null;
     private null|bool|ExpectationFailedException $parameterVerificationResult;
+    private bool $useAssertionCount = \true;
     /**
      * @param array<mixed> $parameters
      *
@@ -69163,6 +69760,10 @@ final class Parameters implements \PHPUnit\Framework\MockObject\Rule\ParametersR
     public function verify(): void
     {
         $this->doVerify();
+    }
+    public function useAssertionCount(bool $useAssertionCount): void
+    {
+        $this->useAssertionCount = $useAssertionCount;
     }
     /**
      * @throws ExpectationFailedException
@@ -69210,6 +69811,9 @@ final class Parameters implements \PHPUnit\Framework\MockObject\Rule\ParametersR
     }
     private function incrementAssertionCount(): void
     {
+        if ($this->useAssertionCount === \false) {
+            return;
+        }
         Test::currentTestCase()->addToAssertionCount(1);
     }
 }
@@ -69238,6 +69842,94 @@ interface ParametersRule
      */
     public function apply(BaseInvocation $invocation): void;
     public function verify(): void;
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Framework\MockObject\Rule;
+
+use function array_search;
+use function array_shift;
+use function count;
+use function implode;
+use function is_array;
+use function sprintf;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\MockObject\Invocation as BaseInvocation;
+use PHPUnit\Framework\MockObject\NoMoreParameterSetsConfiguredException;
+final class UnorderedParameterSets implements \PHPUnit\Framework\MockObject\Rule\ParametersRule
+{
+    /**
+     * @var list<Parameters>
+     */
+    private array $stack = [];
+    /**
+     * @var list<Parameters>
+     */
+    private array $unapplied = [];
+    /**
+     * @var list<Parameters>
+     */
+    private array $applied = [];
+    private int $numberOfConfiguredParameterSets;
+    /**
+     * @param list<Parameters> $stack
+     */
+    public function __construct(array $stack)
+    {
+        foreach ($stack as $parameters) {
+            $this->stack[] = new \PHPUnit\Framework\MockObject\Rule\Parameters(is_array($parameters) ? $parameters : [$parameters]);
+        }
+        $this->unapplied = $this->stack;
+        $this->numberOfConfiguredParameterSets = count($stack);
+    }
+    public function apply(BaseInvocation $invocation): void
+    {
+        if ($this->unapplied === []) {
+            throw new NoMoreParameterSetsConfiguredException($invocation, $this->numberOfConfiguredParameterSets);
+        }
+        $checkedParameters = 0;
+        $unappliedParameters = count($this->unapplied);
+        while ($checkedParameters < $unappliedParameters) {
+            $checkedParameters++;
+            $parameters = array_shift($this->unapplied);
+            try {
+                $parameters->useAssertionCount(\false);
+                $parameters->apply($invocation);
+                $this->applied[] = $parameters;
+                $parameters->useAssertionCount(\true);
+                $parameters->apply($invocation);
+                break;
+            } catch (ExpectationFailedException $e) {
+                $this->unapplied[] = $parameters;
+            }
+        }
+    }
+    /**
+     * Checks if the invocation $invocation matches the current rules. If it
+     * does the rule will get the invoked() method called which should check
+     * if an expectation is met.
+     *
+     * @throws ExpectationFailedException
+     */
+    public function verify(): void
+    {
+        if (count($this->applied) !== $this->numberOfConfiguredParameterSets && count($this->unapplied) > 0) {
+            $unappliedIndexes = [];
+            foreach ($this->unapplied as $parameters) {
+                $unappliedIndexes[] = array_search($parameters, $this->stack, \true);
+            }
+            throw new ExpectationFailedException(sprintf('%d out of %d expected parameter set%s %s called, index%s [' . implode(', ', $unappliedIndexes) . '] %s not called.', count($this->applied), $this->numberOfConfiguredParameterSets, $this->numberOfConfiguredParameterSets !== 1 ? 's' : '', count($this->applied) !== 1 ? 'were' : 'was', count($unappliedIndexes) !== 1 ? 'es' : '', count($unappliedIndexes) !== 1 ? 'were' : 'was'));
+        }
+    }
 }
 <?php
 
@@ -69625,7 +70317,6 @@ abstract class TestDoubleBuilder
         try {
             $reflector = new ReflectionClass($this->type);
             // @codeCoverageIgnoreStart
-            /** @phpstan-ignore catch.neverThrown */
         } catch (\ReflectionException $e) {
             throw new ReflectionException($e->getMessage(), $e->getCode(), $e);
             // @codeCoverageIgnoreEnd
@@ -69902,8 +70593,6 @@ namespace PHPUnit\Framework;
 
 use function array_merge;
 use function assert;
-use function sprintf;
-use PHPUnit\Event\Facade as EventFacade;
 use PHPUnit\Metadata\Api\DataProvider;
 use PHPUnit\Metadata\Api\Groups;
 use PHPUnit\Metadata\Api\ProvidedData;
@@ -69944,10 +70633,10 @@ final readonly class TestBuilder
             }
         }
         if ($data !== null) {
-            return $this->buildDataProviderTestSuite($methodName, $className, $data, $this->shouldTestMethodBeRunInSeparateProcess($className, $methodName), $this->shouldGlobalStateBePreserved($className, $methodName), $this->shouldAllTestMethodsOfTestClassBeRunInSingleSeparateProcess($className), $this->backupSettings($className, $methodName), $groups);
+            return $this->buildDataProviderTestSuite($methodName, $className, $data, $this->shouldTestMethodBeRunInSeparateProcess($className, $methodName), $this->shouldGlobalStateBePreserved($className, $methodName), $this->backupSettings($className, $methodName), $groups);
         }
         $test = new $className($methodName);
-        $this->configureTestCase($test, $this->shouldTestMethodBeRunInSeparateProcess($className, $methodName), $this->shouldGlobalStateBePreserved($className, $methodName), $this->shouldAllTestMethodsOfTestClassBeRunInSingleSeparateProcess($className), $this->backupSettings($className, $methodName));
+        $this->configureTestCase($test, $this->shouldTestMethodBeRunInSeparateProcess($className, $methodName), $this->shouldGlobalStateBePreserved($className, $methodName), $this->backupSettings($className, $methodName));
         return $test;
     }
     /**
@@ -69957,14 +70646,14 @@ final readonly class TestBuilder
      * @param array{backupGlobals: ?true, backupGlobalsExcludeList: list<string>, backupStaticProperties: ?true, backupStaticPropertiesExcludeList: array<string,list<string>>} $backupSettings
      * @param list<non-empty-string>                                                                                                                                            $groups
      */
-    private function buildDataProviderTestSuite(string $methodName, string $className, array $data, bool $runTestInSeparateProcess, ?bool $preserveGlobalState, bool $runClassInSeparateProcess, array $backupSettings, array $groups): \PHPUnit\Framework\DataProviderTestSuite
+    private function buildDataProviderTestSuite(string $methodName, string $className, array $data, bool $runTestInSeparateProcess, ?bool $preserveGlobalState, array $backupSettings, array $groups): \PHPUnit\Framework\DataProviderTestSuite
     {
         $dataProviderTestSuite = \PHPUnit\Framework\DataProviderTestSuite::empty($className . '::' . $methodName);
         $groups = array_merge($groups, (new Groups())->groups($className, $methodName));
         foreach ($data as $_dataName => $_data) {
             $_test = new $className($methodName);
             $_test->setData($_dataName, $_data->value());
-            $this->configureTestCase($_test, $runTestInSeparateProcess, $preserveGlobalState, $runClassInSeparateProcess, $backupSettings);
+            $this->configureTestCase($_test, $runTestInSeparateProcess, $preserveGlobalState, $backupSettings);
             $dataProviderTestSuite->addTest($_test, $groups);
         }
         return $dataProviderTestSuite;
@@ -69972,13 +70661,10 @@ final readonly class TestBuilder
     /**
      * @param array{backupGlobals: ?true, backupGlobalsExcludeList: list<string>, backupStaticProperties: ?true, backupStaticPropertiesExcludeList: array<string,list<string>>} $backupSettings
      */
-    private function configureTestCase(\PHPUnit\Framework\TestCase $test, bool $runTestInSeparateProcess, ?bool $preserveGlobalState, bool $runClassInSeparateProcess, array $backupSettings): void
+    private function configureTestCase(\PHPUnit\Framework\TestCase $test, bool $runTestInSeparateProcess, ?bool $preserveGlobalState, array $backupSettings): void
     {
         if ($runTestInSeparateProcess) {
             $test->setRunTestInSeparateProcess(\true);
-        }
-        if ($runClassInSeparateProcess) {
-            $test->setRunClassInSeparateProcess(\true);
         }
         if ($preserveGlobalState !== null) {
             $test->setPreserveGlobalState($preserveGlobalState);
@@ -70085,17 +70771,6 @@ final readonly class TestBuilder
         return \false;
     }
     /**
-     * @param class-string<TestCase> $className
-     */
-    private function shouldAllTestMethodsOfTestClassBeRunInSingleSeparateProcess(string $className): bool
-    {
-        $result = MetadataRegistry::parser()->forClass($className)->isRunClassInSeparateProcess()->isNotEmpty();
-        if ($result) {
-            EventFacade::emitter()->testRunnerTriggeredPhpunitDeprecation(sprintf('Class %s uses the #[RunClassInSeparateProcess]. This attribute is deprecated and will be removed in PHPUnit 13', $className));
-        }
-        return $result;
-    }
-    /**
      * @param class-string     $className
      * @param non-empty-string $methodName
      */
@@ -70118,6 +70793,7 @@ declare (strict_types=1);
 namespace PHPUnit\Framework;
 
 use const PHP_EOL;
+use function array_any;
 use function array_keys;
 use function array_merge;
 use function array_reverse;
@@ -70202,6 +70878,7 @@ use PHPUnit\Util\Exporter;
 use PHPUnit\Util\Test as TestUtil;
 use ReflectionClass;
 use ReflectionException;
+use ReflectionMethod;
 use ReflectionObject;
 use PHPUnitPHAR\SebastianBergmann\CodeCoverage\UnintentionallyCoveredCodeException;
 use PHPUnitPHAR\SebastianBergmann\Comparator\Comparator;
@@ -70238,7 +70915,6 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
      * @var list<callable>
      */
     private ?array $backupGlobalExceptionHandlers = null;
-    private ?bool $runClassInSeparateProcess = null;
     private ?bool $runTestInSeparateProcess = null;
     private bool $preserveGlobalState = \false;
     private bool $inIsolation = \false;
@@ -70433,7 +71109,7 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
             }
             return;
         }
-        \PHPUnit\Framework\IsolatedTestRunnerRegistry::run($this, $this->runClassInSeparateProcess && !$this->runTestInSeparateProcess, $this->preserveGlobalState, $this->requiresXdebug());
+        \PHPUnit\Framework\IsolatedTestRunnerRegistry::run($this, $this->preserveGlobalState, $this->requiresXdebug());
     }
     /**
      * @return list<string>
@@ -70721,13 +71397,6 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
     /**
      * @internal This method is not covered by the backward compatibility promise for PHPUnit
      */
-    final public function setRunClassInSeparateProcess(bool $runClassInSeparateProcess): void
-    {
-        $this->runClassInSeparateProcess = $runClassInSeparateProcess;
-    }
-    /**
-     * @internal This method is not covered by the backward compatibility promise for PHPUnit
-     */
     final public function setPreserveGlobalState(bool $preserveGlobalState): void
     {
         $this->preserveGlobalState = $preserveGlobalState;
@@ -70902,6 +71571,7 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
      */
     final protected function any(): AnyInvokedCountMatcher
     {
+        Event\Facade::emitter()->testTriggeredPhpunitDeprecation($this->testValueObjectForEvents, 'The any() invoked count expectation is deprecated and will be removed in PHPUnit 14. ' . 'Use a test stub instead or configure a real invocation count expectation.');
         return new AnyInvokedCountMatcher();
     }
     /**
@@ -71145,6 +71815,14 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
         throw $t;
     }
     /**
+     * @param array<mixed> $testArguments
+     */
+    protected function invokeTestMethod(string $methodName, array $testArguments): mixed
+    {
+        /** @phpstan-ignore method.dynamicName */
+        return $this->{$methodName}(...$testArguments);
+    }
+    /**
      * Returns the data set as a string compatible with the --filter CLI option.
      *
      * @internal This method is not covered by the backward compatibility promise for PHPUnit
@@ -71170,8 +71848,7 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
         $testArguments = array_merge($this->data, array_values($this->dependencyInput));
         $this->startErrorLogCapture();
         try {
-            /** @phpstan-ignore method.dynamicName */
-            $testResult = $this->{$this->methodName}(...$testArguments);
+            $testResult = $this->invokeTestMethod($this->methodName, $testArguments);
             $this->verifyErrorLogExpectation();
         } catch (Throwable $exception) {
             $this->handleErrorLogError();
@@ -71183,13 +71860,16 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
         } finally {
             $this->stopErrorLogCapture();
         }
+        $this->emitEventForCustomTestMethodInvocation();
         $this->expectedExceptionWasNotRaised();
         return $testResult;
     }
     private function stripDateFromErrorLog(string $log): string
     {
         // https://github.com/php/php-src/blob/c696087e323263e941774ebbf902ac249774ec9f/main/main.c#L905
-        return preg_replace('/\[\d+-\w+-\d+ \d+:\d+:\d+ [^\r\n[\]]+?\] /', '', $log);
+        $result = preg_replace('/\[\d+-\w+-\d+ \d+:\d+:\d+ [^\r\n[\]]+?\] /', '', $log);
+        assert($result !== null);
+        return $result;
     }
     /**
      * @throws ExpectationFailedException
@@ -71204,13 +71884,7 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
         }
         foreach ($this->expectedUserDeprecationMessageRegularExpression as $deprecationExpectation) {
             $this->numberOfAssertionsPerformed++;
-            $expectedDeprecationTriggered = \false;
-            foreach (DeprecationCollector::deprecations() as $deprecation) {
-                if (@preg_match($deprecationExpectation, $deprecation) > 0) {
-                    $expectedDeprecationTriggered = \true;
-                    break;
-                }
-            }
+            $expectedDeprecationTriggered = array_any(DeprecationCollector::deprecations(), static fn(string $deprecation) => @preg_match($deprecationExpectation, $deprecation) > 0);
             if (!$expectedDeprecationTriggered) {
                 throw new \PHPUnit\Framework\ExpectationFailedException(sprintf('Expected deprecation with message matching regular expression "%s" was not triggered', $deprecationExpectation));
             }
@@ -71223,15 +71897,21 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
     {
         $allowsMockObjectsWithoutExpectations = $this->allowsMockObjectsWithoutExpectations();
         $isPhpunitTestSuite = str_starts_with($this::class, 'PHPUnit\\');
+        $requireSealedMockObjects = ConfigurationRegistry::get()->requireSealedMockObjects();
         foreach ($this->mockObjects as $mockObject) {
-            if (!$mockObject['mockObject']->__phpunit_hasMatchers()) {
+            $mockedType = $mockObject['type'];
+            $mockObject = $mockObject['mockObject'];
+            if ($requireSealedMockObjects && !$mockObject->__phpunit_getInvocationHandler()->isSealed()) {
+                Event\Facade::emitter()->testConsideredRisky($this->valueObjectForEvents(), sprintf('Mock object for %s has not been sealed', $mockedType));
+            }
+            if (!$mockObject->__phpunit_hasMatchers()) {
                 if (!$allowsMockObjectsWithoutExpectations && !$isPhpunitTestSuite) {
-                    Event\Facade::emitter()->testTriggeredPhpunitNotice($this->testValueObjectForEvents, sprintf('No expectations were configured for the mock object for %s. ' . 'Consider refactoring your test code to use a test stub instead. ' . 'The #[AllowMockObjectsWithoutExpectations] attribute can be used to opt out of this check.', $mockObject['type']));
+                    Event\Facade::emitter()->testTriggeredPhpunitNotice($this->testValueObjectForEvents, sprintf('No expectations were configured for the mock object for %s. ' . 'Consider refactoring your test code to use a test stub instead. ' . 'The #[AllowMockObjectsWithoutExpectations] attribute can be used to opt out of this check.', $mockedType));
                 }
                 continue;
             }
             $this->numberOfAssertionsPerformed++;
-            $mockObject['mockObject']->__phpunit_verify($this->shouldInvocationMockerBeReset($mockObject['mockObject']));
+            $mockObject->__phpunit_verify($this->shouldInvocationMockerBeReset($mockObject));
         }
     }
     /**
@@ -71602,9 +72282,6 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
         if ($this->runTestInSeparateProcess) {
             return \true;
         }
-        if ($this->runClassInSeparateProcess) {
-            return \true;
-        }
         return ConfigurationRegistry::get()->processIsolation();
     }
     private function isCallableTestMethod(string $dependency): bool
@@ -71793,12 +72470,7 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
     }
     private function isRegisteredFailure(Throwable $t): bool
     {
-        foreach (array_keys($this->failureTypes) as $failureType) {
-            if ($t instanceof $failureType) {
-                return \true;
-            }
-        }
-        return \false;
+        return array_any(array_keys($this->failureTypes), static fn(string $failureType) => $t instanceof $failureType);
     }
     /**
      * @internal This method is not covered by the backward compatibility promise for PHPUnit
@@ -71895,6 +72567,14 @@ abstract class TestCase extends \PHPUnit\Framework\Assert implements \PHPUnit\Fr
     private function allowsMockObjectsWithoutExpectations(): bool
     {
         return MetadataRegistry::parser()->forClassAndMethod(static::class, $this->methodName)->isAllowMockObjectsWithoutExpectations()->isNotEmpty();
+    }
+    private function emitEventForCustomTestMethodInvocation(): void
+    {
+        $reflector = new ReflectionMethod($this, 'invokeTestMethod');
+        if (self::class === $reflector->getDeclaringClass()->getName()) {
+            return;
+        }
+        Event\Facade::emitter()->testUsedCustomMethodInvocation($this->valueObjectForEvents(), new Event\Code\ClassMethod($reflector->getDeclaringClass()->getName(), 'invokeTestMethod'));
     }
     /**
      * Returns a builder object to create test stubs using a fluent interface.
@@ -72059,7 +72739,7 @@ namespace PHPUnit\Framework;
  */
 interface IsolatedTestRunner
 {
-    public function run(\PHPUnit\Framework\TestCase $test, bool $runEntireClass, bool $preserveGlobalState, bool $requiresXdebug): void;
+    public function run(\PHPUnit\Framework\TestCase $test, bool $preserveGlobalState, bool $requiresXdebug): void;
 }
 <?php
 
@@ -72082,12 +72762,12 @@ namespace PHPUnit\Framework;
 final class IsolatedTestRunnerRegistry
 {
     private static ?\PHPUnit\Framework\IsolatedTestRunner $runner = null;
-    public static function run(\PHPUnit\Framework\TestCase $test, bool $runEntireClass, bool $preserveGlobalState, bool $requiresXdebug): void
+    public static function run(\PHPUnit\Framework\TestCase $test, bool $preserveGlobalState, bool $requiresXdebug): void
     {
         if (self::$runner === null) {
             self::$runner = new \PHPUnit\Framework\SeparateProcessTestRunner();
         }
-        self::$runner->run($test, $runEntireClass, $preserveGlobalState, $requiresXdebug);
+        self::$runner->run($test, $preserveGlobalState, $requiresXdebug);
     }
     public static function set(\PHPUnit\Framework\IsolatedTestRunner $runner): void
     {
@@ -72115,7 +72795,6 @@ use function serialize;
 use function sys_get_temp_dir;
 use function tempnam;
 use function unlink;
-use function unserialize;
 use function var_export;
 use PHPUnit\Event\NoPreviousThrowableException;
 use PHPUnit\Runner\CodeCoverage;
@@ -72141,14 +72820,9 @@ final class SeparateProcessTestRunner implements \PHPUnit\Framework\IsolatedTest
      * @throws NoPreviousThrowableException
      * @throws ProcessIsolationException
      */
-    public function run(\PHPUnit\Framework\TestCase $test, bool $runEntireClass, bool $preserveGlobalState, bool $requiresXdebug): void
+    public function run(\PHPUnit\Framework\TestCase $test, bool $preserveGlobalState, bool $requiresXdebug): void
     {
         $class = new ReflectionClass($test);
-        if ($runEntireClass) {
-            $template = new Template(__DIR__ . '/templates/class.tpl');
-        } else {
-            $template = new Template(__DIR__ . '/templates/method.tpl');
-        }
         $bootstrap = '';
         $constants = '';
         $globals = '';
@@ -72189,10 +72863,8 @@ final class SeparateProcessTestRunner implements \PHPUnit\Framework\IsolatedTest
         $processResultFile = tempnam(sys_get_temp_dir(), 'phpunit_');
         $file = $class->getFileName();
         assert($file !== \false);
-        $var = ['bootstrap' => $bootstrap, 'composerAutoload' => $composerAutoload, 'phar' => $phar, 'filename' => $file, 'className' => $class->getName(), 'collectCodeCoverageInformation' => $coverage, 'data' => $data, 'dataName' => $dataName, 'dependencyInput' => $dependencyInput, 'constants' => $constants, 'globals' => $globals, 'include_path' => $includePath, 'included_files' => $includedFiles, 'iniSettings' => $iniSettings, 'name' => $test->name(), 'offsetSeconds' => (string) $offset[0], 'offsetNanoseconds' => (string) $offset[1], 'serializedConfiguration' => $serializedConfiguration, 'processResultFile' => $processResultFile];
-        if (!$runEntireClass) {
-            $var['methodName'] = $test->name();
-        }
+        $var = ['bootstrap' => $bootstrap, 'composerAutoload' => $composerAutoload, 'phar' => $phar, 'filename' => $file, 'className' => $class->getName(), 'methodName' => $test->name(), 'collectCodeCoverageInformation' => $coverage, 'data' => $data, 'dataName' => $dataName, 'dependencyInput' => $dependencyInput, 'constants' => $constants, 'globals' => $globals, 'include_path' => $includePath, 'included_files' => $includedFiles, 'iniSettings' => $iniSettings, 'name' => $test->name(), 'offsetSeconds' => (string) $offset[0], 'offsetNanoseconds' => (string) $offset[1], 'serializedConfiguration' => $serializedConfiguration, 'processResultFile' => $processResultFile];
+        $template = new Template(__DIR__ . '/templates/method.tpl');
         $template->setVar($var);
         $code = $template->render();
         assert($code !== '');
@@ -72422,7 +73094,7 @@ final class TestRunner
             $_timeout = $this->configuration->timeoutForLargeTests();
         }
         try {
-            (new Invoker())->invoke([$test, 'runBare'], [], $_timeout);
+            (new Invoker())->invoke($test->runBare(...), [], $_timeout);
         } catch (TimeoutException) {
             Facade::emitter()->testConsideredRisky($test->valueObjectForEvents(), sprintf('This test was aborted after %d second%s', $_timeout, $_timeout !== 1 ? 's' : ''));
             return \true;
@@ -72465,143 +73137,6 @@ final class TestRunner
         }
     }
 }
-<?php declare(strict_types=1);
-use PHPUnit\Event\Facade;
-use PHPUnit\Runner\CodeCoverage;
-use PHPUnit\Runner\ErrorHandler;
-use PHPUnit\TextUI\Configuration\Registry as ConfigurationRegistry;
-use PHPUnit\TextUI\Configuration\CodeCoverageFilterRegistry;
-use PHPUnit\TextUI\Configuration\PhpHandler;
-use PHPUnit\TestRunner\TestResult\PassedTests;
-
-// php://stdout does not obey output buffering. Any output would break
-// unserialization of child process results in the parent process.
-if (!defined('STDOUT')) {
-    define('STDOUT', fopen('php://temp', 'w+b'));
-    define('STDERR', fopen('php://stderr', 'wb'));
-}
-
-{iniSettings}
-ini_set('display_errors', 'stderr');
-set_include_path('{include_path}');
-
-$composerAutoload = {composerAutoload};
-$phar             = {phar};
-
-ob_start();
-
-if ($composerAutoload) {
-    require_once $composerAutoload;
-
-    define('PHPUNIT_COMPOSER_INSTALL', $composerAutoload);
-} else if ($phar) {
-    require $phar;
-}
-
-function __phpunit_run_isolated_test()
-{
-    $dispatcher = Facade::instance()->initForIsolation(
-        PHPUnit\Event\Telemetry\HRTime::fromSecondsAndNanoseconds(
-            {offsetSeconds},
-            {offsetNanoseconds}
-        ),
-    );
-
-    require_once '{filename}';
-
-    $configuration = ConfigurationRegistry::get();
-
-    if ({collectCodeCoverageInformation}) {
-        CodeCoverage::instance()->init($configuration, CodeCoverageFilterRegistry::instance(), true);
-    }
-
-    $deprecationTriggers = [
-        'functions' => [],
-        'methods'   => [],
-    ];
-
-    foreach ($configuration->source()->deprecationTriggers()['functions'] as $function) {
-        $deprecationTriggers['functions'][] = $function;
-    }
-
-    foreach ($configuration->source()->deprecationTriggers()['methods'] as $method) {
-        [$className, $methodName] = explode('::', $method);
-
-        $deprecationTriggers['methods'][] = [
-            'className'  => $className,
-            'methodName' => $methodName,
-        ];
-    }
-
-    ErrorHandler::instance()->useDeprecationTriggers($deprecationTriggers);
-
-    $test = new {className}('{name}');
-
-    $test->setData('{dataName}', unserialize('{data}'));
-    $test->setDependencyInput(unserialize('{dependencyInput}'));
-    $test->setInIsolation(true);
-
-    ob_end_clean();
-
-    $test->run();
-
-    $output = '';
-
-    if (!$test->expectsOutput()) {
-        $output = $test->output();
-    }
-
-    ini_set('xdebug.scream', '0');
-
-    // Not every STDOUT target stream is rewindable
-    $hasRewound = @rewind(STDOUT);
-
-    if ($hasRewound && $stdout = @stream_get_contents(STDOUT)) {
-        $output         = $stdout . $output;
-        $streamMetaData = stream_get_meta_data(STDOUT);
-
-        if (!empty($streamMetaData['stream_type']) && 'STDIO' === $streamMetaData['stream_type']) {
-            @ftruncate(STDOUT, 0);
-            @rewind(STDOUT);
-        }
-    }
-
-    file_put_contents(
-        '{processResultFile}',
-        serialize(
-            (object)[
-                'testResult'    => $test->result(),
-                'codeCoverage'  => {collectCodeCoverageInformation} ? CodeCoverage::instance()->codeCoverage() : null,
-                'numAssertions' => $test->numberOfAssertionsPerformed(),
-                'output'        => $output,
-                'events'        => $dispatcher->flush(),
-                'passedTests'   => PassedTests::instance()
-            ]
-        )
-    );
-}
-
-function __phpunit_error_handler($errno, $errstr, $errfile, $errline)
-{
-   return true;
-}
-
-set_error_handler('__phpunit_error_handler');
-
-{constants}
-{included_files}
-{globals}
-
-restore_error_handler();
-
-ConfigurationRegistry::loadFrom('{serializedConfiguration}');
-(new PhpHandler)->handle(ConfigurationRegistry::get()->php());
-
-if ('{bootstrap}' !== '') {
-    require_once '{bootstrap}';
-}
-
-__phpunit_run_isolated_test();
 <?php declare(strict_types=1);
 use PHPUnit\Event\Facade;
 use PHPUnit\Runner\CodeCoverage;
@@ -73539,6 +74074,7 @@ declare (strict_types=1);
 namespace PHPUnit\Framework;
 
 use const PHP_EOL;
+use function array_all;
 use function array_merge;
 use function array_pop;
 use function array_reverse;
@@ -73957,12 +74493,7 @@ class TestSuite implements IteratorAggregate, \PHPUnit\Framework\Reorderable, \P
      */
     private function containsOnlyVirtualGroups(array $groups): bool
     {
-        foreach ($groups as $group) {
-            if (!str_starts_with($group, '__phpunit_')) {
-                return \false;
-            }
-        }
-        return \true;
+        return array_all($groups, static fn(string $group) => str_starts_with($group, '__phpunit_'));
     }
     private function methodDoesNotExistOrIsDeclaredInTestCase(string $methodName): bool
     {
@@ -74077,7 +74608,6 @@ declare (strict_types=1);
 namespace PHPUnit\Framework;
 
 use function assert;
-use function count;
 use RecursiveIterator;
 /**
  * @template-implements RecursiveIterator<non-negative-int, Test>
@@ -74106,7 +74636,7 @@ final class TestSuiteIterator implements RecursiveIterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->tests);
+        return isset($this->tests[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -75016,7 +75546,9 @@ final readonly class InfrastructureInformationProvider
      */
     public function operatingSystem(): string
     {
-        return php_uname();
+        $result = php_uname();
+        assert($result !== '');
+        return $result;
     }
     /**
      * @return non-empty-string
@@ -75072,6 +75604,7 @@ final readonly class InfrastructureInformationProvider
         if (str_contains($originUrl, '@')) {
             $originUrl = explode('@', $originUrl)[1];
         }
+        assert($originUrl !== '');
         $branch = $this->executeGitCommand('symbolic-ref --short HEAD');
         if ($branch === \false) {
             return \false;
@@ -76842,6 +77375,7 @@ use function is_float;
 use function is_int;
 use function is_object;
 use function is_scalar;
+use function is_string;
 use function method_exists;
 use function preg_quote;
 use function preg_replace;
@@ -76922,6 +77456,7 @@ final class NamePrettifier
             $fullyQualifiedName = $className;
         }
         $result = preg_replace('/(?<=[[:lower:]])(?=[[:upper:]])/u', ' ', $className);
+        assert($result !== null);
         if ($fullyQualifiedName !== $className) {
             return $result . ' (' . $fullyQualifiedName . ')';
         }
@@ -77041,9 +77576,6 @@ final class NamePrettifier
         }
         return $providedData;
     }
-    /**
-     * @return non-empty-string
-     */
     private function objectToString(object $value): string
     {
         $reflector = new ReflectionObject($value);
@@ -77052,10 +77584,10 @@ final class NamePrettifier
             if ($enumReflector->isBacked()) {
                 return (string) $value->value;
             }
-            return $value->name;
+            return (string) $value->name;
         }
         if ($reflector->hasMethod('__toString')) {
-            return $value->__toString();
+            return (string) $value;
         }
         return $value::class;
     }
@@ -77073,6 +77605,7 @@ final class NamePrettifier
             $result = preg_replace($variables, $providedData, $annotation);
             $placeholdersUsed = \true;
         }
+        assert($result !== null);
         return [$result, $placeholdersUsed];
     }
     /**
@@ -77103,7 +77636,9 @@ final class NamePrettifier
             return [$this->prettifyTestMethodName($test->name()), \false];
         }
         try {
-            return [$reflector->invokeArgs(null, array_values($test->providedData())), \true];
+            $result = $reflector->invokeArgs(null, array_values($test->providedData()));
+            assert(is_string($result));
+            return [$result, \true];
         } catch (Throwable $t) {
             EventFacade::emitter()->testTriggeredPhpunitError(TestMethodBuilder::fromTestCase($test, \false), sprintf('TestDox formatter %s::%s() triggered an error: %s%s%s', $className, $methodName, $t->getMessage(), PHP_EOL, Filter::stackTraceFromThrowableAsString($t)));
             $this->erroredFormatters[$formatterIdentifier] = \true;
@@ -77783,7 +78318,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\Logging\TestDox;
 
-use function count;
 use Iterator;
 /**
  * @template-implements Iterator<non-negative-int, TestResult>
@@ -77812,7 +78346,7 @@ final class TestResultCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->testResults);
+        return isset($this->testResults[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -78137,10 +78671,7 @@ namespace PHPUnit\Metadata;
 final readonly class After extends \PHPUnit\Metadata\Metadata
 {
     private int $priority;
-    /**
-     * @param int<0, 1> $level
-     */
-    protected function __construct(int $level, int $priority)
+    protected function __construct(\PHPUnit\Metadata\Level $level, int $priority)
     {
         parent::__construct($level);
         $this->priority = $priority;
@@ -78175,10 +78706,7 @@ namespace PHPUnit\Metadata;
 final readonly class AfterClass extends \PHPUnit\Metadata\Metadata
 {
     private int $priority;
-    /**
-     * @param int<0, 1> $level
-     */
-    protected function __construct(int $level, int $priority)
+    protected function __construct(\PHPUnit\Metadata\Level $level, int $priority)
     {
         parent::__construct($level);
         $this->priority = $priority;
@@ -78231,7 +78759,6 @@ declare (strict_types=1);
 namespace PHPUnit\Metadata\Api;
 
 use function assert;
-use PHPUnit\Event\Facade as EventFacade;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Metadata\CoversClass;
 use PHPUnit\Metadata\CoversClassesThatExtendClass;
@@ -78337,14 +78864,8 @@ final class CodeCoverage
     }
     public function shouldCodeCoverageBeCollectedFor(TestCase $test): bool
     {
-        $className = $test::class;
-        $methodName = $test->name();
         $parser = Registry::parser();
-        if ($parser->forMethod($className, $methodName)->isCoversNothing()->isNotEmpty()) {
-            EventFacade::emitter()->testTriggeredPhpunitDeprecation($test->valueObjectForEvents(), 'Using #[CoversNothing] on a test method is deprecated, support for this will be removed in PHPUnit 13');
-            return \false;
-        }
-        if ($parser->forClass($className)->isCoversNothing()->isNotEmpty()) {
+        if ($parser->forClass($test::class)->isCoversNothing()->isNotEmpty()) {
             return \false;
         }
         return \true;
@@ -79025,10 +79546,7 @@ namespace PHPUnit\Metadata;
 final readonly class BackupGlobals extends \PHPUnit\Metadata\Metadata
 {
     private bool $enabled;
-    /**
-     * @param int<0, 1> $level
-     */
-    protected function __construct(int $level, bool $enabled)
+    protected function __construct(\PHPUnit\Metadata\Level $level, bool $enabled)
     {
         parent::__construct($level);
         $this->enabled = $enabled;
@@ -79063,10 +79581,7 @@ namespace PHPUnit\Metadata;
 final readonly class BackupStaticProperties extends \PHPUnit\Metadata\Metadata
 {
     private bool $enabled;
-    /**
-     * @param int<0, 1> $level
-     */
-    protected function __construct(int $level, bool $enabled)
+    protected function __construct(\PHPUnit\Metadata\Level $level, bool $enabled)
     {
         parent::__construct($level);
         $this->enabled = $enabled;
@@ -79101,10 +79616,7 @@ namespace PHPUnit\Metadata;
 final readonly class Before extends \PHPUnit\Metadata\Metadata
 {
     private int $priority;
-    /**
-     * @param int<0, 1> $level
-     */
-    protected function __construct(int $level, int $priority)
+    protected function __construct(\PHPUnit\Metadata\Level $level, int $priority)
     {
         parent::__construct($level);
         $this->priority = $priority;
@@ -79139,10 +79651,7 @@ namespace PHPUnit\Metadata;
 final readonly class BeforeClass extends \PHPUnit\Metadata\Metadata
 {
     private int $priority;
-    /**
-     * @param int<0, 1> $level
-     */
-    protected function __construct(int $level, int $priority)
+    protected function __construct(\PHPUnit\Metadata\Level $level, int $priority)
     {
         parent::__construct($level);
         $this->priority = $priority;
@@ -79181,10 +79690,9 @@ final readonly class CoversClass extends \PHPUnit\Metadata\Metadata
      */
     private string $className;
     /**
-     * @param int<0, 1>    $level
      * @param class-string $className
      */
-    protected function __construct(int $level, string $className)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $className)
     {
         parent::__construct($level);
         $this->className = $className;
@@ -79226,10 +79734,9 @@ final readonly class CoversClassesThatExtendClass extends \PHPUnit\Metadata\Meta
      */
     private string $className;
     /**
-     * @param int<0, 1>    $level
      * @param class-string $className
      */
-    protected function __construct(int $level, string $className)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $className)
     {
         parent::__construct($level);
         $this->className = $className;
@@ -79271,10 +79778,9 @@ final readonly class CoversClassesThatImplementInterface extends \PHPUnit\Metada
      */
     private string $interfaceName;
     /**
-     * @param int<0, 1>    $level
      * @param class-string $interfaceName
      */
-    protected function __construct(int $level, string $interfaceName)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $interfaceName)
     {
         parent::__construct($level);
         $this->interfaceName = $interfaceName;
@@ -79316,10 +79822,9 @@ final readonly class CoversFunction extends \PHPUnit\Metadata\Metadata
      */
     private string $functionName;
     /**
-     * @param int<0, 1>        $level
      * @param non-empty-string $functionName
      */
-    protected function __construct(int $level, string $functionName)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $functionName)
     {
         parent::__construct($level);
         $this->functionName = $functionName;
@@ -79365,11 +79870,10 @@ final readonly class CoversMethod extends \PHPUnit\Metadata\Metadata
      */
     private string $methodName;
     /**
-     * @param int<0, 1>        $level
      * @param class-string     $className
      * @param non-empty-string $methodName
      */
-    protected function __construct(int $level, string $className, string $methodName)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $className, string $methodName)
     {
         parent::__construct($level);
         $this->className = $className;
@@ -79419,10 +79923,9 @@ final readonly class CoversNamespace extends \PHPUnit\Metadata\Metadata
      */
     private string $namespace;
     /**
-     * @param int<0, 1>        $level
      * @param non-empty-string $namespace
      */
-    protected function __construct(int $level, string $namespace)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $namespace)
     {
         parent::__construct($level);
         $this->namespace = $namespace;
@@ -79489,10 +79992,9 @@ final readonly class CoversTrait extends \PHPUnit\Metadata\Metadata
      */
     private string $traitName;
     /**
-     * @param 0|1          $level
      * @param trait-string $traitName
      */
-    protected function __construct(int $level, string $traitName)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $traitName)
     {
         parent::__construct($level);
         $this->traitName = $traitName;
@@ -79539,11 +80041,10 @@ final readonly class DataProvider extends \PHPUnit\Metadata\Metadata
     private string $methodName;
     private bool $validateArgumentCount;
     /**
-     * @param int<0, 1>        $level
      * @param class-string     $className
      * @param non-empty-string $methodName
      */
-    protected function __construct(int $level, string $className, string $methodName, bool $validateArgumentCount)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $className, string $methodName, bool $validateArgumentCount)
     {
         parent::__construct($level);
         $this->className = $className;
@@ -79600,10 +80101,9 @@ final readonly class DependsOnClass extends \PHPUnit\Metadata\Metadata
     private bool $deepClone;
     private bool $shallowClone;
     /**
-     * @param int<0, 1>    $level
      * @param class-string $className
      */
-    protected function __construct(int $level, string $className, bool $deepClone, bool $shallowClone)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $className, bool $deepClone, bool $shallowClone)
     {
         parent::__construct($level);
         $this->className = $className;
@@ -79661,11 +80161,10 @@ final readonly class DependsOnMethod extends \PHPUnit\Metadata\Metadata
     private bool $deepClone;
     private bool $shallowClone;
     /**
-     * @param int<0, 1>        $level
      * @param class-string     $className
      * @param non-empty-string $methodName
      */
-    protected function __construct(int $level, string $className, string $methodName, bool $deepClone, bool $shallowClone)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $className, string $methodName, bool $deepClone, bool $shallowClone)
     {
         parent::__construct($level);
         $this->className = $className;
@@ -79870,10 +80369,9 @@ final readonly class ExcludeGlobalVariableFromBackup extends \PHPUnit\Metadata\M
      */
     private string $globalVariableName;
     /**
-     * @param int<0, 1>        $level
      * @param non-empty-string $globalVariableName
      */
-    protected function __construct(int $level, string $globalVariableName)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $globalVariableName)
     {
         parent::__construct($level);
         $this->globalVariableName = $globalVariableName;
@@ -79919,11 +80417,10 @@ final readonly class ExcludeStaticPropertyFromBackup extends \PHPUnit\Metadata\M
      */
     private string $propertyName;
     /**
-     * @param int<0, 1>        $level
      * @param class-string     $className
      * @param non-empty-string $propertyName
      */
-    protected function __construct(int $level, string $className, string $propertyName)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $className, string $propertyName)
     {
         parent::__construct($level);
         $this->className = $className;
@@ -79973,10 +80470,9 @@ final readonly class Group extends \PHPUnit\Metadata\Metadata
      */
     private string $groupName;
     /**
-     * @param int<0, 1>        $level
      * @param non-empty-string $groupName
      */
-    protected function __construct(int $level, string $groupName)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $groupName)
     {
         parent::__construct($level);
         $this->groupName = $groupName;
@@ -80016,10 +80512,9 @@ final readonly class IgnoreDeprecations extends \PHPUnit\Metadata\Metadata
     /** @var null|non-empty-string */
     private ?string $messagePattern;
     /**
-     * @param int<0, 1>             $level
      * @param null|non-empty-string $messagePattern
      */
-    protected function __construct(int $level, null|string $messagePattern)
+    protected function __construct(\PHPUnit\Metadata\Level $level, null|string $messagePattern)
     {
         parent::__construct($level);
         $this->messagePattern = $messagePattern;
@@ -80086,10 +80581,9 @@ final readonly class IgnorePhpunitWarnings extends \PHPUnit\Metadata\Metadata
     /** @var null|non-empty-string */
     private ?string $messagePattern;
     /**
-     * @param int<0, 1>             $level
      * @param null|non-empty-string $messagePattern
      */
-    protected function __construct(int $level, null|string $messagePattern)
+    protected function __construct(\PHPUnit\Metadata\Level $level, null|string $messagePattern)
     {
         parent::__construct($level);
         $this->messagePattern = $messagePattern;
@@ -80119,6 +80613,27 @@ declare (strict_types=1);
  */
 namespace PHPUnit\Metadata;
 
+/**
+ * @internal This enumeration is not covered by the backward compatibility promise for PHPUnit
+ */
+enum Level
+{
+    case CLASS_LEVEL;
+    case METHOD_LEVEL;
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\Metadata;
+
 use PHPUnit\Metadata\Version\Requirement;
 use PHPUnit\Runner\Extension\Extension;
 /**
@@ -80128,86 +80643,81 @@ use PHPUnit\Runner\Extension\Extension;
  */
 abstract readonly class Metadata
 {
-    private const int CLASS_LEVEL = 0;
-    private const int METHOD_LEVEL = 1;
-    /**
-     * @var int<0, 1>
-     */
-    private int $level;
+    private \PHPUnit\Metadata\Level $level;
     public static function after(int $priority): \PHPUnit\Metadata\After
     {
-        return new \PHPUnit\Metadata\After(self::METHOD_LEVEL, $priority);
+        return new \PHPUnit\Metadata\After(\PHPUnit\Metadata\Level::METHOD_LEVEL, $priority);
     }
     public static function afterClass(int $priority): \PHPUnit\Metadata\AfterClass
     {
-        return new \PHPUnit\Metadata\AfterClass(self::METHOD_LEVEL, $priority);
+        return new \PHPUnit\Metadata\AfterClass(\PHPUnit\Metadata\Level::METHOD_LEVEL, $priority);
     }
     public static function allowMockObjectsWithoutExpectationsOnClass(): \PHPUnit\Metadata\AllowMockObjectsWithoutExpectations
     {
-        return new \PHPUnit\Metadata\AllowMockObjectsWithoutExpectations(self::CLASS_LEVEL);
+        return new \PHPUnit\Metadata\AllowMockObjectsWithoutExpectations(\PHPUnit\Metadata\Level::CLASS_LEVEL);
     }
     public static function allowMockObjectsWithoutExpectationsOnMethod(): \PHPUnit\Metadata\AllowMockObjectsWithoutExpectations
     {
-        return new \PHPUnit\Metadata\AllowMockObjectsWithoutExpectations(self::METHOD_LEVEL);
+        return new \PHPUnit\Metadata\AllowMockObjectsWithoutExpectations(\PHPUnit\Metadata\Level::METHOD_LEVEL);
     }
     public static function backupGlobalsOnClass(bool $enabled): \PHPUnit\Metadata\BackupGlobals
     {
-        return new \PHPUnit\Metadata\BackupGlobals(self::CLASS_LEVEL, $enabled);
+        return new \PHPUnit\Metadata\BackupGlobals(\PHPUnit\Metadata\Level::CLASS_LEVEL, $enabled);
     }
     public static function backupGlobalsOnMethod(bool $enabled): \PHPUnit\Metadata\BackupGlobals
     {
-        return new \PHPUnit\Metadata\BackupGlobals(self::METHOD_LEVEL, $enabled);
+        return new \PHPUnit\Metadata\BackupGlobals(\PHPUnit\Metadata\Level::METHOD_LEVEL, $enabled);
     }
     public static function backupStaticPropertiesOnClass(bool $enabled): \PHPUnit\Metadata\BackupStaticProperties
     {
-        return new \PHPUnit\Metadata\BackupStaticProperties(self::CLASS_LEVEL, $enabled);
+        return new \PHPUnit\Metadata\BackupStaticProperties(\PHPUnit\Metadata\Level::CLASS_LEVEL, $enabled);
     }
     public static function backupStaticPropertiesOnMethod(bool $enabled): \PHPUnit\Metadata\BackupStaticProperties
     {
-        return new \PHPUnit\Metadata\BackupStaticProperties(self::METHOD_LEVEL, $enabled);
+        return new \PHPUnit\Metadata\BackupStaticProperties(\PHPUnit\Metadata\Level::METHOD_LEVEL, $enabled);
     }
     public static function before(int $priority): \PHPUnit\Metadata\Before
     {
-        return new \PHPUnit\Metadata\Before(self::METHOD_LEVEL, $priority);
+        return new \PHPUnit\Metadata\Before(\PHPUnit\Metadata\Level::METHOD_LEVEL, $priority);
     }
     public static function beforeClass(int $priority): \PHPUnit\Metadata\BeforeClass
     {
-        return new \PHPUnit\Metadata\BeforeClass(self::METHOD_LEVEL, $priority);
+        return new \PHPUnit\Metadata\BeforeClass(\PHPUnit\Metadata\Level::METHOD_LEVEL, $priority);
     }
     /**
      * @param non-empty-string $namespace
      */
     public static function coversNamespace(string $namespace): \PHPUnit\Metadata\CoversNamespace
     {
-        return new \PHPUnit\Metadata\CoversNamespace(self::CLASS_LEVEL, $namespace);
+        return new \PHPUnit\Metadata\CoversNamespace(\PHPUnit\Metadata\Level::CLASS_LEVEL, $namespace);
     }
     /**
      * @param class-string $className
      */
     public static function coversClass(string $className): \PHPUnit\Metadata\CoversClass
     {
-        return new \PHPUnit\Metadata\CoversClass(self::CLASS_LEVEL, $className);
+        return new \PHPUnit\Metadata\CoversClass(\PHPUnit\Metadata\Level::CLASS_LEVEL, $className);
     }
     /**
      * @param class-string $className
      */
     public static function coversClassesThatExtendClass(string $className): \PHPUnit\Metadata\CoversClassesThatExtendClass
     {
-        return new \PHPUnit\Metadata\CoversClassesThatExtendClass(self::CLASS_LEVEL, $className);
+        return new \PHPUnit\Metadata\CoversClassesThatExtendClass(\PHPUnit\Metadata\Level::CLASS_LEVEL, $className);
     }
     /**
      * @param class-string $interfaceName
      */
     public static function coversClassesThatImplementInterface(string $interfaceName): \PHPUnit\Metadata\CoversClassesThatImplementInterface
     {
-        return new \PHPUnit\Metadata\CoversClassesThatImplementInterface(self::CLASS_LEVEL, $interfaceName);
+        return new \PHPUnit\Metadata\CoversClassesThatImplementInterface(\PHPUnit\Metadata\Level::CLASS_LEVEL, $interfaceName);
     }
     /**
      * @param trait-string $traitName
      */
     public static function coversTrait(string $traitName): \PHPUnit\Metadata\CoversTrait
     {
-        return new \PHPUnit\Metadata\CoversTrait(self::CLASS_LEVEL, $traitName);
+        return new \PHPUnit\Metadata\CoversTrait(\PHPUnit\Metadata\Level::CLASS_LEVEL, $traitName);
     }
     /**
      * @param class-string     $className
@@ -80215,22 +80725,22 @@ abstract readonly class Metadata
      */
     public static function coversMethod(string $className, string $methodName): \PHPUnit\Metadata\CoversMethod
     {
-        return new \PHPUnit\Metadata\CoversMethod(self::CLASS_LEVEL, $className, $methodName);
+        return new \PHPUnit\Metadata\CoversMethod(\PHPUnit\Metadata\Level::CLASS_LEVEL, $className, $methodName);
     }
     /**
      * @param non-empty-string $functionName
      */
     public static function coversFunction(string $functionName): \PHPUnit\Metadata\CoversFunction
     {
-        return new \PHPUnit\Metadata\CoversFunction(self::CLASS_LEVEL, $functionName);
+        return new \PHPUnit\Metadata\CoversFunction(\PHPUnit\Metadata\Level::CLASS_LEVEL, $functionName);
     }
     public static function coversNothingOnClass(): \PHPUnit\Metadata\CoversNothing
     {
-        return new \PHPUnit\Metadata\CoversNothing(self::CLASS_LEVEL);
+        return new \PHPUnit\Metadata\CoversNothing(\PHPUnit\Metadata\Level::CLASS_LEVEL);
     }
     public static function coversNothingOnMethod(): \PHPUnit\Metadata\CoversNothing
     {
-        return new \PHPUnit\Metadata\CoversNothing(self::METHOD_LEVEL);
+        return new \PHPUnit\Metadata\CoversNothing(\PHPUnit\Metadata\Level::METHOD_LEVEL);
     }
     /**
      * @param class-string     $className
@@ -80238,14 +80748,14 @@ abstract readonly class Metadata
      */
     public static function dataProvider(string $className, string $methodName, bool $validateArgumentCount): \PHPUnit\Metadata\DataProvider
     {
-        return new \PHPUnit\Metadata\DataProvider(self::METHOD_LEVEL, $className, $methodName, $validateArgumentCount);
+        return new \PHPUnit\Metadata\DataProvider(\PHPUnit\Metadata\Level::METHOD_LEVEL, $className, $methodName, $validateArgumentCount);
     }
     /**
      * @param class-string $className
      */
     public static function dependsOnClass(string $className, bool $deepClone, bool $shallowClone): \PHPUnit\Metadata\DependsOnClass
     {
-        return new \PHPUnit\Metadata\DependsOnClass(self::METHOD_LEVEL, $className, $deepClone, $shallowClone);
+        return new \PHPUnit\Metadata\DependsOnClass(\PHPUnit\Metadata\Level::METHOD_LEVEL, $className, $deepClone, $shallowClone);
     }
     /**
      * @param class-string     $className
@@ -80253,33 +80763,33 @@ abstract readonly class Metadata
      */
     public static function dependsOnMethod(string $className, string $methodName, bool $deepClone, bool $shallowClone): \PHPUnit\Metadata\DependsOnMethod
     {
-        return new \PHPUnit\Metadata\DependsOnMethod(self::METHOD_LEVEL, $className, $methodName, $deepClone, $shallowClone);
+        return new \PHPUnit\Metadata\DependsOnMethod(\PHPUnit\Metadata\Level::METHOD_LEVEL, $className, $methodName, $deepClone, $shallowClone);
     }
     public static function disableReturnValueGenerationForTestDoubles(): \PHPUnit\Metadata\DisableReturnValueGenerationForTestDoubles
     {
-        return new \PHPUnit\Metadata\DisableReturnValueGenerationForTestDoubles(self::CLASS_LEVEL);
+        return new \PHPUnit\Metadata\DisableReturnValueGenerationForTestDoubles(\PHPUnit\Metadata\Level::CLASS_LEVEL);
     }
     public static function doesNotPerformAssertionsOnClass(): \PHPUnit\Metadata\DoesNotPerformAssertions
     {
-        return new \PHPUnit\Metadata\DoesNotPerformAssertions(self::CLASS_LEVEL);
+        return new \PHPUnit\Metadata\DoesNotPerformAssertions(\PHPUnit\Metadata\Level::CLASS_LEVEL);
     }
     public static function doesNotPerformAssertionsOnMethod(): \PHPUnit\Metadata\DoesNotPerformAssertions
     {
-        return new \PHPUnit\Metadata\DoesNotPerformAssertions(self::METHOD_LEVEL);
+        return new \PHPUnit\Metadata\DoesNotPerformAssertions(\PHPUnit\Metadata\Level::METHOD_LEVEL);
     }
     /**
      * @param non-empty-string $globalVariableName
      */
     public static function excludeGlobalVariableFromBackupOnClass(string $globalVariableName): \PHPUnit\Metadata\ExcludeGlobalVariableFromBackup
     {
-        return new \PHPUnit\Metadata\ExcludeGlobalVariableFromBackup(self::CLASS_LEVEL, $globalVariableName);
+        return new \PHPUnit\Metadata\ExcludeGlobalVariableFromBackup(\PHPUnit\Metadata\Level::CLASS_LEVEL, $globalVariableName);
     }
     /**
      * @param non-empty-string $globalVariableName
      */
     public static function excludeGlobalVariableFromBackupOnMethod(string $globalVariableName): \PHPUnit\Metadata\ExcludeGlobalVariableFromBackup
     {
-        return new \PHPUnit\Metadata\ExcludeGlobalVariableFromBackup(self::METHOD_LEVEL, $globalVariableName);
+        return new \PHPUnit\Metadata\ExcludeGlobalVariableFromBackup(\PHPUnit\Metadata\Level::METHOD_LEVEL, $globalVariableName);
     }
     /**
      * @param class-string     $className
@@ -80287,7 +80797,7 @@ abstract readonly class Metadata
      */
     public static function excludeStaticPropertyFromBackupOnClass(string $className, string $propertyName): \PHPUnit\Metadata\ExcludeStaticPropertyFromBackup
     {
-        return new \PHPUnit\Metadata\ExcludeStaticPropertyFromBackup(self::CLASS_LEVEL, $className, $propertyName);
+        return new \PHPUnit\Metadata\ExcludeStaticPropertyFromBackup(\PHPUnit\Metadata\Level::CLASS_LEVEL, $className, $propertyName);
     }
     /**
      * @param class-string     $className
@@ -80295,79 +80805,79 @@ abstract readonly class Metadata
      */
     public static function excludeStaticPropertyFromBackupOnMethod(string $className, string $propertyName): \PHPUnit\Metadata\ExcludeStaticPropertyFromBackup
     {
-        return new \PHPUnit\Metadata\ExcludeStaticPropertyFromBackup(self::METHOD_LEVEL, $className, $propertyName);
+        return new \PHPUnit\Metadata\ExcludeStaticPropertyFromBackup(\PHPUnit\Metadata\Level::METHOD_LEVEL, $className, $propertyName);
     }
     /**
      * @param non-empty-string $groupName
      */
     public static function groupOnClass(string $groupName): \PHPUnit\Metadata\Group
     {
-        return new \PHPUnit\Metadata\Group(self::CLASS_LEVEL, $groupName);
+        return new \PHPUnit\Metadata\Group(\PHPUnit\Metadata\Level::CLASS_LEVEL, $groupName);
     }
     /**
      * @param non-empty-string $groupName
      */
     public static function groupOnMethod(string $groupName): \PHPUnit\Metadata\Group
     {
-        return new \PHPUnit\Metadata\Group(self::METHOD_LEVEL, $groupName);
+        return new \PHPUnit\Metadata\Group(\PHPUnit\Metadata\Level::METHOD_LEVEL, $groupName);
     }
     /**
      * @param null|non-empty-string $messagePattern
      */
     public static function ignoreDeprecationsOnClass(?string $messagePattern = null): \PHPUnit\Metadata\IgnoreDeprecations
     {
-        return new \PHPUnit\Metadata\IgnoreDeprecations(self::CLASS_LEVEL, $messagePattern);
+        return new \PHPUnit\Metadata\IgnoreDeprecations(\PHPUnit\Metadata\Level::CLASS_LEVEL, $messagePattern);
     }
     /**
      * @param null|non-empty-string $messagePattern
      */
     public static function ignoreDeprecationsOnMethod(?string $messagePattern = null): \PHPUnit\Metadata\IgnoreDeprecations
     {
-        return new \PHPUnit\Metadata\IgnoreDeprecations(self::METHOD_LEVEL, $messagePattern);
+        return new \PHPUnit\Metadata\IgnoreDeprecations(\PHPUnit\Metadata\Level::METHOD_LEVEL, $messagePattern);
     }
     /**
      * @internal This method is not covered by the backward compatibility promise for PHPUnit
      */
     public static function ignorePhpunitDeprecationsOnClass(): \PHPUnit\Metadata\IgnorePhpunitDeprecations
     {
-        return new \PHPUnit\Metadata\IgnorePhpunitDeprecations(self::CLASS_LEVEL);
+        return new \PHPUnit\Metadata\IgnorePhpunitDeprecations(\PHPUnit\Metadata\Level::CLASS_LEVEL);
     }
     /**
      * @internal This method is not covered by the backward compatibility promise for PHPUnit
      */
     public static function ignorePhpunitDeprecationsOnMethod(): \PHPUnit\Metadata\IgnorePhpunitDeprecations
     {
-        return new \PHPUnit\Metadata\IgnorePhpunitDeprecations(self::METHOD_LEVEL);
+        return new \PHPUnit\Metadata\IgnorePhpunitDeprecations(\PHPUnit\Metadata\Level::METHOD_LEVEL);
     }
     public static function postCondition(int $priority): \PHPUnit\Metadata\PostCondition
     {
-        return new \PHPUnit\Metadata\PostCondition(self::METHOD_LEVEL, $priority);
+        return new \PHPUnit\Metadata\PostCondition(\PHPUnit\Metadata\Level::METHOD_LEVEL, $priority);
     }
     public static function preCondition(int $priority): \PHPUnit\Metadata\PreCondition
     {
-        return new \PHPUnit\Metadata\PreCondition(self::METHOD_LEVEL, $priority);
+        return new \PHPUnit\Metadata\PreCondition(\PHPUnit\Metadata\Level::METHOD_LEVEL, $priority);
     }
     public static function preserveGlobalStateOnClass(bool $enabled): \PHPUnit\Metadata\PreserveGlobalState
     {
-        return new \PHPUnit\Metadata\PreserveGlobalState(self::CLASS_LEVEL, $enabled);
+        return new \PHPUnit\Metadata\PreserveGlobalState(\PHPUnit\Metadata\Level::CLASS_LEVEL, $enabled);
     }
     public static function preserveGlobalStateOnMethod(bool $enabled): \PHPUnit\Metadata\PreserveGlobalState
     {
-        return new \PHPUnit\Metadata\PreserveGlobalState(self::METHOD_LEVEL, $enabled);
+        return new \PHPUnit\Metadata\PreserveGlobalState(\PHPUnit\Metadata\Level::METHOD_LEVEL, $enabled);
     }
     /**
      * @param non-empty-string $functionName
      */
     public static function requiresFunctionOnClass(string $functionName): \PHPUnit\Metadata\RequiresFunction
     {
-        return new \PHPUnit\Metadata\RequiresFunction(self::CLASS_LEVEL, $functionName);
+        return new \PHPUnit\Metadata\RequiresFunction(\PHPUnit\Metadata\Level::CLASS_LEVEL, $functionName);
     }
     /**
      * @param non-empty-string $functionName
      */
     public static function requiresFunctionOnMethod(string $functionName): \PHPUnit\Metadata\RequiresFunction
     {
-        return new \PHPUnit\Metadata\RequiresFunction(self::METHOD_LEVEL, $functionName);
+        return new \PHPUnit\Metadata\RequiresFunction(\PHPUnit\Metadata\Level::METHOD_LEVEL, $functionName);
     }
     /**
      * @param class-string     $className
@@ -80375,7 +80885,7 @@ abstract readonly class Metadata
      */
     public static function requiresMethodOnClass(string $className, string $methodName): \PHPUnit\Metadata\RequiresMethod
     {
-        return new \PHPUnit\Metadata\RequiresMethod(self::CLASS_LEVEL, $className, $methodName);
+        return new \PHPUnit\Metadata\RequiresMethod(\PHPUnit\Metadata\Level::CLASS_LEVEL, $className, $methodName);
     }
     /**
      * @param class-string     $className
@@ -80383,95 +80893,95 @@ abstract readonly class Metadata
      */
     public static function requiresMethodOnMethod(string $className, string $methodName): \PHPUnit\Metadata\RequiresMethod
     {
-        return new \PHPUnit\Metadata\RequiresMethod(self::METHOD_LEVEL, $className, $methodName);
+        return new \PHPUnit\Metadata\RequiresMethod(\PHPUnit\Metadata\Level::METHOD_LEVEL, $className, $methodName);
     }
     /**
      * @param non-empty-string $operatingSystem
      */
     public static function requiresOperatingSystemOnClass(string $operatingSystem): \PHPUnit\Metadata\RequiresOperatingSystem
     {
-        return new \PHPUnit\Metadata\RequiresOperatingSystem(self::CLASS_LEVEL, $operatingSystem);
+        return new \PHPUnit\Metadata\RequiresOperatingSystem(\PHPUnit\Metadata\Level::CLASS_LEVEL, $operatingSystem);
     }
     /**
      * @param non-empty-string $operatingSystem
      */
     public static function requiresOperatingSystemOnMethod(string $operatingSystem): \PHPUnit\Metadata\RequiresOperatingSystem
     {
-        return new \PHPUnit\Metadata\RequiresOperatingSystem(self::METHOD_LEVEL, $operatingSystem);
+        return new \PHPUnit\Metadata\RequiresOperatingSystem(\PHPUnit\Metadata\Level::METHOD_LEVEL, $operatingSystem);
     }
     /**
      * @param non-empty-string $operatingSystemFamily
      */
     public static function requiresOperatingSystemFamilyOnClass(string $operatingSystemFamily): \PHPUnit\Metadata\RequiresOperatingSystemFamily
     {
-        return new \PHPUnit\Metadata\RequiresOperatingSystemFamily(self::CLASS_LEVEL, $operatingSystemFamily);
+        return new \PHPUnit\Metadata\RequiresOperatingSystemFamily(\PHPUnit\Metadata\Level::CLASS_LEVEL, $operatingSystemFamily);
     }
     /**
      * @param non-empty-string $operatingSystemFamily
      */
     public static function requiresOperatingSystemFamilyOnMethod(string $operatingSystemFamily): \PHPUnit\Metadata\RequiresOperatingSystemFamily
     {
-        return new \PHPUnit\Metadata\RequiresOperatingSystemFamily(self::METHOD_LEVEL, $operatingSystemFamily);
+        return new \PHPUnit\Metadata\RequiresOperatingSystemFamily(\PHPUnit\Metadata\Level::METHOD_LEVEL, $operatingSystemFamily);
     }
     public static function requiresPhpOnClass(Requirement $versionRequirement): \PHPUnit\Metadata\RequiresPhp
     {
-        return new \PHPUnit\Metadata\RequiresPhp(self::CLASS_LEVEL, $versionRequirement);
+        return new \PHPUnit\Metadata\RequiresPhp(\PHPUnit\Metadata\Level::CLASS_LEVEL, $versionRequirement);
     }
     public static function requiresPhpOnMethod(Requirement $versionRequirement): \PHPUnit\Metadata\RequiresPhp
     {
-        return new \PHPUnit\Metadata\RequiresPhp(self::METHOD_LEVEL, $versionRequirement);
+        return new \PHPUnit\Metadata\RequiresPhp(\PHPUnit\Metadata\Level::METHOD_LEVEL, $versionRequirement);
     }
     /**
      * @param non-empty-string $extension
      */
     public static function requiresPhpExtensionOnClass(string $extension, ?Requirement $versionRequirement): \PHPUnit\Metadata\RequiresPhpExtension
     {
-        return new \PHPUnit\Metadata\RequiresPhpExtension(self::CLASS_LEVEL, $extension, $versionRequirement);
+        return new \PHPUnit\Metadata\RequiresPhpExtension(\PHPUnit\Metadata\Level::CLASS_LEVEL, $extension, $versionRequirement);
     }
     /**
      * @param non-empty-string $extension
      */
     public static function requiresPhpExtensionOnMethod(string $extension, ?Requirement $versionRequirement): \PHPUnit\Metadata\RequiresPhpExtension
     {
-        return new \PHPUnit\Metadata\RequiresPhpExtension(self::METHOD_LEVEL, $extension, $versionRequirement);
+        return new \PHPUnit\Metadata\RequiresPhpExtension(\PHPUnit\Metadata\Level::METHOD_LEVEL, $extension, $versionRequirement);
     }
     public static function requiresPhpunitOnClass(Requirement $versionRequirement): \PHPUnit\Metadata\RequiresPhpunit
     {
-        return new \PHPUnit\Metadata\RequiresPhpunit(self::CLASS_LEVEL, $versionRequirement);
+        return new \PHPUnit\Metadata\RequiresPhpunit(\PHPUnit\Metadata\Level::CLASS_LEVEL, $versionRequirement);
     }
     public static function requiresPhpunitOnMethod(Requirement $versionRequirement): \PHPUnit\Metadata\RequiresPhpunit
     {
-        return new \PHPUnit\Metadata\RequiresPhpunit(self::METHOD_LEVEL, $versionRequirement);
+        return new \PHPUnit\Metadata\RequiresPhpunit(\PHPUnit\Metadata\Level::METHOD_LEVEL, $versionRequirement);
     }
     /**
      * @param class-string<Extension> $extensionClass
      */
     public static function requiresPhpunitExtensionOnClass(string $extensionClass): \PHPUnit\Metadata\RequiresPhpunitExtension
     {
-        return new \PHPUnit\Metadata\RequiresPhpunitExtension(self::CLASS_LEVEL, $extensionClass);
+        return new \PHPUnit\Metadata\RequiresPhpunitExtension(\PHPUnit\Metadata\Level::CLASS_LEVEL, $extensionClass);
     }
     /**
      * @param class-string<Extension> $extensionClass
      */
     public static function requiresPhpunitExtensionOnMethod(string $extensionClass): \PHPUnit\Metadata\RequiresPhpunitExtension
     {
-        return new \PHPUnit\Metadata\RequiresPhpunitExtension(self::METHOD_LEVEL, $extensionClass);
+        return new \PHPUnit\Metadata\RequiresPhpunitExtension(\PHPUnit\Metadata\Level::METHOD_LEVEL, $extensionClass);
     }
     public static function requiresEnvironmentVariableOnClass(string $environmentVariableName, null|string $value): \PHPUnit\Metadata\RequiresEnvironmentVariable
     {
-        return new \PHPUnit\Metadata\RequiresEnvironmentVariable(self::CLASS_LEVEL, $environmentVariableName, $value);
+        return new \PHPUnit\Metadata\RequiresEnvironmentVariable(\PHPUnit\Metadata\Level::CLASS_LEVEL, $environmentVariableName, $value);
     }
     public static function requiresEnvironmentVariableOnMethod(string $environmentVariableName, null|string $value): \PHPUnit\Metadata\RequiresEnvironmentVariable
     {
-        return new \PHPUnit\Metadata\RequiresEnvironmentVariable(self::METHOD_LEVEL, $environmentVariableName, $value);
+        return new \PHPUnit\Metadata\RequiresEnvironmentVariable(\PHPUnit\Metadata\Level::METHOD_LEVEL, $environmentVariableName, $value);
     }
     public static function withEnvironmentVariableOnClass(string $environmentVariableName, null|string $value): \PHPUnit\Metadata\WithEnvironmentVariable
     {
-        return new \PHPUnit\Metadata\WithEnvironmentVariable(self::CLASS_LEVEL, $environmentVariableName, $value);
+        return new \PHPUnit\Metadata\WithEnvironmentVariable(\PHPUnit\Metadata\Level::CLASS_LEVEL, $environmentVariableName, $value);
     }
     public static function withEnvironmentVariableOnMethod(string $environmentVariableName, null|string $value): \PHPUnit\Metadata\WithEnvironmentVariable
     {
-        return new \PHPUnit\Metadata\WithEnvironmentVariable(self::METHOD_LEVEL, $environmentVariableName, $value);
+        return new \PHPUnit\Metadata\WithEnvironmentVariable(\PHPUnit\Metadata\Level::METHOD_LEVEL, $environmentVariableName, $value);
     }
     /**
      * @param non-empty-string $setting
@@ -80479,7 +80989,7 @@ abstract readonly class Metadata
      */
     public static function requiresSettingOnClass(string $setting, string $value): \PHPUnit\Metadata\RequiresSetting
     {
-        return new \PHPUnit\Metadata\RequiresSetting(self::CLASS_LEVEL, $setting, $value);
+        return new \PHPUnit\Metadata\RequiresSetting(\PHPUnit\Metadata\Level::CLASS_LEVEL, $setting, $value);
     }
     /**
      * @param non-empty-string $setting
@@ -80487,37 +80997,33 @@ abstract readonly class Metadata
      */
     public static function requiresSettingOnMethod(string $setting, string $value): \PHPUnit\Metadata\RequiresSetting
     {
-        return new \PHPUnit\Metadata\RequiresSetting(self::METHOD_LEVEL, $setting, $value);
-    }
-    public static function runClassInSeparateProcess(): \PHPUnit\Metadata\RunClassInSeparateProcess
-    {
-        return new \PHPUnit\Metadata\RunClassInSeparateProcess(self::CLASS_LEVEL);
+        return new \PHPUnit\Metadata\RequiresSetting(\PHPUnit\Metadata\Level::METHOD_LEVEL, $setting, $value);
     }
     public static function runTestsInSeparateProcesses(): \PHPUnit\Metadata\RunTestsInSeparateProcesses
     {
-        return new \PHPUnit\Metadata\RunTestsInSeparateProcesses(self::CLASS_LEVEL);
+        return new \PHPUnit\Metadata\RunTestsInSeparateProcesses(\PHPUnit\Metadata\Level::CLASS_LEVEL);
     }
     public static function runInSeparateProcess(): \PHPUnit\Metadata\RunInSeparateProcess
     {
-        return new \PHPUnit\Metadata\RunInSeparateProcess(self::METHOD_LEVEL);
+        return new \PHPUnit\Metadata\RunInSeparateProcess(\PHPUnit\Metadata\Level::METHOD_LEVEL);
     }
     public static function test(): \PHPUnit\Metadata\Test
     {
-        return new \PHPUnit\Metadata\Test(self::METHOD_LEVEL);
+        return new \PHPUnit\Metadata\Test(\PHPUnit\Metadata\Level::METHOD_LEVEL);
     }
     /**
      * @param non-empty-string $text
      */
     public static function testDoxOnClass(string $text): \PHPUnit\Metadata\TestDox
     {
-        return new \PHPUnit\Metadata\TestDox(self::CLASS_LEVEL, $text);
+        return new \PHPUnit\Metadata\TestDox(\PHPUnit\Metadata\Level::CLASS_LEVEL, $text);
     }
     /**
      * @param non-empty-string $text
      */
     public static function testDoxOnMethod(string $text): \PHPUnit\Metadata\TestDox
     {
-        return new \PHPUnit\Metadata\TestDox(self::METHOD_LEVEL, $text);
+        return new \PHPUnit\Metadata\TestDox(\PHPUnit\Metadata\Level::METHOD_LEVEL, $text);
     }
     /**
      * @param class-string     $className
@@ -80525,56 +81031,56 @@ abstract readonly class Metadata
      */
     public static function testDoxFormatter(string $className, string $methodName): \PHPUnit\Metadata\TestDoxFormatter
     {
-        return new \PHPUnit\Metadata\TestDoxFormatter(self::METHOD_LEVEL, $className, $methodName);
+        return new \PHPUnit\Metadata\TestDoxFormatter(\PHPUnit\Metadata\Level::METHOD_LEVEL, $className, $methodName);
     }
     /**
      * @param ?non-empty-string $name
      */
     public static function testWith(mixed $data, ?string $name = null): \PHPUnit\Metadata\TestWith
     {
-        return new \PHPUnit\Metadata\TestWith(self::METHOD_LEVEL, $data, $name);
+        return new \PHPUnit\Metadata\TestWith(\PHPUnit\Metadata\Level::METHOD_LEVEL, $data, $name);
     }
     /**
      * @param non-empty-string $namespace
      */
     public static function usesNamespace(string $namespace): \PHPUnit\Metadata\UsesNamespace
     {
-        return new \PHPUnit\Metadata\UsesNamespace(self::CLASS_LEVEL, $namespace);
+        return new \PHPUnit\Metadata\UsesNamespace(\PHPUnit\Metadata\Level::CLASS_LEVEL, $namespace);
     }
     /**
      * @param class-string $className
      */
     public static function usesClass(string $className): \PHPUnit\Metadata\UsesClass
     {
-        return new \PHPUnit\Metadata\UsesClass(self::CLASS_LEVEL, $className);
+        return new \PHPUnit\Metadata\UsesClass(\PHPUnit\Metadata\Level::CLASS_LEVEL, $className);
     }
     /**
      * @param class-string $className
      */
     public static function usesClassesThatExtendClass(string $className): \PHPUnit\Metadata\UsesClassesThatExtendClass
     {
-        return new \PHPUnit\Metadata\UsesClassesThatExtendClass(self::CLASS_LEVEL, $className);
+        return new \PHPUnit\Metadata\UsesClassesThatExtendClass(\PHPUnit\Metadata\Level::CLASS_LEVEL, $className);
     }
     /**
      * @param class-string $interfaceName
      */
     public static function usesClassesThatImplementInterface(string $interfaceName): \PHPUnit\Metadata\UsesClassesThatImplementInterface
     {
-        return new \PHPUnit\Metadata\UsesClassesThatImplementInterface(self::CLASS_LEVEL, $interfaceName);
+        return new \PHPUnit\Metadata\UsesClassesThatImplementInterface(\PHPUnit\Metadata\Level::CLASS_LEVEL, $interfaceName);
     }
     /**
      * @param trait-string $traitName
      */
     public static function usesTrait(string $traitName): \PHPUnit\Metadata\UsesTrait
     {
-        return new \PHPUnit\Metadata\UsesTrait(self::CLASS_LEVEL, $traitName);
+        return new \PHPUnit\Metadata\UsesTrait(\PHPUnit\Metadata\Level::CLASS_LEVEL, $traitName);
     }
     /**
      * @param non-empty-string $functionName
      */
     public static function usesFunction(string $functionName): \PHPUnit\Metadata\UsesFunction
     {
-        return new \PHPUnit\Metadata\UsesFunction(self::CLASS_LEVEL, $functionName);
+        return new \PHPUnit\Metadata\UsesFunction(\PHPUnit\Metadata\Level::CLASS_LEVEL, $functionName);
     }
     /**
      * @param class-string     $className
@@ -80582,33 +81088,30 @@ abstract readonly class Metadata
      */
     public static function usesMethod(string $className, string $methodName): \PHPUnit\Metadata\UsesMethod
     {
-        return new \PHPUnit\Metadata\UsesMethod(self::CLASS_LEVEL, $className, $methodName);
+        return new \PHPUnit\Metadata\UsesMethod(\PHPUnit\Metadata\Level::CLASS_LEVEL, $className, $methodName);
     }
     public static function withoutErrorHandler(): \PHPUnit\Metadata\WithoutErrorHandler
     {
-        return new \PHPUnit\Metadata\WithoutErrorHandler(self::METHOD_LEVEL);
+        return new \PHPUnit\Metadata\WithoutErrorHandler(\PHPUnit\Metadata\Level::METHOD_LEVEL);
     }
     /**
      * @param null|non-empty-string $messagePattern
      */
     public static function ignorePhpunitWarnings(?string $messagePattern): \PHPUnit\Metadata\IgnorePhpunitWarnings
     {
-        return new \PHPUnit\Metadata\IgnorePhpunitWarnings(self::METHOD_LEVEL, $messagePattern);
+        return new \PHPUnit\Metadata\IgnorePhpunitWarnings(\PHPUnit\Metadata\Level::METHOD_LEVEL, $messagePattern);
     }
-    /**
-     * @param int<0, 1> $level
-     */
-    protected function __construct(int $level)
+    protected function __construct(\PHPUnit\Metadata\Level $level)
     {
         $this->level = $level;
     }
     public function isClassLevel(): bool
     {
-        return $this->level === self::CLASS_LEVEL;
+        return $this->level === \PHPUnit\Metadata\Level::CLASS_LEVEL;
     }
     public function isMethodLevel(): bool
     {
-        return $this->level === self::METHOD_LEVEL;
+        return $this->level === \PHPUnit\Metadata\Level::METHOD_LEVEL;
     }
     /**
      * @phpstan-assert-if-true After $this
@@ -80784,13 +81287,6 @@ abstract readonly class Metadata
      * @internal This method is not covered by the backward compatibility promise for PHPUnit
      */
     public function isIgnorePhpunitDeprecations(): bool
-    {
-        return \false;
-    }
-    /**
-     * @phpstan-assert-if-true RunClassInSeparateProcess $this
-     */
-    public function isRunClassInSeparateProcess(): bool
     {
         return \false;
     }
@@ -81194,10 +81690,6 @@ final readonly class MetadataCollection implements Countable, IteratorAggregate
     {
         return new self(...array_filter($this->metadata, static fn(\PHPUnit\Metadata\Metadata $metadata): bool => $metadata->isIgnorePhpunitWarnings()));
     }
-    public function isRunClassInSeparateProcess(): self
-    {
-        return new self(...array_filter($this->metadata, static fn(\PHPUnit\Metadata\Metadata $metadata): bool => $metadata->isRunClassInSeparateProcess()));
-    }
     public function isRunInSeparateProcess(): self
     {
         return new self(...array_filter($this->metadata, static fn(\PHPUnit\Metadata\Metadata $metadata): bool => $metadata->isRunInSeparateProcess()));
@@ -81324,7 +81816,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\Metadata;
 
-use function count;
 use Iterator;
 /**
  * @template-implements Iterator<non-negative-int, Metadata>
@@ -81351,7 +81842,7 @@ final class MetadataCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->metadata);
+        return isset($this->metadata[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -81443,7 +81934,6 @@ use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Attributes\RequiresPhpunit;
 use PHPUnit\Framework\Attributes\RequiresPhpunitExtension;
 use PHPUnit\Framework\Attributes\RequiresSetting;
-use PHPUnit\Framework\Attributes\RunClassInSeparateProcess;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\Attributes\Small;
@@ -81617,7 +82107,10 @@ final readonly class AttributeParser implements \PHPUnit\Metadata\Parser\Parser
                     break;
                 case RequiresPhp::class:
                     assert($attributeInstance instanceof RequiresPhp);
-                    $result[] = Metadata::requiresPhpOnClass($this->requirement($attributeInstance->versionRequirement(), $className));
+                    $requirement = $this->requirement($attributeInstance->versionRequirement(), $className);
+                    if ($requirement !== null) {
+                        $result[] = Metadata::requiresPhpOnClass($requirement);
+                    }
                     break;
                 case RequiresPhpExtension::class:
                     assert($attributeInstance instanceof RequiresPhpExtension);
@@ -81630,7 +82123,10 @@ final readonly class AttributeParser implements \PHPUnit\Metadata\Parser\Parser
                     break;
                 case RequiresPhpunit::class:
                     assert($attributeInstance instanceof RequiresPhpunit);
-                    $result[] = Metadata::requiresPhpunitOnClass($this->requirement($attributeInstance->versionRequirement(), $className));
+                    $requirement = $this->requirement($attributeInstance->versionRequirement(), $className);
+                    if ($requirement !== null) {
+                        $result[] = Metadata::requiresPhpunitOnClass($requirement);
+                    }
                     break;
                 case RequiresPhpunitExtension::class:
                     assert($attributeInstance instanceof RequiresPhpunitExtension);
@@ -81647,9 +82143,6 @@ final readonly class AttributeParser implements \PHPUnit\Metadata\Parser\Parser
                 case RequiresSetting::class:
                     assert($attributeInstance instanceof RequiresSetting);
                     $result[] = Metadata::requiresSettingOnClass($attributeInstance->setting(), $attributeInstance->value());
-                    break;
-                case RunClassInSeparateProcess::class:
-                    $result[] = Metadata::runClassInSeparateProcess();
                     break;
                 case RunTestsInSeparateProcesses::class:
                     $result[] = Metadata::runTestsInSeparateProcesses();
@@ -81848,7 +82341,10 @@ final readonly class AttributeParser implements \PHPUnit\Metadata\Parser\Parser
                     break;
                 case RequiresPhp::class:
                     assert($attributeInstance instanceof RequiresPhp);
-                    $result[] = Metadata::requiresPhpOnMethod($this->requirement($attributeInstance->versionRequirement(), $className, $methodName));
+                    $requirement = $this->requirement($attributeInstance->versionRequirement(), $className, $methodName);
+                    if ($requirement !== null) {
+                        $result[] = Metadata::requiresPhpOnMethod($requirement);
+                    }
                     break;
                 case RequiresPhpExtension::class:
                     assert($attributeInstance instanceof RequiresPhpExtension);
@@ -81861,7 +82357,10 @@ final readonly class AttributeParser implements \PHPUnit\Metadata\Parser\Parser
                     break;
                 case RequiresPhpunit::class:
                     assert($attributeInstance instanceof RequiresPhpunit);
-                    $result[] = Metadata::requiresPhpunitOnMethod($this->requirement($attributeInstance->versionRequirement(), $className, $methodName));
+                    $requirement = $this->requirement($attributeInstance->versionRequirement(), $className, $methodName);
+                    if ($requirement !== null) {
+                        $result[] = Metadata::requiresPhpunitOnMethod($requirement);
+                    }
                     break;
                 case RequiresPhpunitExtension::class:
                     assert($attributeInstance instanceof RequiresPhpunitExtension);
@@ -81948,10 +82447,11 @@ final readonly class AttributeParser implements \PHPUnit\Metadata\Parser\Parser
      * @param class-string      $testClassName
      * @param ?non-empty-string $testMethodName
      */
-    private function requirement(string $versionRequirement, string $testClassName, ?string $testMethodName = null): Requirement
+    private function requirement(string $versionRequirement, string $testClassName, ?string $testMethodName = null): ?Requirement
     {
         if (is_numeric(trim($versionRequirement))) {
-            EventFacade::emitter()->testRunnerTriggeredPhpunitDeprecation(sprintf('Test %s has attribute with version constraint string argument without explicit version comparison operator ("%s")', $this->testAsString($testClassName, $testMethodName), $versionRequirement));
+            EventFacade::emitter()->testRunnerTriggeredPhpunitWarning(sprintf('Test %s has attribute with version constraint string argument without explicit version comparison operator ("%s"), version constraint is ignored', $this->testAsString($testClassName, $testMethodName), $versionRequirement));
+            return null;
         }
         return Requirement::from($versionRequirement);
     }
@@ -82138,10 +82638,7 @@ namespace PHPUnit\Metadata;
 final readonly class PostCondition extends \PHPUnit\Metadata\Metadata
 {
     private int $priority;
-    /**
-     * @param int<0, 1> $level
-     */
-    protected function __construct(int $level, int $priority)
+    protected function __construct(\PHPUnit\Metadata\Level $level, int $priority)
     {
         parent::__construct($level);
         $this->priority = $priority;
@@ -82176,10 +82673,7 @@ namespace PHPUnit\Metadata;
 final readonly class PreCondition extends \PHPUnit\Metadata\Metadata
 {
     private int $priority;
-    /**
-     * @param int<0, 1> $level
-     */
-    protected function __construct(int $level, int $priority)
+    protected function __construct(\PHPUnit\Metadata\Level $level, int $priority)
     {
         parent::__construct($level);
         $this->priority = $priority;
@@ -82214,10 +82708,7 @@ namespace PHPUnit\Metadata;
 final readonly class PreserveGlobalState extends \PHPUnit\Metadata\Metadata
 {
     private bool $enabled;
-    /**
-     * @param int<0, 1> $level
-     */
-    protected function __construct(int $level, bool $enabled)
+    protected function __construct(\PHPUnit\Metadata\Level $level, bool $enabled)
     {
         parent::__construct($level);
         $this->enabled = $enabled;
@@ -82253,7 +82744,7 @@ final readonly class RequiresEnvironmentVariable extends \PHPUnit\Metadata\Metad
 {
     private string $environmentVariableName;
     private null|string $value;
-    protected function __construct(int $level, string $environmentVariableName, null|string $value)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $environmentVariableName, null|string $value)
     {
         parent::__construct($level);
         $this->environmentVariableName = $environmentVariableName;
@@ -82297,10 +82788,9 @@ final readonly class RequiresFunction extends \PHPUnit\Metadata\Metadata
      */
     private string $functionName;
     /**
-     * @param int<0, 1>        $level
      * @param non-empty-string $functionName
      */
-    protected function __construct(int $level, string $functionName)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $functionName)
     {
         parent::__construct($level);
         $this->functionName = $functionName;
@@ -82346,11 +82836,10 @@ final readonly class RequiresMethod extends \PHPUnit\Metadata\Metadata
      */
     private string $methodName;
     /**
-     * @param int<0, 1>        $level
      * @param class-string     $className
      * @param non-empty-string $methodName
      */
-    protected function __construct(int $level, string $className, string $methodName)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $className, string $methodName)
     {
         parent::__construct($level);
         $this->className = $className;
@@ -82400,10 +82889,9 @@ final readonly class RequiresOperatingSystem extends \PHPUnit\Metadata\Metadata
      */
     private string $operatingSystem;
     /**
-     * @param int<0, 1>        $level
      * @param non-empty-string $operatingSystem
      */
-    protected function __construct(int $level, string $operatingSystem)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $operatingSystem)
     {
         parent::__construct($level);
         $this->operatingSystem = $operatingSystem;
@@ -82445,10 +82933,9 @@ final readonly class RequiresOperatingSystemFamily extends \PHPUnit\Metadata\Met
      */
     private string $operatingSystemFamily;
     /**
-     * @param int<0, 1>        $level
      * @param non-empty-string $operatingSystemFamily
      */
-    protected function __construct(int $level, string $operatingSystemFamily)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $operatingSystemFamily)
     {
         parent::__construct($level);
         $this->operatingSystemFamily = $operatingSystemFamily;
@@ -82487,10 +82974,7 @@ use PHPUnit\Metadata\Version\Requirement;
 final readonly class RequiresPhp extends \PHPUnit\Metadata\Metadata
 {
     private Requirement $versionRequirement;
-    /**
-     * @param int<0, 1> $level
-     */
-    protected function __construct(int $level, Requirement $versionRequirement)
+    protected function __construct(\PHPUnit\Metadata\Level $level, Requirement $versionRequirement)
     {
         parent::__construct($level);
         $this->versionRequirement = $versionRequirement;
@@ -82531,10 +83015,9 @@ final readonly class RequiresPhpExtension extends \PHPUnit\Metadata\Metadata
     private string $extension;
     private ?Requirement $versionRequirement;
     /**
-     * @param int<0, 1>        $level
      * @param non-empty-string $extension
      */
-    protected function __construct(int $level, string $extension, ?Requirement $versionRequirement)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $extension, ?Requirement $versionRequirement)
     {
         parent::__construct($level);
         $this->extension = $extension;
@@ -82591,10 +83074,7 @@ use PHPUnit\Metadata\Version\Requirement;
 final readonly class RequiresPhpunit extends \PHPUnit\Metadata\Metadata
 {
     private Requirement $versionRequirement;
-    /**
-     * @param int<0, 1> $level
-     */
-    protected function __construct(int $level, Requirement $versionRequirement)
+    protected function __construct(\PHPUnit\Metadata\Level $level, Requirement $versionRequirement)
     {
         parent::__construct($level);
         $this->versionRequirement = $versionRequirement;
@@ -82636,7 +83116,7 @@ final readonly class RequiresPhpunitExtension extends \PHPUnit\Metadata\Metadata
     /**
      * @param class-string<Extension> $extensionClass
      */
-    protected function __construct(int $level, string $extensionClass)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $extensionClass)
     {
         parent::__construct($level);
         $this->extensionClass = $extensionClass;
@@ -82682,11 +83162,10 @@ final readonly class RequiresSetting extends \PHPUnit\Metadata\Metadata
      */
     private string $value;
     /**
-     * @param int<0, 1>        $level
      * @param non-empty-string $setting
      * @param non-empty-string $value
      */
-    protected function __construct(int $level, string $setting, string $value)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $setting, string $value)
     {
         parent::__construct($level);
         $this->setting = $setting;
@@ -82709,31 +83188,6 @@ final readonly class RequiresSetting extends \PHPUnit\Metadata\Metadata
     public function value(): string
     {
         return $this->value;
-    }
-}
-<?php
-
-declare (strict_types=1);
-/*
- * This file is part of PHPUnit.
- *
- * (c) Sebastian Bergmann <sebastian@phpunit.de>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-namespace PHPUnit\Metadata;
-
-/**
- * @immutable
- *
- * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
- */
-final readonly class RunClassInSeparateProcess extends \PHPUnit\Metadata\Metadata
-{
-    public function isRunClassInSeparateProcess(): true
-    {
-        return \true;
     }
 }
 <?php
@@ -82836,10 +83290,9 @@ final readonly class TestDox extends \PHPUnit\Metadata\Metadata
      */
     private string $text;
     /**
-     * @param int<0, 1>        $level
      * @param non-empty-string $text
      */
-    protected function __construct(int $level, string $text)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $text)
     {
         parent::__construct($level);
         $this->text = $text;
@@ -82885,11 +83338,10 @@ final readonly class TestDoxFormatter extends \PHPUnit\Metadata\Metadata
      */
     private string $methodName;
     /**
-     * @param int<0, 1>        $level
      * @param class-string     $className
      * @param non-empty-string $methodName
      */
-    protected function __construct(int $level, string $className, string $methodName)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $className, string $methodName)
     {
         parent::__construct($level);
         $this->className = $className;
@@ -82940,10 +83392,9 @@ final readonly class TestWith extends \PHPUnit\Metadata\Metadata
      */
     private ?string $name;
     /**
-     * @param int<0, 1>         $level
      * @param ?non-empty-string $name
      */
-    protected function __construct(int $level, mixed $data, ?string $name = null)
+    protected function __construct(\PHPUnit\Metadata\Level $level, mixed $data, ?string $name = null)
     {
         parent::__construct($level);
         $this->data = $data;
@@ -82997,10 +83448,9 @@ final readonly class UsesClass extends \PHPUnit\Metadata\Metadata
      */
     private string $className;
     /**
-     * @param int<0, 1>    $level
      * @param class-string $className
      */
-    protected function __construct(int $level, string $className)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $className)
     {
         parent::__construct($level);
         $this->className = $className;
@@ -83042,10 +83492,9 @@ final readonly class UsesClassesThatExtendClass extends \PHPUnit\Metadata\Metada
      */
     private string $className;
     /**
-     * @param int<0, 1>    $level
      * @param class-string $className
      */
-    protected function __construct(int $level, string $className)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $className)
     {
         parent::__construct($level);
         $this->className = $className;
@@ -83087,10 +83536,9 @@ final readonly class UsesClassesThatImplementInterface extends \PHPUnit\Metadata
      */
     private string $interfaceName;
     /**
-     * @param int<0, 1>    $level
      * @param class-string $interfaceName
      */
-    protected function __construct(int $level, string $interfaceName)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $interfaceName)
     {
         parent::__construct($level);
         $this->interfaceName = $interfaceName;
@@ -83132,10 +83580,9 @@ final readonly class UsesFunction extends \PHPUnit\Metadata\Metadata
      */
     private string $functionName;
     /**
-     * @param int<0, 1>        $level
      * @param non-empty-string $functionName
      */
-    protected function __construct(int $level, string $functionName)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $functionName)
     {
         parent::__construct($level);
         $this->functionName = $functionName;
@@ -83181,11 +83628,10 @@ final readonly class UsesMethod extends \PHPUnit\Metadata\Metadata
      */
     private string $methodName;
     /**
-     * @param int<0, 1>        $level
      * @param class-string     $className
      * @param non-empty-string $methodName
      */
-    protected function __construct(int $level, string $className, string $methodName)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $className, string $methodName)
     {
         parent::__construct($level);
         $this->className = $className;
@@ -83235,10 +83681,9 @@ final readonly class UsesNamespace extends \PHPUnit\Metadata\Metadata
      */
     private string $namespace;
     /**
-     * @param int<0, 1>        $level
      * @param non-empty-string $namespace
      */
-    protected function __construct(int $level, string $namespace)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $namespace)
     {
         parent::__construct($level);
         $this->namespace = $namespace;
@@ -83280,10 +83725,9 @@ final readonly class UsesTrait extends \PHPUnit\Metadata\Metadata
      */
     private string $traitName;
     /**
-     * @param 0|1          $level
      * @param trait-string $traitName
      */
-    protected function __construct(int $level, string $traitName)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $traitName)
     {
         parent::__construct($level);
         $this->traitName = $traitName;
@@ -83452,7 +83896,7 @@ final readonly class WithEnvironmentVariable extends \PHPUnit\Metadata\Metadata
     /**
      * @param non-empty-string $environmentVariableName
      */
-    protected function __construct(int $level, string $environmentVariableName, null|string $value)
+    protected function __construct(\PHPUnit\Metadata\Level $level, string $environmentVariableName, null|string $value)
     {
         parent::__construct($level);
         $this->environmentVariableName = $environmentVariableName;
@@ -88784,6 +89228,7 @@ declare (strict_types=1);
  */
 namespace PHPUnit\TestRunner\TestResult;
 
+use function array_any;
 use function str_contains;
 use PHPUnit\Event\Facade as EventFacade;
 use PHPUnit\Runner\DeprecationCollector\Facade as DeprecationCollectorFacade;
@@ -88853,12 +89298,7 @@ final class Facade
         if (!$configuration->hasSpecificDeprecationToStopOn()) {
             return $deprecations !== [];
         }
-        foreach ($deprecations as $deprecation) {
-            if (str_contains($deprecation, $configuration->specificDeprecationToStopOn())) {
-                return \true;
-            }
-        }
-        return \false;
+        return array_any($deprecations, static fn(string $deprecation) => str_contains($deprecation, $configuration->specificDeprecationToStopOn()));
     }
 }
 <?php
@@ -90622,10 +91062,8 @@ final class TestSuiteSorter
      * @var array<string, int> Associative array of (string => DEFECT_SORT_WEIGHT) elements
      */
     private array $defectSortOrder = [];
-    private readonly ResultCache $cache;
-    public function __construct(?ResultCache $cache = null)
+    public function __construct(private readonly ?ResultCache $cache = new NullResultCache())
     {
-        $this->cache = $cache ?? new NullResultCache();
     }
     /**
      * @throws Exception
@@ -90841,7 +91279,7 @@ use PHPUnitPHAR\SebastianBergmann\Version as VersionId;
  */
 final class Version
 {
-    private static string $pharVersion = '12.5.9';
+    private static string $pharVersion = '13.0.0';
     private static string $version = '';
     /**
      * @return non-empty-string
@@ -90852,7 +91290,7 @@ final class Version
             return self::$pharVersion;
         }
         if (self::$version === '') {
-            self::$version = (new VersionId('12.5.9', dirname(__DIR__, 2)))->asString();
+            self::$version = (new VersionId('13.0.0', dirname(__DIR__, 2)))->asString();
         }
         return self::$version;
     }
@@ -91474,6 +91912,7 @@ namespace PHPUnit\TextUI\Command;
 
 use const E_ALL;
 use const PHP_EOL;
+use function assert;
 use function extension_loaded;
 use function in_array;
 use function ini_get;
@@ -91535,7 +91974,9 @@ final readonly class CheckPhpConfigurationCommand implements \PHPUnit\TextUI\Com
             return 'ok';
         }
         // @codeCoverageIgnoreStart
-        return Color::colorizeTextBox('fg-green, bold', 'ok');
+        $result = Color::colorizeTextBox('fg-green, bold', 'ok');
+        assert($result !== '');
+        return $result;
         // @codeCoverageIgnoreEnd
     }
     /**
@@ -91548,7 +91989,9 @@ final readonly class CheckPhpConfigurationCommand implements \PHPUnit\TextUI\Com
             return $message;
         }
         // @codeCoverageIgnoreStart
-        return Color::colorizeTextBox('fg-red, bold', $message);
+        $result = Color::colorizeTextBox('fg-red, bold', $message);
+        assert($result !== '');
+        return $result;
         // @codeCoverageIgnoreEnd
     }
     /**
@@ -92403,7 +92846,7 @@ final class Builder
     /**
      * @var non-empty-list<non-empty-string>
      */
-    private const array LONG_OPTIONS = ['all', 'atleast-version=', 'bootstrap=', 'cache-result', 'do-not-cache-result', 'cache-directory=', 'check-version', 'check-php-configuration', 'colors==', 'columns=', 'configuration=', 'warm-coverage-cache', 'coverage-filter=', 'coverage-clover=', 'coverage-cobertura=', 'coverage-crap4j=', 'coverage-html=', 'coverage-openclover=', 'coverage-php=', 'coverage-text==', 'only-summary-for-coverage-text', 'show-uncovered-for-coverage-text', 'coverage-xml=', 'exclude-source-from-xml-coverage', 'path-coverage', 'disallow-test-output', 'display-all-issues', 'display-incomplete', 'display-skipped', 'display-deprecations', 'display-phpunit-deprecations', 'display-phpunit-notices', 'display-errors', 'display-notices', 'display-warnings', 'default-time-limit=', 'enforce-time-limit', 'exclude-group=', 'filter=', 'exclude-filter=', 'generate-baseline=', 'use-baseline=', 'ignore-baseline', 'generate-configuration', 'globals-backup', 'group=', 'covers=', 'uses=', 'requires-php-extension=', 'help', 'resolve-dependencies', 'ignore-dependencies', 'include-path=', 'list-groups', 'list-suites', 'list-test-files', 'list-tests', 'list-tests-xml=', 'log-junit=', 'log-otr=', 'include-git-information', 'log-teamcity=', 'migrate-configuration', 'no-configuration', 'no-coverage', 'no-logging', 'no-extensions', 'no-output', 'no-progress', 'no-results', 'order-by=', 'process-isolation', 'do-not-report-useless-tests', 'dont-report-useless-tests', 'random-order', 'random-order-seed=', 'reverse-order', 'reverse-list', 'static-backup', 'stderr', 'fail-on-all-issues', 'fail-on-deprecation', 'fail-on-phpunit-deprecation', 'fail-on-phpunit-notice', 'fail-on-phpunit-warning', 'fail-on-empty-test-suite', 'fail-on-incomplete', 'fail-on-notice', 'fail-on-risky', 'fail-on-skipped', 'fail-on-warning', 'do-not-fail-on-deprecation', 'do-not-fail-on-phpunit-deprecation', 'do-not-fail-on-phpunit-notice', 'do-not-fail-on-phpunit-warning', 'do-not-fail-on-empty-test-suite', 'do-not-fail-on-incomplete', 'do-not-fail-on-notice', 'do-not-fail-on-risky', 'do-not-fail-on-skipped', 'do-not-fail-on-warning', 'stop-on-defect', 'stop-on-deprecation==', 'stop-on-error', 'stop-on-failure', 'stop-on-incomplete', 'stop-on-notice', 'stop-on-risky', 'stop-on-skipped', 'stop-on-warning', 'strict-coverage', 'disable-coverage-ignore', 'strict-global-state', 'teamcity', 'testdox', 'testdox-summary', 'testdox-html=', 'testdox-text=', 'test-suffix=', 'testsuite=', 'exclude-testsuite=', 'log-events-text=', 'log-events-verbose-text=', 'version', 'debug', 'with-telemetry', 'extension='];
+    private const array LONG_OPTIONS = ['all', 'atleast-version=', 'bootstrap=', 'cache-result', 'do-not-cache-result', 'cache-directory=', 'check-version', 'check-php-configuration', 'colors==', 'columns=', 'configuration=', 'warm-coverage-cache', 'coverage-filter=', 'coverage-clover=', 'coverage-cobertura=', 'coverage-crap4j=', 'coverage-html=', 'coverage-openclover=', 'coverage-php=', 'coverage-text==', 'only-summary-for-coverage-text', 'show-uncovered-for-coverage-text', 'coverage-xml=', 'exclude-source-from-xml-coverage', 'path-coverage', 'disallow-test-output', 'display-all-issues', 'display-incomplete', 'display-skipped', 'display-deprecations', 'display-phpunit-deprecations', 'display-phpunit-notices', 'display-errors', 'display-notices', 'display-warnings', 'default-time-limit=', 'enforce-time-limit', 'exclude-group=', 'filter=', 'exclude-filter=', 'generate-baseline=', 'use-baseline=', 'ignore-baseline', 'generate-configuration', 'globals-backup', 'group=', 'covers=', 'uses=', 'requires-php-extension=', 'help', 'resolve-dependencies', 'ignore-dependencies', 'include-path=', 'list-groups', 'list-suites', 'list-test-files', 'list-tests', 'list-tests-xml=', 'log-junit=', 'log-otr=', 'include-git-information', 'log-teamcity=', 'migrate-configuration', 'no-configuration', 'no-coverage', 'no-logging', 'no-extensions', 'no-output', 'no-progress', 'no-results', 'order-by=', 'process-isolation', 'do-not-report-useless-tests', 'random-order', 'random-order-seed=', 'reverse-order', 'reverse-list', 'static-backup', 'stderr', 'fail-on-all-issues', 'fail-on-deprecation', 'fail-on-phpunit-deprecation', 'fail-on-phpunit-notice', 'fail-on-phpunit-warning', 'fail-on-empty-test-suite', 'fail-on-incomplete', 'fail-on-notice', 'fail-on-risky', 'fail-on-skipped', 'fail-on-warning', 'do-not-fail-on-deprecation', 'do-not-fail-on-phpunit-deprecation', 'do-not-fail-on-phpunit-notice', 'do-not-fail-on-phpunit-warning', 'do-not-fail-on-empty-test-suite', 'do-not-fail-on-incomplete', 'do-not-fail-on-notice', 'do-not-fail-on-risky', 'do-not-fail-on-skipped', 'do-not-fail-on-warning', 'stop-on-defect', 'stop-on-deprecation==', 'stop-on-error', 'stop-on-failure', 'stop-on-incomplete', 'stop-on-notice', 'stop-on-risky', 'stop-on-skipped', 'stop-on-warning', 'strict-coverage', 'disable-coverage-ignore', 'strict-global-state', 'teamcity', 'testdox', 'testdox-summary', 'testdox-html=', 'testdox-text=', 'test-suffix=', 'testsuite=', 'exclude-testsuite=', 'test-files-file=', 'log-events-text=', 'log-events-verbose-text=', 'version', 'debug', 'with-telemetry', 'extension='];
     private const string SHORT_OPTIONS = 'd:c:h';
     /**
      * @var array<string, non-negative-int>
@@ -92536,6 +92979,7 @@ final class Builder
         $testSuffixes = null;
         $testSuite = null;
         $excludeTestSuite = null;
+        $testFilesFile = null;
         $useDefaultConfiguration = \true;
         $version = \false;
         $logEventsText = null;
@@ -92651,6 +93095,9 @@ final class Builder
                     break;
                 case '--exclude-testsuite':
                     $excludeTestSuite = $option[1];
+                    break;
+                case '--test-files-file':
+                    $testFilesFile = $option[1];
                     break;
                 case '--generate-baseline':
                     $generateBaseline = $option[1];
@@ -92949,10 +93396,6 @@ final class Builder
                 case '--do-not-report-useless-tests':
                     $reportUselessTests = \false;
                     break;
-                case '--dont-report-useless-tests':
-                    EventFacade::emitter()->testRunnerTriggeredPhpunitDeprecation('Option --dont-report-useless-tests is deprecated, use --do-not-report-useless-tests instead');
-                    $reportUselessTests = \false;
-                    break;
                 case '--strict-coverage':
                     $strictCoverage = \true;
                     break;
@@ -93062,7 +93505,7 @@ final class Builder
         if ($extensions === []) {
             $extensions = null;
         }
-        return new \PHPUnit\TextUI\CliArguments\Configuration($options[1], $all, $atLeastVersion, $backupGlobals, $backupStaticProperties, $beStrictAboutChangesToGlobalState, $bootstrap, $cacheDirectory, $cacheResult, $checkPhpConfiguration, $checkVersion, $colors, $columns, $configuration, $coverageClover, $coverageCobertura, $coverageCrap4J, $coverageHtml, $coverageOpenClover, $coveragePhp, $coverageText, $coverageTextShowUncoveredFiles, $coverageTextShowOnlySummary, $coverageXml, $excludeSourceFromXmlCoverage, $pathCoverage, $warmCoverageCache, $defaultTimeLimit, $disableCodeCoverageIgnore, $disallowTestOutput, $enforceTimeLimit, $excludeGroups, $executionOrder, $executionOrderDefects, $failOnAllIssues, $failOnDeprecation, $failOnPhpunitDeprecation, $failOnPhpunitNotice, $failOnPhpunitWarning, $failOnEmptyTestSuite, $failOnIncomplete, $failOnNotice, $failOnRisky, $failOnSkipped, $failOnWarning, $doNotFailOnDeprecation, $doNotFailOnPhpunitDeprecation, $doNotFailOnPhpunitNotice, $doNotFailOnPhpunitWarning, $doNotFailOnEmptyTestSuite, $doNotFailOnIncomplete, $doNotFailOnNotice, $doNotFailOnRisky, $doNotFailOnSkipped, $doNotFailOnWarning, $stopOnDefect, $stopOnDeprecation, $specificDeprecationToStopOn, $stopOnError, $stopOnFailure, $stopOnIncomplete, $stopOnNotice, $stopOnRisky, $stopOnSkipped, $stopOnWarning, $filter, $excludeFilter, $generateBaseline, $useBaseline, $ignoreBaseline, $generateConfiguration, $migrateConfiguration, $groups, $testsCovering, $testsUsing, $testsRequiringPhpExtension, $help, $includePath, $iniSettings, $junitLogfile, $otrLogfile, $includeGitInformation, $listGroups, $listSuites, $listTestFiles, $listTests, $listTestsXml, $noCoverage, $noExtensions, $noOutput, $noProgress, $noResults, $noLogging, $processIsolation, $randomOrderSeed, $reportUselessTests, $resolveDependencies, $reverseList, $stderr, $strictCoverage, $teamcityLogfile, $testdoxHtmlFile, $testdoxTextFile, $testSuffixes, $testSuite, $excludeTestSuite, $useDefaultConfiguration, $displayAllIssues, $displayIncomplete, $displaySkipped, $displayDeprecations, $displayPhpunitDeprecations, $displayPhpunitNotices, $displayErrors, $displayNotices, $displayWarnings, $version, $coverageFilter, $logEventsText, $logEventsVerboseText, $printerTeamCity, $printerTestDox, $printerTestDoxSummary, $debug, $withTelemetry, $extensions);
+        return new \PHPUnit\TextUI\CliArguments\Configuration($options[1], $testFilesFile, $all, $atLeastVersion, $backupGlobals, $backupStaticProperties, $beStrictAboutChangesToGlobalState, $bootstrap, $cacheDirectory, $cacheResult, $checkPhpConfiguration, $checkVersion, $colors, $columns, $configuration, $coverageClover, $coverageCobertura, $coverageCrap4J, $coverageHtml, $coverageOpenClover, $coveragePhp, $coverageText, $coverageTextShowUncoveredFiles, $coverageTextShowOnlySummary, $coverageXml, $excludeSourceFromXmlCoverage, $pathCoverage, $warmCoverageCache, $defaultTimeLimit, $disableCodeCoverageIgnore, $disallowTestOutput, $enforceTimeLimit, $excludeGroups, $executionOrder, $executionOrderDefects, $failOnAllIssues, $failOnDeprecation, $failOnPhpunitDeprecation, $failOnPhpunitNotice, $failOnPhpunitWarning, $failOnEmptyTestSuite, $failOnIncomplete, $failOnNotice, $failOnRisky, $failOnSkipped, $failOnWarning, $doNotFailOnDeprecation, $doNotFailOnPhpunitDeprecation, $doNotFailOnPhpunitNotice, $doNotFailOnPhpunitWarning, $doNotFailOnEmptyTestSuite, $doNotFailOnIncomplete, $doNotFailOnNotice, $doNotFailOnRisky, $doNotFailOnSkipped, $doNotFailOnWarning, $stopOnDefect, $stopOnDeprecation, $specificDeprecationToStopOn, $stopOnError, $stopOnFailure, $stopOnIncomplete, $stopOnNotice, $stopOnRisky, $stopOnSkipped, $stopOnWarning, $filter, $excludeFilter, $generateBaseline, $useBaseline, $ignoreBaseline, $generateConfiguration, $migrateConfiguration, $groups, $testsCovering, $testsUsing, $testsRequiringPhpExtension, $help, $includePath, $iniSettings, $junitLogfile, $otrLogfile, $includeGitInformation, $listGroups, $listSuites, $listTestFiles, $listTests, $listTestsXml, $noCoverage, $noExtensions, $noOutput, $noProgress, $noResults, $noLogging, $processIsolation, $randomOrderSeed, $reportUselessTests, $resolveDependencies, $reverseList, $stderr, $strictCoverage, $teamcityLogfile, $testdoxHtmlFile, $testdoxTextFile, $testSuffixes, $testSuite, $excludeTestSuite, $useDefaultConfiguration, $displayAllIssues, $displayIncomplete, $displaySkipped, $displayDeprecations, $displayPhpunitDeprecations, $displayPhpunitNotices, $displayErrors, $displayNotices, $displayWarnings, $version, $coverageFilter, $logEventsText, $logEventsVerboseText, $printerTeamCity, $printerTestDox, $printerTestDoxSummary, $debug, $withTelemetry, $extensions);
     }
     /**
      * @param non-empty-string $option
@@ -93115,6 +93558,7 @@ final readonly class Configuration
      * @var list<non-empty-string>
      */
     private array $arguments;
+    private ?string $testFilesFile;
     private ?bool $all;
     private ?string $atLeastVersion;
     private ?bool $backupGlobals;
@@ -93279,9 +93723,10 @@ final readonly class Configuration
      * @param ?non-empty-list<non-empty-string>                    $coverageFilter
      * @param ?non-empty-list<non-empty-string>                    $extensions
      */
-    public function __construct(array $arguments, ?bool $all, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, bool $checkPhpConfiguration, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coverageOpenClover, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $coverageXmlIncludeSource, ?bool $pathCoverage, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnAllIssues, ?bool $failOnDeprecation, ?bool $failOnPhpunitDeprecation, ?bool $failOnPhpunitNotice, ?bool $failOnPhpunitWarning, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnNotice, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?bool $doNotFailOnDeprecation, ?bool $doNotFailOnPhpunitDeprecation, ?bool $doNotFailOnPhpunitNotice, ?bool $doNotFailOnPhpunitWarning, ?bool $doNotFailOnEmptyTestSuite, ?bool $doNotFailOnIncomplete, ?bool $doNotFailOnNotice, ?bool $doNotFailOnRisky, ?bool $doNotFailOnSkipped, ?bool $doNotFailOnWarning, ?bool $stopOnDefect, ?bool $stopOnDeprecation, ?string $specificDeprecationToStopOn, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnNotice, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $filter, ?string $excludeFilter, ?string $generateBaseline, ?string $useBaseline, bool $ignoreBaseline, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, ?array $testsRequiringPhpExtension, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, ?string $otrLogfile, ?bool $includeGitInformation, bool $listGroups, bool $listSuites, bool $listTestFiles, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnAllIssues, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnPhpunitDeprecations, ?bool $displayDetailsOnPhpunitNotices, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $testdoxPrinter, ?bool $testdoxPrinterSummary, bool $debug, bool $withTelemetry, ?array $extensions)
+    public function __construct(array $arguments, ?string $testFilesFile, ?bool $all, ?string $atLeastVersion, ?bool $backupGlobals, ?bool $backupStaticProperties, ?bool $beStrictAboutChangesToGlobalState, ?string $bootstrap, ?string $cacheDirectory, ?bool $cacheResult, bool $checkPhpConfiguration, bool $checkVersion, ?string $colors, null|int|string $columns, ?string $configurationFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4J, ?string $coverageHtml, ?string $coverageOpenClover, ?string $coveragePhp, ?string $coverageText, ?bool $coverageTextShowUncoveredFiles, ?bool $coverageTextShowOnlySummary, ?string $coverageXml, ?bool $coverageXmlIncludeSource, ?bool $pathCoverage, bool $warmCoverageCache, ?int $defaultTimeLimit, ?bool $disableCodeCoverageIgnore, ?bool $disallowTestOutput, ?bool $enforceTimeLimit, ?array $excludeGroups, ?int $executionOrder, ?int $executionOrderDefects, ?bool $failOnAllIssues, ?bool $failOnDeprecation, ?bool $failOnPhpunitDeprecation, ?bool $failOnPhpunitNotice, ?bool $failOnPhpunitWarning, ?bool $failOnEmptyTestSuite, ?bool $failOnIncomplete, ?bool $failOnNotice, ?bool $failOnRisky, ?bool $failOnSkipped, ?bool $failOnWarning, ?bool $doNotFailOnDeprecation, ?bool $doNotFailOnPhpunitDeprecation, ?bool $doNotFailOnPhpunitNotice, ?bool $doNotFailOnPhpunitWarning, ?bool $doNotFailOnEmptyTestSuite, ?bool $doNotFailOnIncomplete, ?bool $doNotFailOnNotice, ?bool $doNotFailOnRisky, ?bool $doNotFailOnSkipped, ?bool $doNotFailOnWarning, ?bool $stopOnDefect, ?bool $stopOnDeprecation, ?string $specificDeprecationToStopOn, ?bool $stopOnError, ?bool $stopOnFailure, ?bool $stopOnIncomplete, ?bool $stopOnNotice, ?bool $stopOnRisky, ?bool $stopOnSkipped, ?bool $stopOnWarning, ?string $filter, ?string $excludeFilter, ?string $generateBaseline, ?string $useBaseline, bool $ignoreBaseline, bool $generateConfiguration, bool $migrateConfiguration, ?array $groups, ?array $testsCovering, ?array $testsUsing, ?array $testsRequiringPhpExtension, bool $help, ?string $includePath, ?array $iniSettings, ?string $junitLogfile, ?string $otrLogfile, ?bool $includeGitInformation, bool $listGroups, bool $listSuites, bool $listTestFiles, bool $listTests, ?string $listTestsXml, ?bool $noCoverage, ?bool $noExtensions, ?bool $noOutput, ?bool $noProgress, ?bool $noResults, ?bool $noLogging, ?bool $processIsolation, ?int $randomOrderSeed, ?bool $reportUselessTests, ?bool $resolveDependencies, ?bool $reverseList, ?bool $stderr, ?bool $strictCoverage, ?string $teamcityLogfile, ?string $testdoxHtmlFile, ?string $testdoxTextFile, ?array $testSuffixes, ?string $testSuite, ?string $excludeTestSuite, bool $useDefaultConfiguration, ?bool $displayDetailsOnAllIssues, ?bool $displayDetailsOnIncompleteTests, ?bool $displayDetailsOnSkippedTests, ?bool $displayDetailsOnTestsThatTriggerDeprecations, ?bool $displayDetailsOnPhpunitDeprecations, ?bool $displayDetailsOnPhpunitNotices, ?bool $displayDetailsOnTestsThatTriggerErrors, ?bool $displayDetailsOnTestsThatTriggerNotices, ?bool $displayDetailsOnTestsThatTriggerWarnings, bool $version, ?array $coverageFilter, ?string $logEventsText, ?string $logEventsVerboseText, ?bool $printerTeamCity, ?bool $testdoxPrinter, ?bool $testdoxPrinterSummary, bool $debug, bool $withTelemetry, ?array $extensions)
     {
         $this->arguments = $arguments;
+        $this->testFilesFile = $testFilesFile;
         $this->all = $all;
         $this->atLeastVersion = $atLeastVersion;
         $this->backupGlobals = $backupGlobals;
@@ -93414,6 +93859,23 @@ final readonly class Configuration
     public function arguments(): array
     {
         return $this->arguments;
+    }
+    /**
+     * @phpstan-assert-if-true !null $this->testFilesFile
+     */
+    public function hasTestFilesFile(): bool
+    {
+        return $this->testFilesFile !== null;
+    }
+    /**
+     * @throws Exception
+     */
+    public function testFilesFile(): string
+    {
+        if (!$this->hasTestFilesFile()) {
+            throw new \PHPUnit\TextUI\CliArguments\Exception();
+        }
+        return $this->testFilesFile;
     }
     /**
      * @phpstan-assert-if-true !null $this->all
@@ -95543,6 +96005,7 @@ final readonly class Configuration
      * @var list<non-empty-string>
      */
     private array $cliArguments;
+    private ?string $testFilesFile;
     private ?string $configurationFile;
     private ?string $bootstrap;
     /**
@@ -95643,6 +96106,7 @@ final readonly class Configuration
     private bool $displayDetailsOnTestsThatTriggerWarnings;
     private bool $reverseDefectList;
     private bool $requireCoverageMetadata;
+    private bool $requireSealedMockObjects;
     private bool $noProgress;
     private bool $noResults;
     private bool $noOutput;
@@ -95720,9 +96184,10 @@ final readonly class Configuration
      * @param null|non-empty-string                                                       $generateBaseline
      * @param non-negative-int                                                            $shortenArraysForExportThreshold
      */
-    public function __construct(array $cliArguments, ?string $configurationFile, ?string $bootstrap, array $bootstrapForTestSuite, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, \PHPUnit\TextUI\Configuration\Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coverageOpenClover, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $coverageXmlIncludeSource, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnAllIssues, bool $failOnDeprecation, bool $failOnPhpunitDeprecation, bool $failOnPhpunitNotice, bool $failOnPhpunitWarning, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $doNotFailOnDeprecation, bool $doNotFailOnPhpunitDeprecation, bool $doNotFailOnPhpunitNotice, bool $doNotFailOnPhpunitWarning, bool $doNotFailOnEmptyTestSuite, bool $doNotFailOnIncomplete, bool $doNotFailOnNotice, bool $doNotFailOnRisky, bool $doNotFailOnSkipped, bool $doNotFailOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, ?string $specificDeprecationToStopOn, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnAllIssues, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnPhpunitDeprecations, bool $displayDetailsOnPhpunitNotices, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileOtr, bool $includeGitInformationInOtrLogfile, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, bool $testDoxOutputSummary, ?array $testsCovering, ?array $testsUsing, ?array $testsRequiringPhpExtension, ?string $filter, ?string $excludeFilter, array $groups, array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, \PHPUnit\TextUI\Configuration\TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, bool $ignoreTestSelectionInXmlConfiguration, array $testSuffixes, \PHPUnit\TextUI\Configuration\Php $php, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, ?string $generateBaseline, bool $debug, bool $withTelemetry, int $shortenArraysForExportThreshold)
+    public function __construct(array $cliArguments, ?string $testFilesFile, ?string $configurationFile, ?string $bootstrap, array $bootstrapForTestSuite, bool $cacheResult, ?string $cacheDirectory, ?string $coverageCacheDirectory, \PHPUnit\TextUI\Configuration\Source $source, string $testResultCacheFile, ?string $coverageClover, ?string $coverageCobertura, ?string $coverageCrap4j, int $coverageCrap4jThreshold, ?string $coverageHtml, int $coverageHtmlLowUpperBound, int $coverageHtmlHighLowerBound, string $coverageHtmlColorSuccessLow, string $coverageHtmlColorSuccessMedium, string $coverageHtmlColorSuccessHigh, string $coverageHtmlColorWarning, string $coverageHtmlColorDanger, ?string $coverageHtmlCustomCssFile, ?string $coverageOpenClover, ?string $coveragePhp, ?string $coverageText, bool $coverageTextShowUncoveredFiles, bool $coverageTextShowOnlySummary, ?string $coverageXml, bool $coverageXmlIncludeSource, bool $pathCoverage, bool $ignoreDeprecatedCodeUnitsFromCodeCoverage, bool $disableCodeCoverageIgnore, bool $failOnAllIssues, bool $failOnDeprecation, bool $failOnPhpunitDeprecation, bool $failOnPhpunitNotice, bool $failOnPhpunitWarning, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $doNotFailOnDeprecation, bool $doNotFailOnPhpunitDeprecation, bool $doNotFailOnPhpunitNotice, bool $doNotFailOnPhpunitWarning, bool $doNotFailOnEmptyTestSuite, bool $doNotFailOnIncomplete, bool $doNotFailOnNotice, bool $doNotFailOnRisky, bool $doNotFailOnSkipped, bool $doNotFailOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, ?string $specificDeprecationToStopOn, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, bool $outputToStandardErrorStream, int $columns, bool $noExtensions, ?string $pharExtensionDirectory, array $extensionBootstrappers, bool $backupGlobals, bool $backupStaticProperties, bool $beStrictAboutChangesToGlobalState, bool $colors, bool $processIsolation, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, bool $reportUselessTests, bool $strictCoverage, bool $disallowTestOutput, bool $displayDetailsOnAllIssues, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnPhpunitDeprecations, bool $displayDetailsOnPhpunitNotices, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $requireSealedMockObjects, bool $noProgress, bool $noResults, bool $noOutput, int $executionOrder, int $executionOrderDefects, bool $resolveDependencies, ?string $logfileTeamcity, ?string $logfileJunit, ?string $logfileOtr, bool $includeGitInformationInOtrLogfile, ?string $logfileTestdoxHtml, ?string $logfileTestdoxText, ?string $logEventsText, ?string $logEventsVerboseText, bool $teamCityOutput, bool $testDoxOutput, bool $testDoxOutputSummary, ?array $testsCovering, ?array $testsUsing, ?array $testsRequiringPhpExtension, ?string $filter, ?string $excludeFilter, array $groups, array $excludeGroups, int $randomOrderSeed, bool $includeUncoveredFiles, \PHPUnit\TextUI\Configuration\TestSuiteCollection $testSuite, string $includeTestSuite, string $excludeTestSuite, ?string $defaultTestSuite, bool $ignoreTestSelectionInXmlConfiguration, array $testSuffixes, \PHPUnit\TextUI\Configuration\Php $php, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, ?string $generateBaseline, bool $debug, bool $withTelemetry, int $shortenArraysForExportThreshold)
     {
         $this->cliArguments = $cliArguments;
+        $this->testFilesFile = $testFilesFile;
         $this->configurationFile = $configurationFile;
         $this->bootstrap = $bootstrap;
         $this->bootstrapForTestSuite = $bootstrapForTestSuite;
@@ -95814,6 +96279,7 @@ final readonly class Configuration
         $this->displayDetailsOnTestsThatTriggerWarnings = $displayDetailsOnTestsThatTriggerWarnings;
         $this->reverseDefectList = $reverseDefectList;
         $this->requireCoverageMetadata = $requireCoverageMetadata;
+        $this->requireSealedMockObjects = $requireSealedMockObjects;
         $this->noProgress = $noProgress;
         $this->noResults = $noResults;
         $this->noOutput = $noOutput;
@@ -95867,6 +96333,23 @@ final readonly class Configuration
     public function cliArguments(): array
     {
         return $this->cliArguments;
+    }
+    /**
+     * @phpstan-assert-if-true !null $this->testFilesFile
+     */
+    public function hasTestFilesFile(): bool
+    {
+        return $this->testFilesFile !== null;
+    }
+    /**
+     * @throws NoTestFilesFileException
+     */
+    public function testFilesFile(): string
+    {
+        if (!$this->hasTestFilesFile()) {
+            throw new \PHPUnit\TextUI\Configuration\NoTestFilesFileException();
+        }
+        return $this->testFilesFile;
     }
     /**
      * @phpstan-assert-if-true !null $this->configurationFile
@@ -96439,6 +96922,10 @@ final readonly class Configuration
     {
         return $this->requireCoverageMetadata;
     }
+    public function requireSealedMockObjects(): bool
+    {
+        return $this->requireSealedMockObjects;
+    }
     public function noProgress(): bool
     {
         return $this->noProgress;
@@ -96740,13 +97227,6 @@ final readonly class Configuration
         return $this->testSuite;
     }
     /**
-     * @deprecated Use includeTestSuites() instead
-     */
-    public function includeTestSuite(): string
-    {
-        return $this->includeTestSuite;
-    }
-    /**
      * @return list<non-empty-string>
      */
     public function includeTestSuites(): array
@@ -96755,13 +97235,6 @@ final readonly class Configuration
             return [];
         }
         return explode(',', $this->includeTestSuite);
-    }
-    /**
-     * @deprecated Use excludeTestSuites() instead
-     */
-    public function excludeTestSuite(): string
-    {
-        return $this->excludeTestSuite;
     }
     /**
      * @return list<non-empty-string>
@@ -97224,6 +97697,28 @@ use RuntimeException;
  *
  * @internal This class is not covered by the backward compatibility promise for PHPUnit
  */
+final class NoTestFilesFileException extends RuntimeException implements \PHPUnit\TextUI\Configuration\Exception
+{
+}
+<?php
+
+declare (strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PHPUnit\TextUI\Configuration;
+
+use RuntimeException;
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+ *
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
 final class SpecificDeprecationToStopOnNotConfiguredException extends RuntimeException implements \PHPUnit\TextUI\Configuration\Exception
 {
 }
@@ -97275,6 +97770,10 @@ final readonly class Merger
      */
     public function merge(CliConfiguration $cliConfiguration, XmlConfiguration $xmlConfiguration): \PHPUnit\TextUI\Configuration\Configuration
     {
+        $testFilesFile = null;
+        if ($cliConfiguration->hasTestFilesFile()) {
+            $testFilesFile = $cliConfiguration->testFilesFile();
+        }
         $configurationFile = null;
         if ($xmlConfiguration->wasLoadedFromFile()) {
             assert($xmlConfiguration instanceof LoadedFromFileConfiguration);
@@ -97705,6 +98204,7 @@ final readonly class Merger
             $reverseDefectList = $xmlConfiguration->phpunit()->reverseDefectList();
         }
         $requireCoverageMetadata = $xmlConfiguration->phpunit()->requireCoverageMetadata();
+        $requireSealedMockObjects = $xmlConfiguration->phpunit()->requireSealedMockObjects();
         if ($cliConfiguration->hasExecutionOrder()) {
             $executionOrder = $cliConfiguration->executionOrder();
         } else {
@@ -97943,7 +98443,7 @@ final readonly class Merger
         if ($issueTriggerIdentificationNeeded && !$xmlConfiguration->source()->identifyIssueTrigger()) {
             EventFacade::emitter()->testRunnerTriggeredPhpunitWarning('The identification of issue triggers is disabled. However, ignoring self-deprecations, direct deprecations, or indirect deprecations is requested.');
         }
-        return new \PHPUnit\TextUI\Configuration\Configuration($cliConfiguration->arguments(), $configurationFile, $bootstrap, $xmlConfiguration->phpunit()->bootstrapForTestSuite(), $cacheResult, $cacheDirectory, $coverageCacheDirectory, new \PHPUnit\TextUI\Configuration\Source($useBaseline, $cliConfiguration->ignoreBaseline(), \PHPUnit\TextUI\Configuration\FilterDirectoryCollection::fromArray($sourceIncludeDirectories), $sourceIncludeFiles, $sourceExcludeDirectories, $sourceExcludeFiles, $xmlConfiguration->source()->restrictNotices(), $xmlConfiguration->source()->restrictWarnings(), $xmlConfiguration->source()->ignoreSuppressionOfDeprecations(), $xmlConfiguration->source()->ignoreSuppressionOfPhpDeprecations(), $xmlConfiguration->source()->ignoreSuppressionOfErrors(), $xmlConfiguration->source()->ignoreSuppressionOfNotices(), $xmlConfiguration->source()->ignoreSuppressionOfPhpNotices(), $xmlConfiguration->source()->ignoreSuppressionOfWarnings(), $xmlConfiguration->source()->ignoreSuppressionOfPhpWarnings(), $xmlConfiguration->source()->deprecationTriggers(), $xmlConfiguration->source()->ignoreSelfDeprecations(), $xmlConfiguration->source()->ignoreDirectDeprecations(), $xmlConfiguration->source()->ignoreIndirectDeprecations(), $xmlConfiguration->source()->identifyIssueTrigger()), $testResultCacheFile, $coverageClover, $coverageCobertura, $coverageCrap4j, $coverageCrap4jThreshold, $coverageHtml, $coverageHtmlLowUpperBound, $coverageHtmlHighLowerBound, $coverageHtmlColorSuccessLow, $coverageHtmlColorSuccessMedium, $coverageHtmlColorSuccessHigh, $coverageHtmlColorWarning, $coverageHtmlColorDanger, $coverageHtmlCustomCssFile, $coverageOpenClover, $coveragePhp, $coverageText, $coverageTextShowUncoveredFiles, $coverageTextShowOnlySummary, $coverageXml, $coverageXmlIncludeSource, $pathCoverage, $xmlConfiguration->codeCoverage()->ignoreDeprecatedCodeUnits(), $disableCodeCoverageIgnore, $failOnAllIssues, $failOnDeprecation, $failOnPhpunitDeprecation, $failOnPhpunitNotice, $failOnPhpunitWarning, $failOnEmptyTestSuite, $failOnIncomplete, $failOnNotice, $failOnRisky, $failOnSkipped, $failOnWarning, $doNotFailOnDeprecation, $doNotFailOnPhpunitDeprecation, $doNotFailOnPhpunitNotice, $doNotFailOnPhpunitWarning, $doNotFailOnEmptyTestSuite, $doNotFailOnIncomplete, $doNotFailOnNotice, $doNotFailOnRisky, $doNotFailOnSkipped, $doNotFailOnWarning, $stopOnDefect, $stopOnDeprecation, $specificDeprecationToStopOn, $stopOnError, $stopOnFailure, $stopOnIncomplete, $stopOnNotice, $stopOnRisky, $stopOnSkipped, $stopOnWarning, $outputToStandardErrorStream, $columns, $noExtensions, $pharExtensionDirectory, $extensionBootstrappers, $backupGlobals, $backupStaticProperties, $beStrictAboutChangesToGlobalState, $colors, $processIsolation, $enforceTimeLimit, $defaultTimeLimit, $timeoutForSmallTests, $timeoutForMediumTests, $timeoutForLargeTests, $reportUselessTests, $strictCoverage, $disallowTestOutput, $displayDetailsOnAllIssues, $displayDetailsOnIncompleteTests, $displayDetailsOnSkippedTests, $displayDetailsOnTestsThatTriggerDeprecations, $displayDetailsOnPhpunitDeprecations, $displayDetailsOnPhpunitNotices, $displayDetailsOnTestsThatTriggerErrors, $displayDetailsOnTestsThatTriggerNotices, $displayDetailsOnTestsThatTriggerWarnings, $reverseDefectList, $requireCoverageMetadata, $noProgress, $noResults, $noOutput, $executionOrder, $executionOrderDefects, $resolveDependencies, $logfileTeamcity, $logfileJunit, $logfileOtr, $includeGitInformationInOtrLogfile, $logfileTestdoxHtml, $logfileTestdoxText, $logEventsText, $logEventsVerboseText, $teamCityOutput, $testDoxOutput, $testDoxOutputSummary, $testsCovering, $testsUsing, $testsRequiringPhpExtension, $filter, $excludeFilter, $groups, $excludeGroups, $randomOrderSeed, $includeUncoveredFiles, $xmlConfiguration->testSuite(), $includeTestSuite, $excludeTestSuite, $xmlConfiguration->phpunit()->hasDefaultTestSuite() ? $xmlConfiguration->phpunit()->defaultTestSuite() : null, $ignoreTestSelectionInXmlConfiguration, $testSuffixes, new \PHPUnit\TextUI\Configuration\Php(\PHPUnit\TextUI\Configuration\DirectoryCollection::fromArray($includePaths), \PHPUnit\TextUI\Configuration\IniSettingCollection::fromArray($iniSettings), $xmlConfiguration->php()->constants(), $xmlConfiguration->php()->globalVariables(), $xmlConfiguration->php()->envVariables(), $xmlConfiguration->php()->postVariables(), $xmlConfiguration->php()->getVariables(), $xmlConfiguration->php()->cookieVariables(), $xmlConfiguration->php()->serverVariables(), $xmlConfiguration->php()->filesVariables(), $xmlConfiguration->php()->requestVariables()), $xmlConfiguration->phpunit()->controlGarbageCollector(), $xmlConfiguration->phpunit()->numberOfTestsBeforeGarbageCollection(), $generateBaseline, $cliConfiguration->debug(), $cliConfiguration->withTelemetry(), $xmlConfiguration->phpunit()->shortenArraysForExportThreshold());
+        return new \PHPUnit\TextUI\Configuration\Configuration($cliConfiguration->arguments(), $testFilesFile, $configurationFile, $bootstrap, $xmlConfiguration->phpunit()->bootstrapForTestSuite(), $cacheResult, $cacheDirectory, $coverageCacheDirectory, new \PHPUnit\TextUI\Configuration\Source($useBaseline, $cliConfiguration->ignoreBaseline(), \PHPUnit\TextUI\Configuration\FilterDirectoryCollection::fromArray($sourceIncludeDirectories), $sourceIncludeFiles, $sourceExcludeDirectories, $sourceExcludeFiles, $xmlConfiguration->source()->restrictNotices(), $xmlConfiguration->source()->restrictWarnings(), $xmlConfiguration->source()->ignoreSuppressionOfDeprecations(), $xmlConfiguration->source()->ignoreSuppressionOfPhpDeprecations(), $xmlConfiguration->source()->ignoreSuppressionOfErrors(), $xmlConfiguration->source()->ignoreSuppressionOfNotices(), $xmlConfiguration->source()->ignoreSuppressionOfPhpNotices(), $xmlConfiguration->source()->ignoreSuppressionOfWarnings(), $xmlConfiguration->source()->ignoreSuppressionOfPhpWarnings(), $xmlConfiguration->source()->deprecationTriggers(), $xmlConfiguration->source()->ignoreSelfDeprecations(), $xmlConfiguration->source()->ignoreDirectDeprecations(), $xmlConfiguration->source()->ignoreIndirectDeprecations(), $xmlConfiguration->source()->identifyIssueTrigger()), $testResultCacheFile, $coverageClover, $coverageCobertura, $coverageCrap4j, $coverageCrap4jThreshold, $coverageHtml, $coverageHtmlLowUpperBound, $coverageHtmlHighLowerBound, $coverageHtmlColorSuccessLow, $coverageHtmlColorSuccessMedium, $coverageHtmlColorSuccessHigh, $coverageHtmlColorWarning, $coverageHtmlColorDanger, $coverageHtmlCustomCssFile, $coverageOpenClover, $coveragePhp, $coverageText, $coverageTextShowUncoveredFiles, $coverageTextShowOnlySummary, $coverageXml, $coverageXmlIncludeSource, $pathCoverage, $xmlConfiguration->codeCoverage()->ignoreDeprecatedCodeUnits(), $disableCodeCoverageIgnore, $failOnAllIssues, $failOnDeprecation, $failOnPhpunitDeprecation, $failOnPhpunitNotice, $failOnPhpunitWarning, $failOnEmptyTestSuite, $failOnIncomplete, $failOnNotice, $failOnRisky, $failOnSkipped, $failOnWarning, $doNotFailOnDeprecation, $doNotFailOnPhpunitDeprecation, $doNotFailOnPhpunitNotice, $doNotFailOnPhpunitWarning, $doNotFailOnEmptyTestSuite, $doNotFailOnIncomplete, $doNotFailOnNotice, $doNotFailOnRisky, $doNotFailOnSkipped, $doNotFailOnWarning, $stopOnDefect, $stopOnDeprecation, $specificDeprecationToStopOn, $stopOnError, $stopOnFailure, $stopOnIncomplete, $stopOnNotice, $stopOnRisky, $stopOnSkipped, $stopOnWarning, $outputToStandardErrorStream, $columns, $noExtensions, $pharExtensionDirectory, $extensionBootstrappers, $backupGlobals, $backupStaticProperties, $beStrictAboutChangesToGlobalState, $colors, $processIsolation, $enforceTimeLimit, $defaultTimeLimit, $timeoutForSmallTests, $timeoutForMediumTests, $timeoutForLargeTests, $reportUselessTests, $strictCoverage, $disallowTestOutput, $displayDetailsOnAllIssues, $displayDetailsOnIncompleteTests, $displayDetailsOnSkippedTests, $displayDetailsOnTestsThatTriggerDeprecations, $displayDetailsOnPhpunitDeprecations, $displayDetailsOnPhpunitNotices, $displayDetailsOnTestsThatTriggerErrors, $displayDetailsOnTestsThatTriggerNotices, $displayDetailsOnTestsThatTriggerWarnings, $reverseDefectList, $requireCoverageMetadata, $requireSealedMockObjects, $noProgress, $noResults, $noOutput, $executionOrder, $executionOrderDefects, $resolveDependencies, $logfileTeamcity, $logfileJunit, $logfileOtr, $includeGitInformationInOtrLogfile, $logfileTestdoxHtml, $logfileTestdoxText, $logEventsText, $logEventsVerboseText, $teamCityOutput, $testDoxOutput, $testDoxOutputSummary, $testsCovering, $testsUsing, $testsRequiringPhpExtension, $filter, $excludeFilter, $groups, $excludeGroups, $randomOrderSeed, $includeUncoveredFiles, $xmlConfiguration->testSuite(), $includeTestSuite, $excludeTestSuite, $xmlConfiguration->phpunit()->hasDefaultTestSuite() ? $xmlConfiguration->phpunit()->defaultTestSuite() : null, $ignoreTestSelectionInXmlConfiguration, $testSuffixes, new \PHPUnit\TextUI\Configuration\Php(\PHPUnit\TextUI\Configuration\DirectoryCollection::fromArray($includePaths), \PHPUnit\TextUI\Configuration\IniSettingCollection::fromArray($iniSettings), $xmlConfiguration->php()->constants(), $xmlConfiguration->php()->globalVariables(), $xmlConfiguration->php()->envVariables(), $xmlConfiguration->php()->postVariables(), $xmlConfiguration->php()->getVariables(), $xmlConfiguration->php()->cookieVariables(), $xmlConfiguration->php()->serverVariables(), $xmlConfiguration->php()->filesVariables(), $xmlConfiguration->php()->requestVariables()), $xmlConfiguration->phpunit()->controlGarbageCollector(), $xmlConfiguration->phpunit()->numberOfTestsBeforeGarbageCollection(), $generateBaseline, $cliConfiguration->debug(), $cliConfiguration->withTelemetry(), $xmlConfiguration->phpunit()->shortenArraysForExportThreshold());
     }
 }
 <?php
@@ -98164,6 +98664,9 @@ final class SourceFilter
     {
         $this->map = $map;
     }
+    /**
+     * @param non-empty-string $path
+     */
     public function includes(string $path): bool
     {
         return isset($this->map[$path]);
@@ -98286,13 +98789,17 @@ declare (strict_types=1);
  */
 namespace PHPUnit\TextUI\Configuration;
 
+use const DIRECTORY_SEPARATOR;
 use const PHP_EOL;
 use function assert;
 use function count;
+use function dirname;
+use function file;
 use function is_dir;
 use function is_file;
 use function realpath;
 use function str_ends_with;
+use function trim;
 use PHPUnit\Event\Facade as EventFacade;
 use PHPUnit\Exception;
 use PHPUnit\Framework\TestSuite;
@@ -98317,14 +98824,33 @@ final readonly class TestSuiteBuilder
      */
     public function build(\PHPUnit\TextUI\Configuration\Configuration $configuration): TestSuite
     {
-        if ($configuration->hasCliArguments()) {
+        if ($configuration->hasCliArguments() || $configuration->hasTestFilesFile()) {
             $arguments = [];
-            foreach ($configuration->cliArguments() as $cliArgument) {
-                $argument = realpath($cliArgument);
-                if (!$argument) {
-                    throw new TestFileNotFoundException($cliArgument);
+            if ($configuration->hasCliArguments()) {
+                foreach ($configuration->cliArguments() as $cliArgument) {
+                    $argument = realpath($cliArgument);
+                    if (!$argument) {
+                        throw new TestFileNotFoundException($cliArgument);
+                    }
+                    $arguments[] = $argument;
                 }
-                $arguments[] = $argument;
+            }
+            if ($configuration->hasTestFilesFile()) {
+                if (!is_file($configuration->testFilesFile())) {
+                    throw new RuntimeException('Cannot read from ' . $configuration->testFilesFile());
+                }
+                $directory = dirname($configuration->testFilesFile()) . DIRECTORY_SEPARATOR;
+                foreach (file($configuration->testFilesFile()) as $file) {
+                    $file = trim($file);
+                    $argument = realpath($file);
+                    if (!$argument) {
+                        $argument = realpath($directory . $file);
+                    }
+                    if (!$argument) {
+                        throw new TestFileNotFoundException($file);
+                    }
+                    $arguments[] = $argument;
+                }
             }
             if (count($arguments) === 1) {
                 $testSuite = $this->testSuiteFromPath($arguments[0], $configuration->testSuffixes());
@@ -98495,7 +99021,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\TextUI\Configuration;
 
-use function count;
 use Iterator;
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -98522,7 +99047,7 @@ final class ConstantCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->constants);
+        return isset($this->constants[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -98643,7 +99168,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\TextUI\Configuration;
 
-use function count;
 use Iterator;
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -98670,7 +99194,7 @@ final class DirectoryCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->directories);
+        return isset($this->directories[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -98803,7 +99327,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\TextUI\Configuration;
 
-use function count;
 use Iterator;
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -98830,7 +99353,7 @@ final class ExtensionBootstrapCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->extensionBootstraps);
+        return isset($this->extensionBootstraps[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -98960,7 +99483,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\TextUI\Configuration;
 
-use function count;
 use Iterator;
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -98987,7 +99509,7 @@ final class FileCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->files);
+        return isset($this->files[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -99129,7 +99651,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\TextUI\Configuration;
 
-use function count;
 use Iterator;
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -99156,7 +99677,7 @@ final class FilterDirectoryCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->directories);
+        return isset($this->directories[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -99282,7 +99803,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\TextUI\Configuration;
 
-use function count;
 use Iterator;
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -99309,7 +99829,7 @@ final class GroupCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->groups);
+        return isset($this->groups[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -99432,7 +99952,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\TextUI\Configuration;
 
-use function count;
 use Iterator;
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -99459,7 +99978,7 @@ final class IniSettingCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->iniSettings);
+        return isset($this->iniSettings[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -99896,7 +100415,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\TextUI\Configuration;
 
-use function count;
 use Iterator;
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -99923,7 +100441,7 @@ final class TestDirectoryCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->directories);
+        return isset($this->directories[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -100079,7 +100597,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\TextUI\Configuration;
 
-use function count;
 use Iterator;
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -100106,7 +100623,7 @@ final class TestFileCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->files);
+        return isset($this->files[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -100254,7 +100771,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\TextUI\Configuration;
 
-use function count;
 use Iterator;
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -100281,7 +100797,7 @@ final class TestSuiteCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->testSuites);
+        return isset($this->testSuites[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -100410,7 +100926,6 @@ declare (strict_types=1);
  */
 namespace PHPUnit\TextUI\Configuration;
 
-use function count;
 use Iterator;
 /**
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
@@ -100437,7 +100952,7 @@ final class VariableCollectionIterator implements Iterator
     }
     public function valid(): bool
     {
-        return $this->position < count($this->variables);
+        return isset($this->variables[$this->position]);
     }
     /**
      * @return non-negative-int
@@ -101148,7 +101663,7 @@ final readonly class DefaultConfiguration extends \PHPUnit\TextUI\XmlConfigurati
 {
     public static function create(): self
     {
-        return new self(ExtensionBootstrapCollection::fromArray([]), new Source(null, \false, CodeCoverageFilterDirectoryCollection::fromArray([]), FileCollection::fromArray([]), CodeCoverageFilterDirectoryCollection::fromArray([]), FileCollection::fromArray([]), \false, \false, \false, \false, \false, \false, \false, \false, \false, ['functions' => [], 'methods' => []], \false, \false, \false, \true), new CodeCoverage(\false, \true, \false, \false, null, null, null, null, null, null, null, null), new \PHPUnit\TextUI\XmlConfiguration\Groups(GroupCollection::fromArray([]), GroupCollection::fromArray([])), new Logging(null, null, null, null, null), new Php(DirectoryCollection::fromArray([]), IniSettingCollection::fromArray([]), ConstantCollection::fromArray([]), VariableCollection::fromArray([]), VariableCollection::fromArray([]), VariableCollection::fromArray([]), VariableCollection::fromArray([]), VariableCollection::fromArray([]), VariableCollection::fromArray([]), VariableCollection::fromArray([]), VariableCollection::fromArray([])), new \PHPUnit\TextUI\XmlConfiguration\PHPUnit(null, \true, 80, \PHPUnit\TextUI\Configuration\Configuration::COLOR_DEFAULT, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, null, [], \false, \false, \false, \false, \false, \true, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, null, \false, \false, \true, \false, \false, 1, 1, 10, 60, null, TestSuiteSorter::ORDER_DEFAULT, \true, \false, \false, \false, \false, \false, \false, 100, 10), TestSuiteCollection::fromArray([]));
+        return new self(ExtensionBootstrapCollection::fromArray([]), new Source(null, \false, CodeCoverageFilterDirectoryCollection::fromArray([]), FileCollection::fromArray([]), CodeCoverageFilterDirectoryCollection::fromArray([]), FileCollection::fromArray([]), \false, \false, \false, \false, \false, \false, \false, \false, \false, ['functions' => [], 'methods' => []], \false, \false, \false, \true), new CodeCoverage(\false, \true, \false, \false, null, null, null, null, null, null, null, null), new \PHPUnit\TextUI\XmlConfiguration\Groups(GroupCollection::fromArray([]), GroupCollection::fromArray([])), new Logging(null, null, null, null, null), new Php(DirectoryCollection::fromArray([]), IniSettingCollection::fromArray([]), ConstantCollection::fromArray([]), VariableCollection::fromArray([]), VariableCollection::fromArray([]), VariableCollection::fromArray([]), VariableCollection::fromArray([]), VariableCollection::fromArray([]), VariableCollection::fromArray([]), VariableCollection::fromArray([]), VariableCollection::fromArray([])), new \PHPUnit\TextUI\XmlConfiguration\PHPUnit(null, \true, 80, \PHPUnit\TextUI\Configuration\Configuration::COLOR_DEFAULT, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, null, [], \false, \false, \false, \false, \false, \true, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, \false, null, \false, \false, \true, \false, \false, 1, 1, 10, 60, null, TestSuiteSorter::ORDER_DEFAULT, \true, \false, \false, \false, \false, \false, \false, 100, 10), TestSuiteCollection::fromArray([]));
     }
     public function isDefault(): bool
     {
@@ -101854,6 +102369,10 @@ final readonly class Loader
         if ($document->documentElement->hasAttribute('requireCoverageMetadata')) {
             $requireCoverageMetadata = $this->parseBooleanAttribute($document->documentElement, 'requireCoverageMetadata', \false);
         }
+        $requireSealedMockObjects = \false;
+        if ($document->documentElement->hasAttribute('requireSealedMockObjects')) {
+            $requireSealedMockObjects = $this->parseBooleanAttribute($document->documentElement, 'requireSealedMockObjects', \false);
+        }
         $beStrictAboutCoverageMetadata = \false;
         if ($document->documentElement->hasAttribute('beStrictAboutCoverageMetadata')) {
             $beStrictAboutCoverageMetadata = $this->parseBooleanAttribute($document->documentElement, 'beStrictAboutCoverageMetadata', \false);
@@ -101862,7 +102381,7 @@ final readonly class Loader
         if ($shortenArraysForExportThreshold < 0) {
             $shortenArraysForExportThreshold = 0;
         }
-        return new \PHPUnit\TextUI\XmlConfiguration\PHPUnit($cacheDirectory, $this->parseBooleanAttribute($document->documentElement, 'cacheResult', \true), $this->parseColumns($document), $this->parseColors($document), $this->parseBooleanAttribute($document->documentElement, 'stderr', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnAllIssues', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnIncompleteTests', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnSkippedTests', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnTestsThatTriggerDeprecations', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnPhpunitDeprecations', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnPhpunitNotices', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnTestsThatTriggerErrors', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnTestsThatTriggerNotices', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnTestsThatTriggerWarnings', \false), $this->parseBooleanAttribute($document->documentElement, 'reverseDefectList', \false), $requireCoverageMetadata, $bootstrap, $this->bootstrapForTestSuite($filename, $xpath), $this->parseBooleanAttribute($document->documentElement, 'processIsolation', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnAllIssues', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnDeprecation', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnPhpunitDeprecation', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnPhpunitNotice', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnPhpunitWarning', \true), $this->parseBooleanAttribute($document->documentElement, 'failOnEmptyTestSuite', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnIncomplete', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnNotice', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnRisky', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnSkipped', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnWarning', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnDefect', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnDeprecation', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnError', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnFailure', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnIncomplete', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnNotice', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnRisky', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnSkipped', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnWarning', \false), $extensionsDirectory, $this->parseBooleanAttribute($document->documentElement, 'beStrictAboutChangesToGlobalState', \false), $this->parseBooleanAttribute($document->documentElement, 'beStrictAboutOutputDuringTests', \false), $this->parseBooleanAttribute($document->documentElement, 'beStrictAboutTestsThatDoNotTestAnything', \true), $beStrictAboutCoverageMetadata, $this->parseBooleanAttribute($document->documentElement, 'enforceTimeLimit', \false), $this->parseIntegerAttribute($document->documentElement, 'defaultTimeLimit', 1), $this->parseIntegerAttribute($document->documentElement, 'timeoutForSmallTests', 1), $this->parseIntegerAttribute($document->documentElement, 'timeoutForMediumTests', 10), $this->parseIntegerAttribute($document->documentElement, 'timeoutForLargeTests', 60), $this->parseStringAttribute($document->documentElement, 'defaultTestSuite'), $executionOrder, $resolveDependencies, $defectsFirst, $this->parseBooleanAttribute($document->documentElement, 'backupGlobals', \false), $backupStaticProperties, $this->parseBooleanAttribute($document->documentElement, 'testdox', \false), $this->parseBooleanAttribute($document->documentElement, 'testdoxSummary', \false), $this->parseBooleanAttribute($document->documentElement, 'controlGarbageCollector', \false), $this->parseIntegerAttribute($document->documentElement, 'numberOfTestsBeforeGarbageCollection', 100), $shortenArraysForExportThreshold);
+        return new \PHPUnit\TextUI\XmlConfiguration\PHPUnit($cacheDirectory, $this->parseBooleanAttribute($document->documentElement, 'cacheResult', \true), $this->parseColumns($document), $this->parseColors($document), $this->parseBooleanAttribute($document->documentElement, 'stderr', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnAllIssues', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnIncompleteTests', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnSkippedTests', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnTestsThatTriggerDeprecations', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnPhpunitDeprecations', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnPhpunitNotices', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnTestsThatTriggerErrors', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnTestsThatTriggerNotices', \false), $this->parseBooleanAttribute($document->documentElement, 'displayDetailsOnTestsThatTriggerWarnings', \false), $this->parseBooleanAttribute($document->documentElement, 'reverseDefectList', \false), $requireCoverageMetadata, $requireSealedMockObjects, $bootstrap, $this->bootstrapForTestSuite($filename, $xpath), $this->parseBooleanAttribute($document->documentElement, 'processIsolation', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnAllIssues', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnDeprecation', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnPhpunitDeprecation', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnPhpunitNotice', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnPhpunitWarning', \true), $this->parseBooleanAttribute($document->documentElement, 'failOnEmptyTestSuite', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnIncomplete', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnNotice', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnRisky', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnSkipped', \false), $this->parseBooleanAttribute($document->documentElement, 'failOnWarning', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnDefect', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnDeprecation', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnError', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnFailure', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnIncomplete', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnNotice', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnRisky', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnSkipped', \false), $this->parseBooleanAttribute($document->documentElement, 'stopOnWarning', \false), $extensionsDirectory, $this->parseBooleanAttribute($document->documentElement, 'beStrictAboutChangesToGlobalState', \false), $this->parseBooleanAttribute($document->documentElement, 'beStrictAboutOutputDuringTests', \false), $this->parseBooleanAttribute($document->documentElement, 'beStrictAboutTestsThatDoNotTestAnything', \true), $beStrictAboutCoverageMetadata, $this->parseBooleanAttribute($document->documentElement, 'enforceTimeLimit', \false), $this->parseIntegerAttribute($document->documentElement, 'defaultTimeLimit', 1), $this->parseIntegerAttribute($document->documentElement, 'timeoutForSmallTests', 1), $this->parseIntegerAttribute($document->documentElement, 'timeoutForMediumTests', 10), $this->parseIntegerAttribute($document->documentElement, 'timeoutForLargeTests', 60), $this->parseStringAttribute($document->documentElement, 'defaultTestSuite'), $executionOrder, $resolveDependencies, $defectsFirst, $this->parseBooleanAttribute($document->documentElement, 'backupGlobals', \false), $backupStaticProperties, $this->parseBooleanAttribute($document->documentElement, 'testdox', \false), $this->parseBooleanAttribute($document->documentElement, 'testdoxSummary', \false), $this->parseBooleanAttribute($document->documentElement, 'controlGarbageCollector', \false), $this->parseIntegerAttribute($document->documentElement, 'numberOfTestsBeforeGarbageCollection', 100), $shortenArraysForExportThreshold);
     }
     private function parseColors(DOMDocument $document): string
     {
@@ -103954,6 +104473,7 @@ final readonly class PHPUnit
     private bool $displayDetailsOnTestsThatTriggerWarnings;
     private bool $reverseDefectList;
     private bool $requireCoverageMetadata;
+    private bool $requireSealedMockObjects;
     private ?string $bootstrap;
     /**
      * @var array<non-empty-string, non-empty-string>
@@ -104012,7 +104532,7 @@ final readonly class PHPUnit
      * @param ?non-empty-string                         $extensionsDirectory
      * @param non-negative-int                          $shortenArraysForExportThreshold
      */
-    public function __construct(?string $cacheDirectory, bool $cacheResult, int|string $columns, string $colors, bool $stderr, bool $displayDetailsOnAllIssues, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnPhpunitDeprecations, bool $displayDetailsOnPhpunitNotices, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, ?string $bootstrap, array $bootstrapForTestSuite, bool $processIsolation, bool $failOnAllIssues, bool $failOnDeprecation, bool $failOnPhpunitDeprecation, bool $failOnPhpunitNotice, bool $failOnPhpunitWarning, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, ?string $extensionsDirectory, bool $beStrictAboutChangesToGlobalState, bool $beStrictAboutOutputDuringTests, bool $beStrictAboutTestsThatDoNotTestAnything, bool $beStrictAboutCoverageMetadata, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, ?string $defaultTestSuite, int $executionOrder, bool $resolveDependencies, bool $defectsFirst, bool $backupGlobals, bool $backupStaticProperties, bool $testdoxPrinter, bool $testdoxPrinterSummary, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, int $shortenArraysForExportThreshold)
+    public function __construct(?string $cacheDirectory, bool $cacheResult, int|string $columns, string $colors, bool $stderr, bool $displayDetailsOnAllIssues, bool $displayDetailsOnIncompleteTests, bool $displayDetailsOnSkippedTests, bool $displayDetailsOnTestsThatTriggerDeprecations, bool $displayDetailsOnPhpunitDeprecations, bool $displayDetailsOnPhpunitNotices, bool $displayDetailsOnTestsThatTriggerErrors, bool $displayDetailsOnTestsThatTriggerNotices, bool $displayDetailsOnTestsThatTriggerWarnings, bool $reverseDefectList, bool $requireCoverageMetadata, bool $requireSealedMockObjects, ?string $bootstrap, array $bootstrapForTestSuite, bool $processIsolation, bool $failOnAllIssues, bool $failOnDeprecation, bool $failOnPhpunitDeprecation, bool $failOnPhpunitNotice, bool $failOnPhpunitWarning, bool $failOnEmptyTestSuite, bool $failOnIncomplete, bool $failOnNotice, bool $failOnRisky, bool $failOnSkipped, bool $failOnWarning, bool $stopOnDefect, bool $stopOnDeprecation, bool $stopOnError, bool $stopOnFailure, bool $stopOnIncomplete, bool $stopOnNotice, bool $stopOnRisky, bool $stopOnSkipped, bool $stopOnWarning, ?string $extensionsDirectory, bool $beStrictAboutChangesToGlobalState, bool $beStrictAboutOutputDuringTests, bool $beStrictAboutTestsThatDoNotTestAnything, bool $beStrictAboutCoverageMetadata, bool $enforceTimeLimit, int $defaultTimeLimit, int $timeoutForSmallTests, int $timeoutForMediumTests, int $timeoutForLargeTests, ?string $defaultTestSuite, int $executionOrder, bool $resolveDependencies, bool $defectsFirst, bool $backupGlobals, bool $backupStaticProperties, bool $testdoxPrinter, bool $testdoxPrinterSummary, bool $controlGarbageCollector, int $numberOfTestsBeforeGarbageCollection, int $shortenArraysForExportThreshold)
     {
         $this->cacheDirectory = $cacheDirectory;
         $this->cacheResult = $cacheResult;
@@ -104030,6 +104550,7 @@ final readonly class PHPUnit
         $this->displayDetailsOnTestsThatTriggerWarnings = $displayDetailsOnTestsThatTriggerWarnings;
         $this->reverseDefectList = $reverseDefectList;
         $this->requireCoverageMetadata = $requireCoverageMetadata;
+        $this->requireSealedMockObjects = $requireSealedMockObjects;
         $this->bootstrap = $bootstrap;
         $this->bootstrapForTestSuite = $bootstrapForTestSuite;
         $this->processIsolation = $processIsolation;
@@ -104151,6 +104672,10 @@ final readonly class PHPUnit
     public function requireCoverageMetadata(): bool
     {
         return $this->requireCoverageMetadata;
+    }
+    public function requireSealedMockObjects(): bool
+    {
+        return $this->requireSealedMockObjects;
     }
     /**
      * @phpstan-assert-if-true !null $this->bootstrap
@@ -105072,7 +105597,7 @@ final class Help
      */
     private function elements(): array
     {
-        $elements = ['Usage' => [['text' => 'phpunit [options] <directory|file> ...']], 'Configuration' => [['arg' => '--bootstrap <file>', 'desc' => 'A PHP script that is included before the tests run'], ['arg' => '-c|--configuration <file>', 'desc' => 'Read configuration from XML file'], ['arg' => '--no-configuration', 'desc' => 'Ignore default configuration file (phpunit.xml)'], ['arg' => '--extension <class>', 'desc' => 'Register test runner extension with bootstrap <class>'], ['arg' => '--no-extensions', 'desc' => 'Do not register test runner extensions'], ['arg' => '--include-path <path(s)>', 'desc' => 'Prepend PHP\'s include_path with given path(s)'], ['arg' => '-d <key[=value]>', 'desc' => 'Sets a php.ini value'], ['arg' => '--cache-directory <dir>', 'desc' => 'Specify cache directory'], ['arg' => '--generate-configuration', 'desc' => 'Generate configuration file with suggested settings'], ['arg' => '--migrate-configuration', 'desc' => 'Migrate configuration file to current format'], ['arg' => '--generate-baseline <file>', 'desc' => 'Generate baseline for issues'], ['arg' => '--use-baseline <file>', 'desc' => 'Use baseline to ignore issues'], ['arg' => '--ignore-baseline', 'desc' => 'Do not use baseline to ignore issues']], 'Selection' => [['arg' => '--all', 'desc' => 'Ignore test selection from XML configuration file'], ['arg' => '--list-suites', 'desc' => 'List available test suites'], ['arg' => '--testsuite <name>', 'desc' => 'Only run tests from the specified test suite(s)'], ['arg' => '--exclude-testsuite <name>', 'desc' => 'Exclude tests from the specified test suite(s)'], ['arg' => '--list-groups', 'desc' => 'List available test groups'], ['arg' => '--group <name>', 'desc' => 'Only run tests from the specified group(s)'], ['arg' => '--exclude-group <name>', 'desc' => 'Exclude tests from the specified group(s)'], ['arg' => '--covers <name>', 'desc' => 'Only run tests that intend to cover <name>'], ['arg' => '--uses <name>', 'desc' => 'Only run tests that intend to use <name>'], ['arg' => '--requires-php-extension <name>', 'desc' => 'Only run tests that require PHP extension <name>'], ['arg' => '--list-test-files', 'desc' => 'List available test files'], ['arg' => '--list-tests', 'desc' => 'List available tests'], ['arg' => '--list-tests-xml <file>', 'desc' => 'List available tests in XML format'], ['arg' => '--filter <pattern>', 'desc' => 'Filter which tests to run'], ['arg' => '--exclude-filter <pattern>', 'desc' => 'Exclude tests for the specified filter pattern'], ['arg' => '--test-suffix <suffixes>', 'desc' => 'Only search for test in files with specified suffix(es). Default: Test.php,.phpt']], 'Execution' => [['arg' => '--process-isolation', 'desc' => 'Run each test in a separate PHP process'], ['arg' => '--globals-backup', 'desc' => 'Backup and restore $GLOBALS for each test'], ['arg' => '--static-backup', 'desc' => 'Backup and restore static properties for each test'], ['spacer' => ''], ['arg' => '--strict-coverage', 'desc' => 'Be strict about code coverage metadata'], ['arg' => '--strict-global-state', 'desc' => 'Be strict about changes to global state'], ['arg' => '--disallow-test-output', 'desc' => 'Be strict about output during tests'], ['arg' => '--enforce-time-limit', 'desc' => 'Enforce time limit based on test size'], ['arg' => '--default-time-limit <sec>', 'desc' => 'Timeout in seconds for tests that have no declared size'], ['arg' => '--do-not-report-useless-tests', 'desc' => 'Do not report tests that do not test anything'], ['spacer' => ''], ['arg' => '--stop-on-defect', 'desc' => 'Stop after first error, failure, warning, or risky test'], ['arg' => '--stop-on-error', 'desc' => 'Stop after first error'], ['arg' => '--stop-on-failure', 'desc' => 'Stop after first failure'], ['arg' => '--stop-on-warning', 'desc' => 'Stop after first warning'], ['arg' => '--stop-on-risky', 'desc' => 'Stop after first risky test'], ['arg' => '--stop-on-deprecation', 'desc' => 'Stop after first test that triggered a deprecation'], ['arg' => '--stop-on-notice', 'desc' => 'Stop after first test that triggered a notice'], ['arg' => '--stop-on-skipped', 'desc' => 'Stop after first skipped test'], ['arg' => '--stop-on-incomplete', 'desc' => 'Stop after first incomplete test'], ['spacer' => ''], ['arg' => '--fail-on-empty-test-suite', 'desc' => 'Signal failure using shell exit code when no tests were run'], ['arg' => '--fail-on-warning', 'desc' => 'Signal failure using shell exit code when a warning was triggered'], ['arg' => '--fail-on-risky', 'desc' => 'Signal failure using shell exit code when a test was considered risky'], ['arg' => '--fail-on-deprecation', 'desc' => 'Signal failure using shell exit code when a deprecation was triggered'], ['arg' => '--fail-on-phpunit-deprecation', 'desc' => 'Signal failure using shell exit code when a PHPUnit deprecation was triggered'], ['arg' => '--fail-on-phpunit-notice', 'desc' => 'Signal failure using shell exit code when a PHPUnit notice was triggered'], ['arg' => '--fail-on-phpunit-warning', 'desc' => 'Signal failure using shell exit code when a PHPUnit warning was triggered'], ['arg' => '--fail-on-notice', 'desc' => 'Signal failure using shell exit code when a notice was triggered'], ['arg' => '--fail-on-skipped', 'desc' => 'Signal failure using shell exit code when a test was skipped'], ['arg' => '--fail-on-incomplete', 'desc' => 'Signal failure using shell exit code when a test was marked incomplete'], ['arg' => '--fail-on-all-issues', 'desc' => 'Signal failure using shell exit code when an issue is triggered'], ['spacer' => ''], ['arg' => '--do-not-fail-on-empty-test-suite', 'desc' => 'Do not signal failure using shell exit code when no tests were run'], ['arg' => '--do-not-fail-on-warning', 'desc' => 'Do not signal failure using shell exit code when a warning was triggered'], ['arg' => '--do-not-fail-on-risky', 'desc' => 'Do not signal failure using shell exit code when a test was considered risky'], ['arg' => '--do-not-fail-on-deprecation', 'desc' => 'Do not signal failure using shell exit code when a deprecation was triggered'], ['arg' => '--do-not-fail-on-phpunit-deprecation', 'desc' => 'Do not signal failure using shell exit code when a PHPUnit deprecation was triggered'], ['arg' => '--do-not-fail-on-phpunit-notice', 'desc' => 'Do not signal failure using shell exit code when a PHPUnit notice was triggered'], ['arg' => '--do-not-fail-on-phpunit-warning', 'desc' => 'Do not signal failure using shell exit code when a PHPUnit warning was triggered'], ['arg' => '--do-not-fail-on-notice', 'desc' => 'Do not signal failure using shell exit code when a notice was triggered'], ['arg' => '--do-not-fail-on-skipped', 'desc' => 'Do not signal failure using shell exit code when a test was skipped'], ['arg' => '--do-not-fail-on-incomplete', 'desc' => 'Do not signal failure using shell exit code when a test was marked incomplete'], ['spacer' => ''], ['arg' => '--cache-result', 'desc' => 'Write test results to cache file'], ['arg' => '--do-not-cache-result', 'desc' => 'Do not write test results to cache file'], ['spacer' => ''], ['arg' => '--order-by <order>', 'desc' => 'Run tests in order: default|defects|depends|duration|no-depends|random|reverse|size'], ['arg' => '--random-order-seed <N>', 'desc' => 'Use the specified random seed when running tests in random order']], 'Reporting' => [['arg' => '--colors <flag>', 'desc' => 'Use colors in output ("never", "auto" or "always")'], ['arg' => '--columns <n>', 'desc' => 'Number of columns to use for progress output'], ['arg' => '--columns max', 'desc' => 'Use maximum number of columns for progress output'], ['arg' => '--stderr', 'desc' => 'Write to STDERR instead of STDOUT'], ['spacer' => ''], ['arg' => '--no-progress', 'desc' => 'Disable output of test execution progress'], ['arg' => '--no-results', 'desc' => 'Disable output of test results'], ['arg' => '--no-output', 'desc' => 'Disable all output'], ['spacer' => ''], ['arg' => '--display-incomplete', 'desc' => 'Display details for incomplete tests'], ['arg' => '--display-skipped', 'desc' => 'Display details for skipped tests'], ['arg' => '--display-deprecations', 'desc' => 'Display details for deprecations triggered by tests'], ['arg' => '--display-phpunit-deprecations', 'desc' => 'Display details for PHPUnit deprecations'], ['arg' => '--display-phpunit-notices', 'desc' => 'Display details for PHPUnit notices'], ['arg' => '--display-errors', 'desc' => 'Display details for errors triggered by tests'], ['arg' => '--display-notices', 'desc' => 'Display details for notices triggered by tests'], ['arg' => '--display-warnings', 'desc' => 'Display details for warnings triggered by tests'], ['arg' => '--display-all-issues', 'desc' => 'Display details for all issues that are triggered'], ['arg' => '--reverse-list', 'desc' => 'Print defects in reverse order'], ['spacer' => ''], ['arg' => '--teamcity', 'desc' => 'Replace default progress and result output with TeamCity format'], ['arg' => '--testdox', 'desc' => 'Replace default result output with TestDox format'], ['arg' => '--testdox-summary', 'desc' => 'Repeat TestDox output for tests with errors, failures, or issues'], ['spacer' => ''], ['arg' => '--debug', 'desc' => 'Replace default progress and result output with debugging information'], ['arg' => '--with-telemetry', 'desc' => 'Include telemetry information in debugging information output']], 'Logging' => [['arg' => '--log-junit <file>', 'desc' => 'Write test results in JUnit XML format to file'], ['arg' => '--log-otr <file>', 'desc' => 'Write test results in Open Test Reporting XML format to file'], ['arg' => '--include-git-information', 'desc' => 'Include Git information in Open Test Reporting XML logfile'], ['arg' => '--log-teamcity <file>', 'desc' => 'Write test results in TeamCity format to file'], ['arg' => '--testdox-html <file>', 'desc' => 'Write test results in TestDox format (HTML) to file'], ['arg' => '--testdox-text <file>', 'desc' => 'Write test results in TestDox format (plain text) to file'], ['arg' => '--log-events-text <file>', 'desc' => 'Stream events as plain text to file'], ['arg' => '--log-events-verbose-text <file>', 'desc' => 'Stream events as plain text with extended information to file'], ['arg' => '--no-logging', 'desc' => 'Ignore logging configured in the XML configuration file']], 'Code Coverage' => [['arg' => '--coverage-clover <file>', 'desc' => 'Write code coverage report in Clover XML format to file'], ['arg' => '--coverage-openclover <file>', 'desc' => 'Write code coverage report in OpenClover XML format to file'], ['arg' => '--coverage-cobertura <file>', 'desc' => 'Write code coverage report in Cobertura XML format to file'], ['arg' => '--coverage-crap4j <file>', 'desc' => 'Write code coverage report in Crap4J XML format to file'], ['arg' => '--coverage-html <dir>', 'desc' => 'Write code coverage report in HTML format to directory'], ['arg' => '--coverage-php <file>', 'desc' => 'Write serialized code coverage data to file'], ['arg' => '--coverage-text=<file>', 'desc' => 'Write code coverage report in text format to file [default: standard output]'], ['arg' => '--only-summary-for-coverage-text', 'desc' => 'Option for code coverage report in text format: only show summary'], ['arg' => '--show-uncovered-for-coverage-text', 'desc' => 'Option for code coverage report in text format: show uncovered files'], ['arg' => '--coverage-xml <dir>', 'desc' => 'Write code coverage report in XML format to directory'], ['arg' => '--exclude-source-from-xml-coverage', 'desc' => 'Exclude <source> element from code coverage report in XML format'], ['arg' => '--warm-coverage-cache', 'desc' => 'Warm static analysis cache'], ['arg' => '--coverage-filter <dir>', 'desc' => 'Include <dir> in code coverage reporting'], ['arg' => '--path-coverage', 'desc' => 'Report path coverage in addition to line coverage'], ['arg' => '--disable-coverage-ignore', 'desc' => 'Disable metadata for ignoring code coverage'], ['arg' => '--no-coverage', 'desc' => 'Ignore code coverage reporting configured in the XML configuration file']]];
+        $elements = ['Usage' => [['text' => 'phpunit [options] <directory|file> ...']], 'Configuration' => [['arg' => '--bootstrap <file>', 'desc' => 'A PHP script that is included before the tests run'], ['arg' => '-c|--configuration <file>', 'desc' => 'Read configuration from XML file'], ['arg' => '--no-configuration', 'desc' => 'Ignore default configuration file (phpunit.xml)'], ['arg' => '--extension <class>', 'desc' => 'Register test runner extension with bootstrap <class>'], ['arg' => '--no-extensions', 'desc' => 'Do not register test runner extensions'], ['arg' => '--include-path <path(s)>', 'desc' => 'Prepend PHP\'s include_path with given path(s)'], ['arg' => '-d <key[=value]>', 'desc' => 'Sets a php.ini value'], ['arg' => '--cache-directory <dir>', 'desc' => 'Specify cache directory'], ['arg' => '--generate-configuration', 'desc' => 'Generate configuration file with suggested settings'], ['arg' => '--migrate-configuration', 'desc' => 'Migrate configuration file to current format'], ['arg' => '--generate-baseline <file>', 'desc' => 'Generate baseline for issues'], ['arg' => '--use-baseline <file>', 'desc' => 'Use baseline to ignore issues'], ['arg' => '--ignore-baseline', 'desc' => 'Do not use baseline to ignore issues']], 'Selection' => [['arg' => '--all', 'desc' => 'Ignore test selection from XML configuration file'], ['arg' => '--list-suites', 'desc' => 'List available test suites'], ['arg' => '--testsuite <name>', 'desc' => 'Only run tests from the specified test suite(s)'], ['arg' => '--exclude-testsuite <name>', 'desc' => 'Exclude tests from the specified test suite(s)'], ['arg' => '--list-groups', 'desc' => 'List available test groups'], ['arg' => '--group <name>', 'desc' => 'Only run tests from the specified group(s)'], ['arg' => '--exclude-group <name>', 'desc' => 'Exclude tests from the specified group(s)'], ['arg' => '--covers <name>', 'desc' => 'Only run tests that intend to cover <name>'], ['arg' => '--uses <name>', 'desc' => 'Only run tests that intend to use <name>'], ['arg' => '--requires-php-extension <name>', 'desc' => 'Only run tests that require PHP extension <name>'], ['arg' => '--list-test-files', 'desc' => 'List available test files'], ['arg' => '--list-tests', 'desc' => 'List available tests'], ['arg' => '--list-tests-xml <file>', 'desc' => 'List available tests in XML format'], ['arg' => '--filter <pattern>', 'desc' => 'Filter which tests to run'], ['arg' => '--exclude-filter <pattern>', 'desc' => 'Exclude tests for the specified filter pattern'], ['arg' => '--test-suffix <suffixes>', 'desc' => 'Only search for test in files with specified suffix(es). Default: Test.php,.phpt'], ['arg' => '--test-files-file <file>', 'desc' => 'Only run test files listed in file (one file by line)']], 'Execution' => [['arg' => '--process-isolation', 'desc' => 'Run each test in a separate PHP process'], ['arg' => '--globals-backup', 'desc' => 'Backup and restore $GLOBALS for each test'], ['arg' => '--static-backup', 'desc' => 'Backup and restore static properties for each test'], ['spacer' => ''], ['arg' => '--strict-coverage', 'desc' => 'Be strict about code coverage metadata'], ['arg' => '--strict-global-state', 'desc' => 'Be strict about changes to global state'], ['arg' => '--disallow-test-output', 'desc' => 'Be strict about output during tests'], ['arg' => '--enforce-time-limit', 'desc' => 'Enforce time limit based on test size'], ['arg' => '--default-time-limit <sec>', 'desc' => 'Timeout in seconds for tests that have no declared size'], ['arg' => '--do-not-report-useless-tests', 'desc' => 'Do not report tests that do not test anything'], ['spacer' => ''], ['arg' => '--stop-on-defect', 'desc' => 'Stop after first error, failure, warning, or risky test'], ['arg' => '--stop-on-error', 'desc' => 'Stop after first error'], ['arg' => '--stop-on-failure', 'desc' => 'Stop after first failure'], ['arg' => '--stop-on-warning', 'desc' => 'Stop after first warning'], ['arg' => '--stop-on-risky', 'desc' => 'Stop after first risky test'], ['arg' => '--stop-on-deprecation', 'desc' => 'Stop after first test that triggered a deprecation'], ['arg' => '--stop-on-notice', 'desc' => 'Stop after first test that triggered a notice'], ['arg' => '--stop-on-skipped', 'desc' => 'Stop after first skipped test'], ['arg' => '--stop-on-incomplete', 'desc' => 'Stop after first incomplete test'], ['spacer' => ''], ['arg' => '--fail-on-empty-test-suite', 'desc' => 'Signal failure using shell exit code when no tests were run'], ['arg' => '--fail-on-warning', 'desc' => 'Signal failure using shell exit code when a warning was triggered'], ['arg' => '--fail-on-risky', 'desc' => 'Signal failure using shell exit code when a test was considered risky'], ['arg' => '--fail-on-deprecation', 'desc' => 'Signal failure using shell exit code when a deprecation was triggered'], ['arg' => '--fail-on-phpunit-deprecation', 'desc' => 'Signal failure using shell exit code when a PHPUnit deprecation was triggered'], ['arg' => '--fail-on-phpunit-notice', 'desc' => 'Signal failure using shell exit code when a PHPUnit notice was triggered'], ['arg' => '--fail-on-phpunit-warning', 'desc' => 'Signal failure using shell exit code when a PHPUnit warning was triggered'], ['arg' => '--fail-on-notice', 'desc' => 'Signal failure using shell exit code when a notice was triggered'], ['arg' => '--fail-on-skipped', 'desc' => 'Signal failure using shell exit code when a test was skipped'], ['arg' => '--fail-on-incomplete', 'desc' => 'Signal failure using shell exit code when a test was marked incomplete'], ['arg' => '--fail-on-all-issues', 'desc' => 'Signal failure using shell exit code when an issue is triggered'], ['spacer' => ''], ['arg' => '--do-not-fail-on-empty-test-suite', 'desc' => 'Do not signal failure using shell exit code when no tests were run'], ['arg' => '--do-not-fail-on-warning', 'desc' => 'Do not signal failure using shell exit code when a warning was triggered'], ['arg' => '--do-not-fail-on-risky', 'desc' => 'Do not signal failure using shell exit code when a test was considered risky'], ['arg' => '--do-not-fail-on-deprecation', 'desc' => 'Do not signal failure using shell exit code when a deprecation was triggered'], ['arg' => '--do-not-fail-on-phpunit-deprecation', 'desc' => 'Do not signal failure using shell exit code when a PHPUnit deprecation was triggered'], ['arg' => '--do-not-fail-on-phpunit-notice', 'desc' => 'Do not signal failure using shell exit code when a PHPUnit notice was triggered'], ['arg' => '--do-not-fail-on-phpunit-warning', 'desc' => 'Do not signal failure using shell exit code when a PHPUnit warning was triggered'], ['arg' => '--do-not-fail-on-notice', 'desc' => 'Do not signal failure using shell exit code when a notice was triggered'], ['arg' => '--do-not-fail-on-skipped', 'desc' => 'Do not signal failure using shell exit code when a test was skipped'], ['arg' => '--do-not-fail-on-incomplete', 'desc' => 'Do not signal failure using shell exit code when a test was marked incomplete'], ['spacer' => ''], ['arg' => '--cache-result', 'desc' => 'Write test results to cache file'], ['arg' => '--do-not-cache-result', 'desc' => 'Do not write test results to cache file'], ['spacer' => ''], ['arg' => '--order-by <order>', 'desc' => 'Run tests in order: default|defects|depends|duration|no-depends|random|reverse|size'], ['arg' => '--random-order-seed <N>', 'desc' => 'Use the specified random seed when running tests in random order']], 'Reporting' => [['arg' => '--colors <flag>', 'desc' => 'Use colors in output ("never", "auto" or "always")'], ['arg' => '--columns <n>', 'desc' => 'Number of columns to use for progress output'], ['arg' => '--columns max', 'desc' => 'Use maximum number of columns for progress output'], ['arg' => '--stderr', 'desc' => 'Write to STDERR instead of STDOUT'], ['spacer' => ''], ['arg' => '--no-progress', 'desc' => 'Disable output of test execution progress'], ['arg' => '--no-results', 'desc' => 'Disable output of test results'], ['arg' => '--no-output', 'desc' => 'Disable all output'], ['spacer' => ''], ['arg' => '--display-incomplete', 'desc' => 'Display details for incomplete tests'], ['arg' => '--display-skipped', 'desc' => 'Display details for skipped tests'], ['arg' => '--display-deprecations', 'desc' => 'Display details for deprecations triggered by tests'], ['arg' => '--display-phpunit-deprecations', 'desc' => 'Display details for PHPUnit deprecations'], ['arg' => '--display-phpunit-notices', 'desc' => 'Display details for PHPUnit notices'], ['arg' => '--display-errors', 'desc' => 'Display details for errors triggered by tests'], ['arg' => '--display-notices', 'desc' => 'Display details for notices triggered by tests'], ['arg' => '--display-warnings', 'desc' => 'Display details for warnings triggered by tests'], ['arg' => '--display-all-issues', 'desc' => 'Display details for all issues that are triggered'], ['arg' => '--reverse-list', 'desc' => 'Print defects in reverse order'], ['spacer' => ''], ['arg' => '--teamcity', 'desc' => 'Replace default progress and result output with TeamCity format'], ['arg' => '--testdox', 'desc' => 'Replace default result output with TestDox format'], ['arg' => '--testdox-summary', 'desc' => 'Repeat TestDox output for tests with errors, failures, or issues'], ['spacer' => ''], ['arg' => '--debug', 'desc' => 'Replace default progress and result output with debugging information'], ['arg' => '--with-telemetry', 'desc' => 'Include telemetry information in debugging information output']], 'Logging' => [['arg' => '--log-junit <file>', 'desc' => 'Write test results in JUnit XML format to file'], ['arg' => '--log-otr <file>', 'desc' => 'Write test results in Open Test Reporting XML format to file'], ['arg' => '--include-git-information', 'desc' => 'Include Git information in Open Test Reporting XML logfile'], ['arg' => '--log-teamcity <file>', 'desc' => 'Write test results in TeamCity format to file'], ['arg' => '--testdox-html <file>', 'desc' => 'Write test results in TestDox format (HTML) to file'], ['arg' => '--testdox-text <file>', 'desc' => 'Write test results in TestDox format (plain text) to file'], ['arg' => '--log-events-text <file>', 'desc' => 'Stream events as plain text to file'], ['arg' => '--log-events-verbose-text <file>', 'desc' => 'Stream events as plain text with extended information to file'], ['arg' => '--no-logging', 'desc' => 'Ignore logging configured in the XML configuration file']], 'Code Coverage' => [['arg' => '--coverage-clover <file>', 'desc' => 'Write code coverage report in Clover XML format to file'], ['arg' => '--coverage-openclover <file>', 'desc' => 'Write code coverage report in OpenClover XML format to file'], ['arg' => '--coverage-cobertura <file>', 'desc' => 'Write code coverage report in Cobertura XML format to file'], ['arg' => '--coverage-crap4j <file>', 'desc' => 'Write code coverage report in Crap4J XML format to file'], ['arg' => '--coverage-html <dir>', 'desc' => 'Write code coverage report in HTML format to directory'], ['arg' => '--coverage-php <file>', 'desc' => 'Write serialized code coverage data to file'], ['arg' => '--coverage-text=<file>', 'desc' => 'Write code coverage report in text format to file [default: standard output]'], ['arg' => '--only-summary-for-coverage-text', 'desc' => 'Option for code coverage report in text format: only show summary'], ['arg' => '--show-uncovered-for-coverage-text', 'desc' => 'Option for code coverage report in text format: show uncovered files'], ['arg' => '--coverage-xml <dir>', 'desc' => 'Write code coverage report in XML format to directory'], ['arg' => '--exclude-source-from-xml-coverage', 'desc' => 'Exclude <source> element from code coverage report in XML format'], ['arg' => '--warm-coverage-cache', 'desc' => 'Warm static analysis cache'], ['arg' => '--coverage-filter <dir>', 'desc' => 'Include <dir> in code coverage reporting'], ['arg' => '--path-coverage', 'desc' => 'Report path coverage in addition to line coverage'], ['arg' => '--disable-coverage-ignore', 'desc' => 'Disable metadata for ignoring code coverage'], ['arg' => '--no-coverage', 'desc' => 'Ignore code coverage reporting configured in the XML configuration file']]];
         if (defined('__PHPUNIT_PHAR__')) {
             $elements['PHAR'] = [['arg' => '--manifest', 'desc' => 'Print Software Bill of Materials (SBOM) in plain-text format'], ['arg' => '--sbom', 'desc' => 'Print Software Bill of Materials (SBOM) in CycloneDX XML format'], ['arg' => '--composer-lock', 'desc' => 'Print composer.lock file used to build the PHAR']];
         }
@@ -106556,6 +107081,7 @@ final class Facade
         if ($configuration->outputIsTeamCity()) {
             new TeamCityLogger(\PHPUnit\TextUI\Output\DefaultPrinter::standardOutput(), EventFacade::instance());
         }
+        assert(self::$printer !== null);
         return self::$printer;
     }
     /**
@@ -106588,7 +107114,7 @@ final class Facade
     public static function printerFor(string $target): \PHPUnit\TextUI\Output\Printer
     {
         if ($target === 'php://stdout') {
-            if (!self::$printer instanceof \PHPUnit\TextUI\Output\NullPrinter) {
+            if (self::$printer !== null && !self::$printer instanceof \PHPUnit\TextUI\Output\NullPrinter) {
                 return self::$printer;
             }
             return \PHPUnit\TextUI\Output\DefaultPrinter::standardOutput();
@@ -107126,7 +107652,7 @@ final readonly class ResultPrinter
     {
         $lines = [];
         if ($buffer !== '') {
-            $lines = array_map('\rtrim', explode(PHP_EOL, $buffer));
+            $lines = array_map(\rtrim(...), explode(PHP_EOL, $buffer));
         }
         $message = [];
         $diff = [];
@@ -107552,8 +108078,10 @@ namespace PHPUnit\Util;
 
 use const DIRECTORY_SEPARATOR;
 use const PHP_EOL;
+use function array_key_exists;
 use function array_map;
 use function array_walk;
+use function assert;
 use function count;
 use function explode;
 use function implode;
@@ -107585,27 +108113,37 @@ final class Color
      * @var non-empty-array<non-empty-string, non-empty-string>
      */
     private const array ANSI_CODES = ['reset' => '0', 'bold' => '1', 'dim' => '2', 'dim-reset' => '22', 'underlined' => '4', 'fg-default' => '39', 'fg-black' => '30', 'fg-red' => '31', 'fg-green' => '32', 'fg-yellow' => '33', 'fg-blue' => '34', 'fg-magenta' => '35', 'fg-cyan' => '36', 'fg-white' => '37', 'bg-default' => '49', 'bg-black' => '40', 'bg-red' => '41', 'bg-green' => '42', 'bg-yellow' => '43', 'bg-blue' => '44', 'bg-magenta' => '45', 'bg-cyan' => '46', 'bg-white' => '47'];
+    /**
+     * @param non-empty-string $color
+     */
     public static function colorize(string $color, string $buffer): string
     {
         if (trim($buffer) === '') {
             return $buffer;
         }
-        $codes = array_map('\trim', explode(',', $color));
+        if (array_key_exists($color, self::ANSI_CODES)) {
+            return self::optimizeColor(sprintf("\x1b[%sm%s\x1b[0m", self::ANSI_CODES[$color], $buffer));
+        }
         $styles = [];
-        foreach ($codes as $code) {
-            if (isset(self::ANSI_CODES[$code])) {
+        foreach (explode(',', $color) as $code) {
+            $code = trim($code);
+            if (array_key_exists($code, self::ANSI_CODES)) {
                 $styles[] = self::ANSI_CODES[$code];
             }
         }
         if ($styles === []) {
             return $buffer;
         }
-        return self::optimizeColor(sprintf("\x1b[%sm", implode(';', $styles)) . $buffer . "\x1b[0m");
+        return self::optimizeColor(sprintf("\x1b[%sm%s\x1b[0m", implode(';', $styles), $buffer));
     }
+    /**
+     * @param non-empty-string  $color
+     * @param ?non-negative-int $columns
+     */
     public static function colorizeTextBox(string $color, string $buffer, ?int $columns = null): string
     {
         $lines = preg_split('/\r\n|\r|\n/', $buffer);
-        $maxBoxWidth = max(array_map('\strlen', $lines));
+        $maxBoxWidth = max(array_map(\strlen(...), $lines));
         if ($columns !== null) {
             $maxBoxWidth = min($maxBoxWidth, $columns);
         }
@@ -107614,6 +108152,10 @@ final class Color
         });
         return implode(PHP_EOL, $lines);
     }
+    /**
+     * @param non-empty-string  $path
+     * @param ?non-empty-string $previousPath
+     */
     public static function colorizePath(string $path, ?string $previousPath = null, bool $colorizeFilename = \false): string
     {
         if ($previousPath === null) {
@@ -107642,11 +108184,15 @@ final class Color
     public static function visualizeWhitespace(string $buffer, bool $visualizeEOL = \false): string
     {
         $replaceMap = $visualizeEOL ? self::WHITESPACE_EOL_MAP : self::WHITESPACE_MAP;
-        return preg_replace_callback('/\s+/', static fn(array $matches) => self::dim(strtr($matches[0], $replaceMap)), $buffer);
+        $result = preg_replace_callback('/\s+/', static fn(array $matches) => self::dim(strtr($matches[0], $replaceMap)), $buffer);
+        assert($result !== null);
+        return $result;
     }
     private static function optimizeColor(string $buffer): string
     {
-        return preg_replace(["/\x1b\\[22m\x1b\\[2m/", "/\x1b\\[([^m]*)m\x1b\\[([1-9][0-9;]*)m/", "/(\x1b\\[[^m]*m)+(\x1b\\[0m)/"], ['', "\x1b[\$1;\$2m", '$2'], $buffer);
+        $result = preg_replace(["/\x1b\\[22m\x1b\\[2m/", "/\x1b\\[([^m]*)m\x1b\\[([1-9][0-9;]*)m/", "/(\x1b\\[[^m]*m)+(\x1b\\[0m)/"], ['', "\x1b[\$1;\$2m", '$2'], $buffer);
+        assert($result !== null);
+        return $result;
     }
 }
 <?php
@@ -107807,6 +108353,7 @@ declare (strict_types=1);
 namespace PHPUnit\Util;
 
 use const PHP_OS_FAMILY;
+use function array_any;
 use function assert;
 use function class_exists;
 use function defined;
@@ -107945,12 +108492,7 @@ final class ExcludeList
             return \false;
         }
         self::initialize();
-        foreach (self::$directories as $directory) {
-            if (str_starts_with($file, $directory)) {
-                return \true;
-            }
-        }
-        return \false;
+        return array_any(self::$directories, static fn(string $directory) => str_starts_with($file, $directory));
     }
     private static function initialize(): void
     {
@@ -108087,6 +108629,7 @@ declare (strict_types=1);
  */
 namespace PHPUnit\Util;
 
+use function array_any;
 use function array_unshift;
 use function defined;
 use function in_array;
@@ -108175,12 +108718,7 @@ final readonly class Filter
      */
     private static function frameExists(array $trace, string $file, int $line): bool
     {
-        foreach ($trace as $frame) {
-            if (isset($frame['file'], $frame['line']) && $frame['file'] === $file && $frame['line'] === $line) {
-                return \true;
-            }
-        }
-        return \false;
+        return array_any($trace, static fn(array $frame) => isset($frame['file'], $frame['line']) && $frame['file'] === $file && $frame['line'] === $line);
     }
 }
 <?php
@@ -108519,6 +109057,7 @@ namespace PHPUnit\Util\PHP;
 
 use const PHP_BINARY;
 use const PHP_SAPI;
+use function array_any;
 use function array_keys;
 use function array_merge;
 use function array_values;
@@ -108626,13 +109165,7 @@ final readonly class DefaultJobRunner extends \PHPUnit\Util\PHP\JobRunner
         $runtime = new Runtime();
         $command = [PHP_BINARY];
         $phpSettings = $job->phpSettings();
-        $xdebugModeConfiguredExplicitly = \false;
-        foreach ($phpSettings as $phpSetting) {
-            if (str_starts_with($phpSetting, 'xdebug.mode')) {
-                $xdebugModeConfiguredExplicitly = \true;
-                break;
-            }
-        }
+        $xdebugModeConfiguredExplicitly = array_any($phpSettings, static fn(string $phpSetting) => str_starts_with($phpSetting, 'xdebug.mode'));
         if ($runtime->hasPCOV()) {
             $pcovSettings = ini_get_all('pcov');
             assert($pcovSettings !== \false);
@@ -109289,6 +109822,7 @@ declare (strict_types=1);
 namespace PHPUnit\Util;
 
 use const ENT_QUOTES;
+use function assert;
 use function htmlspecialchars;
 use function mb_convert_encoding;
 use function ord;
@@ -109311,7 +109845,9 @@ final readonly class Xml
      */
     public static function prepareString(string $string): string
     {
-        return preg_replace('/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/', '', htmlspecialchars(self::convertToUtf8($string), ENT_QUOTES));
+        $result = preg_replace('/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/', '', htmlspecialchars(self::convertToUtf8($string), ENT_QUOTES));
+        assert($result !== null);
+        return $result;
     }
     private static function convertToUtf8(string $string): string
     {
@@ -109350,14 +109886,14 @@ final readonly class Xml
   <component type="library">
    <group>phpunit</group>
    <name>phpunit</name>
-   <version>12.5.9</version>
+   <version>13.0.0</version>
    <description>The PHP Unit Testing framework.</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/phpunit/phpunit@12.5.9</purl>
+   <purl>pkg:composer/phpunit/phpunit@13.0.0</purl>
   </component>
   <component type="library">
    <group>myclabs</group>
@@ -109410,218 +109946,218 @@ final readonly class Xml
   <component type="library">
    <group>phpunit</group>
    <name>php-code-coverage</name>
-   <version>12.5.2</version>
+   <version>13.0.0</version>
    <description>Library that provides collection, processing, and rendering functionality for PHP code coverage information.</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/phpunit/php-code-coverage@12.5.2</purl>
+   <purl>pkg:composer/phpunit/php-code-coverage@13.0.0</purl>
   </component>
   <component type="library">
    <group>phpunit</group>
    <name>php-file-iterator</name>
-   <version>6.0.1</version>
+   <version>7.0.0</version>
    <description>FilterIterator implementation that filters files based on a list of suffixes.</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/phpunit/php-file-iterator@6.0.1</purl>
+   <purl>pkg:composer/phpunit/php-file-iterator@7.0.0</purl>
   </component>
   <component type="library">
    <group>phpunit</group>
    <name>php-invoker</name>
-   <version>6.0.0</version>
+   <version>7.0.0</version>
    <description>Invoke callables with a timeout</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/phpunit/php-invoker@6.0.0</purl>
+   <purl>pkg:composer/phpunit/php-invoker@7.0.0</purl>
   </component>
   <component type="library">
    <group>phpunit</group>
    <name>php-text-template</name>
-   <version>5.0.0</version>
+   <version>6.0.0</version>
    <description>Simple template engine.</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/phpunit/php-text-template@5.0.0</purl>
+   <purl>pkg:composer/phpunit/php-text-template@6.0.0</purl>
   </component>
   <component type="library">
    <group>phpunit</group>
    <name>php-timer</name>
-   <version>8.0.0</version>
+   <version>9.0.0</version>
    <description>Utility class for timing</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/phpunit/php-timer@8.0.0</purl>
+   <purl>pkg:composer/phpunit/php-timer@9.0.0</purl>
   </component>
   <component type="library">
    <group>sebastian</group>
    <name>cli-parser</name>
-   <version>4.2.0</version>
+   <version>5.0.0</version>
    <description>Library for parsing CLI options</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/sebastian/cli-parser@4.2.0</purl>
+   <purl>pkg:composer/sebastian/cli-parser@5.0.0</purl>
   </component>
   <component type="library">
    <group>sebastian</group>
    <name>comparator</name>
-   <version>7.1.4</version>
+   <version>8.0.0</version>
    <description>Provides the functionality to compare PHP values for equality</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/sebastian/comparator@7.1.4</purl>
+   <purl>pkg:composer/sebastian/comparator@8.0.0</purl>
   </component>
   <component type="library">
    <group>sebastian</group>
    <name>complexity</name>
-   <version>5.0.0</version>
+   <version>6.0.0</version>
    <description>Library for calculating the complexity of PHP code units</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/sebastian/complexity@5.0.0</purl>
+   <purl>pkg:composer/sebastian/complexity@6.0.0</purl>
   </component>
   <component type="library">
    <group>sebastian</group>
    <name>diff</name>
-   <version>7.0.0</version>
+   <version>8.0.0</version>
    <description>Diff implementation</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/sebastian/diff@7.0.0</purl>
+   <purl>pkg:composer/sebastian/diff@8.0.0</purl>
   </component>
   <component type="library">
    <group>sebastian</group>
    <name>environment</name>
-   <version>8.0.3</version>
+   <version>9.0.0</version>
    <description>Provides functionality to handle HHVM/PHP environments</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/sebastian/environment@8.0.3</purl>
+   <purl>pkg:composer/sebastian/environment@9.0.0</purl>
   </component>
   <component type="library">
    <group>sebastian</group>
    <name>exporter</name>
-   <version>7.0.2</version>
+   <version>8.0.0</version>
    <description>Provides the functionality to export PHP variables for visualization</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/sebastian/exporter@7.0.2</purl>
+   <purl>pkg:composer/sebastian/exporter@8.0.0</purl>
   </component>
   <component type="library">
    <group>sebastian</group>
    <name>global-state</name>
-   <version>8.0.2</version>
+   <version>9.0.0</version>
    <description>Snapshotting of global state</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/sebastian/global-state@8.0.2</purl>
+   <purl>pkg:composer/sebastian/global-state@9.0.0</purl>
   </component>
   <component type="library">
    <group>sebastian</group>
    <name>lines-of-code</name>
-   <version>4.0.0</version>
+   <version>5.0.0</version>
    <description>Library for counting the lines of code in PHP source code</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/sebastian/lines-of-code@4.0.0</purl>
+   <purl>pkg:composer/sebastian/lines-of-code@5.0.0</purl>
   </component>
   <component type="library">
    <group>sebastian</group>
    <name>object-enumerator</name>
-   <version>7.0.0</version>
+   <version>8.0.0</version>
    <description>Traverses array structures and object graphs to enumerate all referenced objects</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/sebastian/object-enumerator@7.0.0</purl>
+   <purl>pkg:composer/sebastian/object-enumerator@8.0.0</purl>
   </component>
   <component type="library">
    <group>sebastian</group>
    <name>object-reflector</name>
-   <version>5.0.0</version>
+   <version>6.0.0</version>
    <description>Allows reflection of object attributes, including inherited and non-public ones</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/sebastian/object-reflector@5.0.0</purl>
+   <purl>pkg:composer/sebastian/object-reflector@6.0.0</purl>
   </component>
   <component type="library">
    <group>sebastian</group>
    <name>recursion-context</name>
-   <version>7.0.1</version>
+   <version>8.0.0</version>
    <description>Provides functionality to recursively process PHP variables</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/sebastian/recursion-context@7.0.1</purl>
+   <purl>pkg:composer/sebastian/recursion-context@8.0.0</purl>
   </component>
   <component type="library">
    <group>sebastian</group>
    <name>type</name>
-   <version>6.0.3</version>
+   <version>7.0.0</version>
    <description>Collection of value objects that represent the types of the PHP type system</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/sebastian/type@6.0.3</purl>
+   <purl>pkg:composer/sebastian/type@7.0.0</purl>
   </component>
   <component type="library">
    <group>sebastian</group>
    <name>version</name>
-   <version>6.0.0</version>
+   <version>7.0.0</version>
    <description>Library that helps with managing the version number of Git-hosted PHP projects</description>
    <licenses>
     <license>
      <id>BSD-3-Clause</id>
     </license>
    </licenses>
-   <purl>pkg:composer/sebastian/version@6.0.0</purl>
+   <purl>pkg:composer/sebastian/version@7.0.0</purl>
   </component>
   <component type="library">
    <group>staabm</group>
@@ -115251,6 +115787,359 @@ final readonly class Xml
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:annotation>
         <xs:documentation source="https://phpunit.de/documentation.html">
+            This Schema file defines the rules by which the XML configuration file of PHPUnit 12.5 may be structured.
+        </xs:documentation>
+        <xs:appinfo source="https://phpunit.de/documentation.html"/>
+    </xs:annotation>
+    <xs:element name="phpunit" type="phpUnitType">
+        <xs:annotation>
+            <xs:documentation>Root Element</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:complexType name="sourceType">
+        <xs:all>
+            <xs:element name="include" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:group ref="sourcePathGroup"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="exclude" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:group ref="sourcePathGroup"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="deprecationTrigger" type="deprecationTriggerType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="baseline" type="xs:anyURI"/>
+        <xs:attribute name="restrictNotices" type="xs:boolean" default="false"/>
+        <xs:attribute name="restrictWarnings" type="xs:boolean" default="false"/>
+        <xs:attribute name="ignoreSuppressionOfDeprecations" type="xs:boolean" default="false"/>
+        <xs:attribute name="ignoreSuppressionOfPhpDeprecations" type="xs:boolean" default="false"/>
+        <xs:attribute name="ignoreSuppressionOfErrors" type="xs:boolean" default="false"/>
+        <xs:attribute name="ignoreSuppressionOfNotices" type="xs:boolean" default="false"/>
+        <xs:attribute name="ignoreSuppressionOfPhpNotices" type="xs:boolean" default="false"/>
+        <xs:attribute name="ignoreSuppressionOfWarnings" type="xs:boolean" default="false"/>
+        <xs:attribute name="ignoreSuppressionOfPhpWarnings" type="xs:boolean" default="false"/>
+        <xs:attribute name="identifyIssueTrigger" type="xs:boolean" default="true"/>
+        <xs:attribute name="ignoreSelfDeprecations" type="xs:boolean" default="false"/>
+        <xs:attribute name="ignoreDirectDeprecations" type="xs:boolean" default="false"/>
+        <xs:attribute name="ignoreIndirectDeprecations" type="xs:boolean" default="false"/>
+    </xs:complexType>
+    <xs:group name="sourcePathGroup">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="directory" type="sourceDirectoryType"/>
+                <xs:element name="file" type="xs:anyURI"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="sourceDirectoryType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute type="xs:string" name="prefix" default=""/>
+                <xs:attribute type="xs:string" name="suffix" default=".php"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="coverageType">
+        <xs:all>
+            <xs:element name="report" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:group ref="coverageReportGroup"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="pathCoverage" type="xs:boolean" default="false"/>
+        <xs:attribute name="includeUncoveredFiles" type="xs:boolean" default="true"/>
+        <xs:attribute name="ignoreDeprecatedCodeUnits" type="xs:boolean" default="false"/>
+        <xs:attribute name="disableCodeCoverageIgnore" type="xs:boolean" default="false"/>
+    </xs:complexType>
+    <xs:complexType name="loggingType">
+        <xs:group ref="loggingGroup"/>
+    </xs:complexType>
+    <xs:complexType name="groupsType">
+        <xs:choice>
+            <xs:sequence>
+                <xs:element name="include" type="groupType"/>
+                <xs:element name="exclude" type="groupType" minOccurs="0"/>
+            </xs:sequence>
+            <xs:sequence>
+                <xs:element name="exclude" type="groupType"/>
+            </xs:sequence>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="groupType">
+        <xs:sequence>
+            <xs:element name="group" type="xs:string" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="extensionsType">
+        <xs:sequence>
+            <xs:element name="bootstrap" type="bootstrapType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="bootstrapType">
+        <xs:sequence>
+            <xs:element name="parameter" type="parameterType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="parameterType">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="value" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:simpleType name="columnsType">
+        <xs:union>
+            <xs:simpleType>
+                <xs:restriction base="xs:integer"/>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="max"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:union>
+    </xs:simpleType>
+    <xs:simpleType name="executionOrderType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="default"/>
+            <xs:enumeration value="defects"/>
+            <xs:enumeration value="defects,random"/>
+            <xs:enumeration value="depends"/>
+            <xs:enumeration value="depends,defects"/>
+            <xs:enumeration value="depends,duration"/>
+            <xs:enumeration value="depends,random"/>
+            <xs:enumeration value="depends,reverse"/>
+            <xs:enumeration value="depends,size"/>
+            <xs:enumeration value="duration"/>
+            <xs:enumeration value="no-depends"/>
+            <xs:enumeration value="no-depends,defects"/>
+            <xs:enumeration value="no-depends,duration"/>
+            <xs:enumeration value="no-depends,random"/>
+            <xs:enumeration value="no-depends,reverse"/>
+            <xs:enumeration value="no-depends,size"/>
+            <xs:enumeration value="random"/>
+            <xs:enumeration value="reverse"/>
+            <xs:enumeration value="size"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="phpType">
+        <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+                <xs:element name="includePath" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="ini" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="const" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="var" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="env" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="post" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="get" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="cookie" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="server" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="files" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="request" type="namedValueType" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="namedValueType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="value" use="required" type="xs:anySimpleType"/>
+        <xs:attribute name="verbatim" use="optional" type="xs:boolean"/>
+        <xs:attribute name="force" use="optional" type="xs:boolean"/>
+    </xs:complexType>
+    <xs:complexType name="phpUnitType">
+        <xs:annotation>
+            <xs:documentation>The main type specifying the document structure</xs:documentation>
+        </xs:annotation>
+        <xs:group ref="configGroup"/>
+        <xs:attributeGroup ref="configAttributeGroup"/>
+    </xs:complexType>
+    <xs:attributeGroup name="configAttributeGroup">
+        <xs:attribute name="backupGlobals" type="xs:boolean" default="false"/>
+        <xs:attribute name="backupStaticProperties" type="xs:boolean" default="false"/>
+        <xs:attribute name="bootstrap" type="xs:anyURI"/>
+        <xs:attribute name="cacheDirectory" type="xs:anyURI"/>
+        <xs:attribute name="cacheResult" type="xs:boolean" default="true"/>
+        <xs:attribute name="colors" type="xs:boolean" default="false"/>
+        <xs:attribute name="columns" type="columnsType" default="80"/>
+        <xs:attribute name="controlGarbageCollector" type="xs:boolean" default="false"/>
+        <xs:attribute name="numberOfTestsBeforeGarbageCollection" type="xs:integer" default="100"/>
+        <xs:attribute name="requireCoverageMetadata" type="xs:boolean" default="false"/>
+        <xs:attribute name="processIsolation" type="xs:boolean" default="false"/>
+        <xs:attribute name="failOnAllIssues" type="xs:boolean" default="false"/>
+        <xs:attribute name="failOnDeprecation" type="xs:boolean" default="false"/>
+        <xs:attribute name="failOnPhpunitDeprecation" type="xs:boolean" default="false"/>
+        <xs:attribute name="failOnPhpunitNotice" type="xs:boolean" default="false"/>
+        <xs:attribute name="failOnPhpunitWarning" type="xs:boolean" default="true"/>
+        <xs:attribute name="failOnEmptyTestSuite" type="xs:boolean" default="false"/>
+        <xs:attribute name="failOnIncomplete" type="xs:boolean" default="false"/>
+        <xs:attribute name="failOnNotice" type="xs:boolean" default="false"/>
+        <xs:attribute name="failOnRisky" type="xs:boolean" default="false"/>
+        <xs:attribute name="failOnSkipped" type="xs:boolean" default="false"/>
+        <xs:attribute name="failOnWarning" type="xs:boolean" default="false"/>
+        <xs:attribute name="stopOnDefect" type="xs:boolean" default="false"/>
+        <xs:attribute name="stopOnDeprecation" type="xs:boolean" default="false"/>
+        <xs:attribute name="stopOnError" type="xs:boolean" default="false"/>
+        <xs:attribute name="stopOnFailure" type="xs:boolean" default="false"/>
+        <xs:attribute name="stopOnIncomplete" type="xs:boolean" default="false"/>
+        <xs:attribute name="stopOnNotice" type="xs:boolean" default="false"/>
+        <xs:attribute name="stopOnRisky" type="xs:boolean" default="false"/>
+        <xs:attribute name="stopOnSkipped" type="xs:boolean" default="false"/>
+        <xs:attribute name="stopOnWarning" type="xs:boolean" default="false"/>
+        <xs:attribute name="beStrictAboutChangesToGlobalState" type="xs:boolean" default="false"/>
+        <xs:attribute name="beStrictAboutOutputDuringTests" type="xs:boolean" default="false"/>
+        <xs:attribute name="beStrictAboutTestsThatDoNotTestAnything" type="xs:boolean" default="true"/>
+        <xs:attribute name="beStrictAboutCoverageMetadata" type="xs:boolean" default="false"/>
+        <xs:attribute name="defaultTimeLimit" type="xs:integer" default="0"/>
+        <xs:attribute name="enforceTimeLimit" type="xs:boolean" default="false"/>
+        <xs:attribute name="timeoutForSmallTests" type="xs:integer" default="1"/>
+        <xs:attribute name="timeoutForMediumTests" type="xs:integer" default="10"/>
+        <xs:attribute name="timeoutForLargeTests" type="xs:integer" default="60"/>
+        <xs:attribute name="defaultTestSuite" type="xs:string" default=""/>
+        <xs:attribute name="testdox" type="xs:boolean" default="false"/>
+        <xs:attribute name="testdoxSummary" type="xs:boolean" default="false"/>
+        <xs:attribute name="stderr" type="xs:boolean" default="false"/>
+        <xs:attribute name="reverseDefectList" type="xs:boolean" default="false"/>
+        <xs:attribute name="extensionsDirectory" type="xs:anyURI"/>
+        <xs:attribute name="executionOrder" type="executionOrderType" default="default"/>
+        <xs:attribute name="resolveDependencies" type="xs:boolean" default="true"/>
+        <xs:attribute name="displayDetailsOnAllIssues" type="xs:boolean" default="false"/>
+        <xs:attribute name="displayDetailsOnIncompleteTests" type="xs:boolean" default="false"/>
+        <xs:attribute name="displayDetailsOnSkippedTests" type="xs:boolean" default="false"/>
+        <xs:attribute name="displayDetailsOnTestsThatTriggerDeprecations" type="xs:boolean" default="false"/>
+        <xs:attribute name="displayDetailsOnPhpunitDeprecations" type="xs:boolean" default="false"/>
+        <xs:attribute name="displayDetailsOnPhpunitNotices" type="xs:boolean" default="false"/>
+        <xs:attribute name="displayDetailsOnTestsThatTriggerErrors" type="xs:boolean" default="false"/>
+        <xs:attribute name="displayDetailsOnTestsThatTriggerNotices" type="xs:boolean" default="false"/>
+        <xs:attribute name="displayDetailsOnTestsThatTriggerWarnings" type="xs:boolean" default="false"/>
+        <xs:attribute name="shortenArraysForExportThreshold" type="xs:integer" default="10"/>
+    </xs:attributeGroup>
+    <xs:group name="configGroup">
+        <xs:all>
+            <xs:element ref="testSuiteFacet" minOccurs="0"/>
+            <xs:element name="groups" type="groupsType" minOccurs="0"/>
+            <xs:element name="source" type="sourceType" minOccurs="0"/>
+            <xs:element name="coverage" type="coverageType" minOccurs="0"/>
+            <xs:element name="logging" type="loggingType" minOccurs="0"/>
+            <xs:element name="extensions" type="extensionsType" minOccurs="0"/>
+            <xs:element name="php" type="phpType" minOccurs="0"/>
+        </xs:all>
+    </xs:group>
+    <xs:element name="testSuiteFacet" abstract="true"/>
+    <xs:element name="testsuite" type="testSuiteType" substitutionGroup="testSuiteFacet"/>
+    <xs:element name="testsuites" type="testSuitesType" substitutionGroup="testSuiteFacet"/>
+    <xs:complexType name="testSuitesType">
+        <xs:sequence>
+            <xs:element name="testsuite" type="testSuiteType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="testSuiteType">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="testSuitePathGroup"/>
+                <xs:element name="exclude" type="xs:string"/>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="bootstrap" type="xs:string" use="optional"/>
+    </xs:complexType>
+    <xs:group name="testSuitePathGroup">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="directory" type="testSuiteDirectoryType"/>
+                <xs:element name="file" type="testSuiteFileType"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="testSuiteDirectoryType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute type="xs:string" name="prefix" default=""/>
+                <xs:attribute type="xs:string" name="suffix" default="Test.php"/>
+                <xs:attributeGroup ref="phpVersionGroup"/>
+                <xs:attribute type="xs:string" name="groups"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="testSuiteFileType">
+        <xs:simpleContent>
+            <xs:extension base="xs:anyURI">
+                <xs:attributeGroup ref="phpVersionGroup"/>
+                <xs:attribute type="xs:string" name="groups"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:attributeGroup name="phpVersionGroup">
+        <xs:attribute name="phpVersion" type="xs:string" default="5.3.0"/>
+        <xs:attribute name="phpVersionOperator" type="xs:string" default="&gt;="/>
+    </xs:attributeGroup>
+    <xs:group name="coverageReportGroup">
+        <xs:all>
+            <xs:element name="clover" type="logToFileType" minOccurs="0"/>
+            <xs:element name="cobertura" type="logToFileType" minOccurs="0"/>
+            <xs:element name="crap4j" type="coverageReportCrap4JType" minOccurs="0" />
+            <xs:element name="html" type="coverageReportHtmlType" minOccurs="0" />
+            <xs:element name="openclover" type="logToFileType" minOccurs="0"/>
+            <xs:element name="php" type="logToFileType" minOccurs="0" />
+            <xs:element name="text" type="coverageReportTextType" minOccurs="0" />
+            <xs:element name="xml" type="coverageReportXmlType" minOccurs="0" />
+        </xs:all>
+    </xs:group>
+    <xs:group name="loggingGroup">
+        <xs:all>
+            <xs:element name="junit" type="logToFileType" minOccurs="0" />
+            <xs:element name="otr" type="otrType" minOccurs="0" />
+            <xs:element name="teamcity" type="logToFileType" minOccurs="0" />
+            <xs:element name="testdoxHtml" type="logToFileType" minOccurs="0" />
+            <xs:element name="testdoxText" type="logToFileType" minOccurs="0" />
+        </xs:all>
+    </xs:group>
+    <xs:complexType name="logToFileType">
+        <xs:attribute name="outputFile" type="xs:anyURI" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="logToDirectoryType">
+        <xs:attribute name="outputDirectory" type="xs:anyURI" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="otrType">
+        <xs:attribute name="outputFile" type="xs:anyURI" use="required"/>
+        <xs:attribute name="includeGitInformation" type="xs:boolean" default="false"/>
+    </xs:complexType>
+    <xs:complexType name="coverageReportCrap4JType">
+        <xs:attribute name="outputFile" type="xs:anyURI" use="required"/>
+        <xs:attribute name="threshold" type="xs:integer"/>
+    </xs:complexType>
+    <xs:complexType name="coverageReportHtmlType">
+        <xs:attribute name="outputDirectory" type="xs:anyURI" use="required"/>
+        <xs:attribute name="lowUpperBound" type="xs:integer" default="50"/>
+        <xs:attribute name="highLowerBound" type="xs:integer" default="90"/>
+        <xs:attribute name="colorSuccessLow" type="xs:string" default="#dff0d8"/>
+        <xs:attribute name="colorSuccessMedium" type="xs:string" default="#c3e3b5"/>
+        <xs:attribute name="colorSuccessHigh" type="xs:string" default="#99cb84"/>
+        <xs:attribute name="colorWarning" type="xs:string" default="#fcf8e3"/>
+        <xs:attribute name="colorDanger" type="xs:string" default="#f2dede"/>
+        <xs:attribute name="customCssFile" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="coverageReportTextType">
+        <xs:attribute name="outputFile" type="xs:anyURI" use="required"/>
+        <xs:attribute name="showUncoveredFiles" type="xs:boolean" default="false"/>
+        <xs:attribute name="showOnlySummary" type="xs:boolean" default="false"/>
+    </xs:complexType>
+    <xs:complexType name="coverageReportXmlType">
+        <xs:attribute name="outputDirectory" type="xs:anyURI" use="required"/>
+        <xs:attribute name="includeSource" type="xs:boolean" default="true"/>
+    </xs:complexType>
+    <xs:complexType name="deprecationTriggerType">
+        <xs:sequence>
+            <xs:choice maxOccurs="unbounded">
+                <xs:element name="function" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="method" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:annotation>
+        <xs:documentation source="https://phpunit.de/documentation.html">
             This Schema file defines the rules by which the XML configuration file of PHPUnit 8.5 may be structured.
         </xs:documentation>
         <xs:appinfo source="https://phpunit.de/documentation.html"/>
@@ -117502,7 +118391,7 @@ final readonly class Xml
 </xs:schema>
 BSD 3-Clause License
 
-Copyright (c) 2020-2025, Sebastian Bergmann
+Copyright (c) 2020-2026, Sebastian Bergmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -117565,7 +118454,7 @@ use function strlen;
 use function strstr;
 use function substr;
 use function usort;
-final class Parser
+final readonly class Parser
 {
     /**
      * @param list<string> $argv
@@ -117592,7 +118481,7 @@ final class Parser
             array_shift($argv);
         }
         reset($argv);
-        $argv = array_map('trim', $argv);
+        $argv = array_map(trim(...), $argv);
         while (\false !== $arg = current($argv)) {
             $i = key($argv);
             assert(is_int($i));
@@ -117662,13 +118551,13 @@ final class Parser
         $count = count($longOptions);
         $list = explode('=', $argument);
         $option = $list[0];
+        $optionLength = strlen($option);
+        $similarOptions = [];
         $optionArgument = null;
         if (count($list) > 1) {
             /** @phpstan-ignore offsetAccess.notFound */
             $optionArgument = $list[1];
         }
-        $optionLength = strlen($option);
-        $similarOptions = [];
         foreach ($longOptions as $i => $longOption) {
             $similarOptions[] = [levenshtein($longOption, $option), '--' . rtrim($longOption, '=')];
             $opt_start = substr($longOption, 0, $optionLength);
@@ -117708,9 +118597,7 @@ final class Parser
      */
     private function formatSimilarOptions(array $similarOptions): array
     {
-        usort($similarOptions, static function (array $a, array $b) {
-            return $a[0] <=> $b[0];
-        });
+        usort($similarOptions, static fn(array $a, array $b): int => $a[0] <=> $b[0]);
         $similarFormatted = [];
         foreach (array_slice($similarOptions, 0, 5) as [$distance, $label]) {
             $similarFormatted[] = $label;
@@ -118497,13 +119384,14 @@ final class NumberComparator extends ObjectComparator
     public function assertEquals(mixed $expected, mixed $actual, float $delta = 0.0, bool $canonicalize = \false, bool $ignoreCase = \false, array &$processed = []): void
     {
         if (!$expected instanceof Number) {
-            assert(is_string($expected) || is_int($expected));
+            assert(is_int($expected) || is_string($expected) && is_numeric($expected));
             $expected = new Number($expected);
         }
         if (!$actual instanceof Number) {
-            assert(is_string($actual) || is_int($actual));
+            assert(is_int($actual) || is_string($actual) && is_numeric($actual));
             $actual = new Number($actual);
         }
+        /** @phpstan-ignore argument.type */
         $deltaNumber = new Number(number_format($delta, max($expected->scale, $actual->scale)));
         if ($actual < $expected - $deltaNumber || $actual > $expected + $deltaNumber) {
             throw new ComparisonFailure($expected, $actual, (string) $expected, (string) $actual, 'Failed asserting that two Number objects are equal.');
@@ -119142,7 +120030,7 @@ final readonly class ComplexityCollection implements Countable, IteratorAggregat
     }
     public function isEmpty(): bool
     {
-        return empty($this->items);
+        return $this->items === [];
     }
     /**
      * @return non-negative-int
@@ -119260,7 +120148,7 @@ final class RuntimeException extends \RuntimeException implements Exception
 }
 BSD 3-Clause License
 
-Copyright (c) 2020-2025, Sebastian Bergmann
+Copyright (c) 2020-2026, Sebastian Bergmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -119617,6 +120505,7 @@ namespace PHPUnitPHAR\SebastianBergmann\Diff;
 use const PHP_INT_SIZE;
 use const PREG_SPLIT_DELIM_CAPTURE;
 use const PREG_SPLIT_NO_EMPTY;
+use function array_any;
 use function array_shift;
 use function array_unshift;
 use function array_values;
@@ -119742,19 +120631,12 @@ final class Differ
             return \false;
         }
         // two-way compare
-        foreach ($newLineBreaks as $break => $set) {
-            if (!isset($oldLineBreaks[$break])) {
-                return \true;
-            }
+        if (array_any($newLineBreaks, static fn(bool $set, string $break) => !isset($oldLineBreaks[$break]))) {
+            return \true;
         }
-        foreach ($oldLineBreaks as $break => $set) {
-            if (!isset($newLineBreaks[$break])) {
-                return \true;
-            }
-        }
-        return \false;
+        return array_any($oldLineBreaks, static fn(bool $set, string $break) => !isset($newLineBreaks[$break]));
     }
-    private function getLinebreak($line): string
+    private function getLinebreak(int|string $line): string
     {
         if (!is_string($line)) {
             return '';
@@ -119817,10 +120699,10 @@ namespace PHPUnitPHAR\SebastianBergmann\Diff;
 use function gettype;
 use function is_object;
 use function sprintf;
-use Exception;
-final class ConfigurationException extends InvalidArgumentException
+use InvalidArgumentException;
+final class ConfigurationException extends InvalidArgumentException implements Exception
 {
-    public function __construct(string $option, string $expected, mixed $value, int $code = 0, ?Exception $previous = null)
+    public function __construct(string $option, string $expected, mixed $value, int $code = 0, ?\Exception $previous = null)
     {
         parent::__construct(sprintf('Option "%s" must be %s, got "%s".', $option, $expected, is_object($value) ? $value::class : (null === $value ? '<null>' : gettype($value) . '#' . $value)), $code, $previous);
     }
@@ -119842,25 +120724,9 @@ use Throwable;
 interface Exception extends Throwable
 {
 }
-<?php
-
-declare (strict_types=1);
-/*
- * This file is part of sebastian/diff.
- *
- * (c) Sebastian Bergmann <sebastian@phpunit.de>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-namespace PHPUnitPHAR\SebastianBergmann\Diff;
-
-class InvalidArgumentException extends \InvalidArgumentException implements Exception
-{
-}
 BSD 3-Clause License
 
-Copyright (c) 2002-2025, Sebastian Bergmann
+Copyright (c) 2002-2026, Sebastian Bergmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -120271,8 +121137,9 @@ final class StrictUnifiedDiffOutputBuilder implements DiffOutputBuilderInterface
         $last = substr($diff, -1);
         return "\n" !== $last && "\r" !== $last ? $diff . "\n" : $diff;
     }
-    private function writeDiffHunks($output, array $diff): void
+    private function writeDiffHunks(mixed $output, array $diff): void
     {
+        assert(is_resource($output));
         // detect "No newline at end of file" and insert into `$diff` if needed
         $upperLimit = count($diff);
         if (0 === $diff[$upperLimit - 1][1]) {
@@ -120291,7 +121158,7 @@ final class StrictUnifiedDiffOutputBuilder implements DiffOutputBuilderInterface
                     if ("\n" !== $lc) {
                         array_splice($diff, $i + 1, 0, [["\n\\ No newline at end of file\n", Differ::NO_LINE_END_EOF_WARNING]]);
                     }
-                    if (!count($toFind)) {
+                    if ($toFind === []) {
                         break;
                     }
                 }
@@ -120302,8 +121169,6 @@ final class StrictUnifiedDiffOutputBuilder implements DiffOutputBuilderInterface
         $hunkCapture = \false;
         $sameCount = $toRange = $fromRange = 0;
         $toStart = $fromStart = 1;
-        $i = 0;
-        /** @var int $i */
         foreach ($diff as $i => $entry) {
             if (0 === $entry[1]) {
                 // same
@@ -120363,10 +121228,12 @@ final class StrictUnifiedDiffOutputBuilder implements DiffOutputBuilderInterface
         $contextEndOffset = min($sameCount, $this->contextLines);
         $fromRange -= $sameCount;
         $toRange -= $sameCount;
+        assert(isset($i) && is_int($i));
         $this->writeHunk($diff, $hunkCapture - $contextStartOffset, $i - $sameCount + $contextEndOffset + 1, $fromStart - $contextStartOffset, $fromRange + $contextStartOffset + $contextEndOffset, $toStart - $contextStartOffset, $toRange + $contextStartOffset + $contextEndOffset, $output);
     }
-    private function writeHunk(array $diff, int $diffStartIndex, int $diffEndIndex, int $fromStart, int $fromRange, int $toStart, int $toRange, $output): void
+    private function writeHunk(array $diff, int $diffStartIndex, int $diffEndIndex, int $fromStart, int $fromRange, int $toStart, int $toRange, mixed $output): void
     {
+        assert(is_resource($output));
         fwrite($output, '@@ -' . $fromStart);
         if (!$this->collapseRanges || 1 !== $fromRange) {
             fwrite($output, ',' . $fromRange);
@@ -120428,6 +121295,7 @@ use function count;
 use function fclose;
 use function fopen;
 use function fwrite;
+use function is_int;
 use function is_resource;
 use function max;
 use function min;
@@ -120440,6 +121308,7 @@ use PHPUnitPHAR\SebastianBergmann\Diff\Differ;
  */
 final class UnifiedDiffOutputBuilder extends AbstractChunkOutputBuilder
 {
+    /** @phpstan-ignore property.tooWideBool */
     private bool $collapseRanges = \true;
     private int $commonLineThreshold = 6;
     /**
@@ -120473,8 +121342,9 @@ final class UnifiedDiffOutputBuilder extends AbstractChunkOutputBuilder
         $last = substr($diff, -1);
         return '' !== $diff && "\n" !== $last && "\r" !== $last ? $diff . "\n" : $diff;
     }
-    private function writeDiffHunks($output, array $diff): void
+    private function writeDiffHunks(mixed $output, array $diff): void
     {
+        assert(is_resource($output));
         // detect "No newline at end of file" and insert into `$diff` if needed
         $upperLimit = count($diff);
         if (0 === $diff[$upperLimit - 1][1]) {
@@ -120493,7 +121363,7 @@ final class UnifiedDiffOutputBuilder extends AbstractChunkOutputBuilder
                     if ("\n" !== $lc) {
                         array_splice($diff, $i + 1, 0, [["\n\\ No newline at end of file\n", Differ::NO_LINE_END_EOF_WARNING]]);
                     }
-                    if (!count($toFind)) {
+                    if ($toFind === []) {
                         break;
                     }
                 }
@@ -120504,8 +121374,6 @@ final class UnifiedDiffOutputBuilder extends AbstractChunkOutputBuilder
         $hunkCapture = \false;
         $sameCount = $toRange = $fromRange = 0;
         $toStart = $fromStart = 1;
-        $i = 0;
-        /** @var int $i */
         foreach ($diff as $i => $entry) {
             if (0 === $entry[1]) {
                 // same
@@ -120562,10 +121430,12 @@ final class UnifiedDiffOutputBuilder extends AbstractChunkOutputBuilder
         $contextEndOffset = min($sameCount, $this->contextLines);
         $fromRange -= $sameCount;
         $toRange -= $sameCount;
+        assert(isset($i) && is_int($i));
         $this->writeHunk($diff, $hunkCapture - $contextStartOffset, $i - $sameCount + $contextEndOffset + 1, $fromStart - $contextStartOffset, $fromRange + $contextStartOffset + $contextEndOffset, $toStart - $contextStartOffset, $toRange + $contextStartOffset + $contextEndOffset, $output);
     }
-    private function writeHunk(array $diff, int $diffStartIndex, int $diffEndIndex, int $fromStart, int $fromRange, int $toStart, int $toRange, $output): void
+    private function writeHunk(array $diff, int $diffStartIndex, int $diffEndIndex, int $fromStart, int $fromRange, int $toStart, int $toRange, mixed $output): void
     {
+        assert(is_resource($output));
         if ($this->addLineNumbers) {
             fwrite($output, '@@ -' . $fromStart);
             if (!$this->collapseRanges || 1 !== $fromRange) {
@@ -120611,7 +121481,6 @@ namespace PHPUnitPHAR\SebastianBergmann\Diff;
 
 use const PREG_UNMATCHED_AS_NULL;
 use function array_pop;
-use function assert;
 use function count;
 use function max;
 use function preg_match;
@@ -120622,12 +121491,12 @@ use function preg_split;
 final class Parser
 {
     /**
-     * @return Diff[]
+     * @return list<Diff>
      */
     public function parse(string $string): array
     {
         $lines = preg_split('(\r\n|\r|\n)', $string);
-        if (!empty($lines) && $lines[count($lines) - 1] === '') {
+        if ($lines !== \false && $lines !== [] && $lines[count($lines) - 1] === '') {
             array_pop($lines);
         }
         $lineCount = count($lines);
@@ -120641,8 +121510,6 @@ final class Parser
                     $diffs[] = $diff;
                     $collected = [];
                 }
-                assert(!empty($fromMatch['file']));
-                assert(!empty($toMatch['file']));
                 $diff = new Diff($fromMatch['file'], $toMatch['file']);
                 $i++;
             } else {
@@ -120652,7 +121519,7 @@ final class Parser
                 $collected[] = $lines[$i];
             }
         }
-        if ($diff !== null && count($collected)) {
+        if ($diff !== null && $collected !== []) {
             $this->parseFileDiff($diff, $collected);
             $diffs[] = $diff;
         }
@@ -120781,7 +121648,6 @@ use function fstat;
 use function function_exists;
 use function getenv;
 use function in_array;
-use function is_array;
 use function is_int;
 use function is_resource;
 use function is_string;
@@ -120918,7 +121784,6 @@ final class Console
             $columns = (int) $matches[1];
         } elseif (function_exists('proc_open')) {
             $process = proc_open('mode CON', [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, null, null, ['suppress_errors' => \true]);
-            assert(is_array($pipes));
             assert(isset($pipes[1]) && is_resource($pipes[1]));
             assert(isset($pipes[2]) && is_resource($pipes[2]));
             if (is_resource($process)) {
@@ -120937,7 +121802,7 @@ final class Console
 }
 BSD 3-Clause License
 
-Copyright (c) 2014-2025, Sebastian Bergmann
+Copyright (c) 2014-2026, Sebastian Bergmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -121086,10 +121951,14 @@ final class Runtime
     public function getNameWithVersionAndCodeCoverageDriver(): string
     {
         if ($this->hasPCOV()) {
-            return sprintf('%s with PCOV %s', $this->getNameWithVersion(), phpversion('pcov'));
+            $version = phpversion('pcov');
+            assert($version !== \false);
+            return sprintf('%s with PCOV %s', $this->getNameWithVersion(), $version);
         }
         if ($this->hasXdebug()) {
-            return sprintf('%s with Xdebug %s', $this->getNameWithVersion(), phpversion('xdebug'));
+            $version = phpversion('xdebug');
+            assert($version !== \false);
+            return sprintf('%s with Xdebug %s', $this->getNameWithVersion(), $version);
         }
         return $this->getNameWithVersion();
     }
@@ -121170,7 +122039,7 @@ final class Runtime
         }
         $scanned = php_ini_scanned_files();
         if ($scanned !== \false) {
-            $files = array_merge($files, array_map('trim', explode(",\n", $scanned)));
+            $files = array_merge($files, array_map(trim(...), explode(",\n", $scanned)));
         }
         foreach ($files as $ini) {
             $config = parse_ini_file($ini, \true);
@@ -121535,7 +122404,7 @@ final readonly class Exporter
 }
 BSD 3-Clause License
 
-Copyright (c) 2002-2025, Sebastian Bergmann
+Copyright (c) 2002-2026, Sebastian Bergmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -121766,7 +122635,7 @@ final class ExcludeList
 }
 BSD 3-Clause License
 
-Copyright (c) 2001-2025, Sebastian Bergmann
+Copyright (c) 2001-2026, Sebastian Bergmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -121811,8 +122680,10 @@ use function array_key_exists;
 use function array_keys;
 use function array_merge;
 use function assert;
+use function class_exists;
 use function in_array;
 use function is_array;
+use function property_exists;
 use ReflectionClass;
 use ReflectionProperty;
 final class Restorer
@@ -121841,6 +122712,8 @@ final class Restorer
         unset($current);
         foreach ($snapshot->staticProperties() as $className => $staticProperties) {
             foreach ($staticProperties as $name => $value) {
+                assert(class_exists($className));
+                assert(property_exists($className, $name));
                 $reflector = new ReflectionProperty($className, $name);
                 $reflector->setValue(null, $value);
             }
@@ -122316,7 +123189,7 @@ final class Counter
     public function countInSourceString(string $source): LinesOfCode
     {
         $linesOfCode = substr_count($source, "\n");
-        if ($linesOfCode === 0 && !empty($source)) {
+        if ($linesOfCode === 0 && $source !== '') {
             $linesOfCode = 1;
         }
         try {
@@ -122403,7 +123276,7 @@ final class RuntimeException extends \RuntimeException implements Exception
 }
 BSD 3-Clause License
 
-Copyright (c) 2020-2025, Sebastian Bergmann
+Copyright (c) 2020-2026, Sebastian Bergmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -122618,7 +123491,7 @@ final class Enumerator
     public function enumerate(array|object $variable, Context $processed = new Context()): array
     {
         $objects = [];
-        if ($processed->contains($variable)) {
+        if ($processed->contains($variable) !== \false) {
             return $objects;
         }
         $array = $variable;
@@ -122825,7 +123698,7 @@ final class Context
 }
 BSD 3-Clause License
 
-Copyright (c) 2002-2025, Sebastian Bergmann
+Copyright (c) 2002-2026, Sebastian Bergmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -122854,7 +123727,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 BSD 3-Clause License
 
-Copyright (c) 2019-2025, Sebastian Bergmann
+Copyright (c) 2019-2026, Sebastian Bergmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -124186,6 +125059,7 @@ declare (strict_types=1);
  */
 namespace PHPUnitPHAR\SebastianBergmann\Type;
 
+use function array_any;
 use function assert;
 use function count;
 use function implode;
@@ -124211,12 +125085,7 @@ final class UnionType extends Type
     }
     public function isAssignable(Type $other): bool
     {
-        foreach ($this->types as $type) {
-            if ($type->isAssignable($other)) {
-                return \true;
-            }
-        }
-        return \false;
+        return array_any($this->types, static fn(Type $type) => $type->isAssignable($other));
     }
     /**
      * @return non-empty-string
@@ -124243,12 +125112,7 @@ final class UnionType extends Type
     }
     public function allowsNull(): bool
     {
-        foreach ($this->types as $type) {
-            if ($type instanceof NullType) {
-                return \true;
-            }
-        }
-        return \false;
+        return array_any($this->types, static fn(Type $type) => $type instanceof NullType);
     }
     public function isUnion(): bool
     {
@@ -124256,12 +125120,7 @@ final class UnionType extends Type
     }
     public function containsIntersectionTypes(): bool
     {
-        foreach ($this->types as $type) {
-            if ($type->isIntersection()) {
-                return \true;
-            }
-        }
-        return \false;
+        return array_any($this->types, static fn(Type $type) => $type->isIntersection());
     }
     /**
      * @return non-empty-list<Type>
@@ -124379,7 +125238,7 @@ final class VoidType extends Type
 }
 BSD 3-Clause License
 
-Copyright (c) 2013-2025, Sebastian Bergmann
+Copyright (c) 2013-2026, Sebastian Bergmann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -124424,7 +125283,6 @@ use function assert;
 use function end;
 use function explode;
 use function fclose;
-use function is_array;
 use function is_dir;
 use function is_resource;
 use function proc_close;
@@ -124467,7 +125325,7 @@ final readonly class Version
             $version = $release . '-dev';
         }
         $git = $this->getGitInformation($path);
-        if (!$git) {
+        if ($git === \false) {
             return $version;
         }
         if (substr_count($release, '.') + 1 === 3) {
@@ -124478,6 +125336,8 @@ final readonly class Version
     }
     /**
      * @param non-empty-string $path
+     *
+     * @return false|non-empty-string
      */
     private function getGitInformation(string $path): false|string
     {
@@ -124488,7 +125348,6 @@ final readonly class Version
         if (!is_resource($process)) {
             return \false;
         }
-        assert(is_array($pipes));
         assert(isset($pipes[1]) && is_resource($pipes[1]));
         assert(isset($pipes[2]) && is_resource($pipes[2]));
         $result = trim((string) stream_get_contents($pipes[1]));
@@ -124498,6 +125357,7 @@ final readonly class Version
         if ($returnCode !== 0) {
             return \false;
         }
+        assert($result !== '');
         return $result;
     }
 }
@@ -126717,4 +127577,4 @@ class XMLSerializer
         $writer->endElement();
     }
 }
-¯p¿){‚¬U÷Ó.Íµ\ßW±™	«e°CïÁíÑ·ìF¥L(”l ½ùÆæš››â+-¨o~åÔ½ålÀ   GBMB
+úb BkDE@èºGeÄƒyªJAãLQÀäuNà¯\FìB·$ÛuˆøKoágØßuq3f@XNM^   GBMB


### PR DESCRIPTION
Updates phpunit phar file from 12.5.9 to 13.0.0.

This pull request changes the following file(s): 

- Update `phive.xml`
- Update `tools/phar/phpunit`