### PR TITLE
Update phpunit/phpunit to version 13.0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/filesystem": "^0.1.2",
         "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^13.0.4",
+        "phpunit/phpunit": "^13.0.5",
         "symfony/var-dumper": "^8.0.4"
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a4c108fef2a9ee7899610aa8d043095f",
+    "content-hash": "d488f16ad2bb28a3d5d08e3cdd3449ae",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -3328,16 +3328,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "13.0.4",
+            "version": "13.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "915a2e7266f04c1867b2dc812abc86c34f1aa52f"
+                "reference": "d57826e8921a534680c613924bfd921ded8047f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/915a2e7266f04c1867b2dc812abc86c34f1aa52f",
-                "reference": "915a2e7266f04c1867b2dc812abc86c34f1aa52f",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d57826e8921a534680c613924bfd921ded8047f4",
+                "reference": "d57826e8921a534680c613924bfd921ded8047f4",
                 "shasum": ""
             },
             "require": {
@@ -3406,7 +3406,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.0.4"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.0.5"
             },
             "funding": [
                 {
@@ -3430,7 +3430,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-18T09:00:54+00:00"
+            "time": "2026-02-18T12:40:03+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Updates the `phpunit/phpunit` dependency from `13.0.4` to `13.0.5`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`