### PR TITLE
Update ghostwriter/http to version 0.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "ghostwriter/config": "^2.1.1",
         "ghostwriter/container": "^6.1.1",
         "ghostwriter/event-dispatcher": "^6.1.0",
-        "ghostwriter/http": "^0.1.0",
+        "ghostwriter/http": "^0.1.1",
         "ghostwriter/json": "^3.0.2",
         "ghostwriter/option": "^2.0.0",
         "ghostwriter/result": "^2.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5df092d424cf89fb4b4b0176a45fa7be",
+    "content-hash": "1d1b43787705fb868b9c5e8045483b81",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -452,16 +452,16 @@
         },
         {
             "name": "ghostwriter/http",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/http.git",
-                "reference": "1e7647eaba8d290b4da62edc2588f0119166b95a"
+                "reference": "7b32c5362157b83ef33e193cdd8908256429e0a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/http/zipball/1e7647eaba8d290b4da62edc2588f0119166b95a",
-                "reference": "1e7647eaba8d290b4da62edc2588f0119166b95a",
+                "url": "https://api.github.com/repos/ghostwriter/http/zipball/7b32c5362157b83ef33e193cdd8908256429e0a8",
+                "reference": "7b32c5362157b83ef33e193cdd8908256429e0a8",
                 "shasum": ""
             },
             "require": {
@@ -469,10 +469,10 @@
                 "ext-json": "*",
                 "ext-mbstring": "*",
                 "ghostwriter/clock": "^3.0.1",
-                "ghostwriter/config": "^2.0.2",
-                "ghostwriter/container": "^6.0.1",
-                "ghostwriter/event-dispatcher": "^6.0.2",
-                "ghostwriter/json": "^3.0.1",
+                "ghostwriter/config": "^2.1.1",
+                "ghostwriter/container": "^6.1.1",
+                "ghostwriter/event-dispatcher": "^6.1.0",
+                "ghostwriter/json": "^3.0.2",
                 "guzzlehttp/guzzle": "^7.10.0",
                 "laminas/laminas-diactoros": "^3.8.0",
                 "php": "~8.4.0 || ~8.5.0",
@@ -486,8 +486,8 @@
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^13.0.5",
-                "symfony/var-dumper": "^8.0.4"
+                "phpunit/phpunit": "^13.1.3",
+                "symfony/var-dumper": "^8.0.8"
             },
             "type": "library",
             "extra": {
@@ -497,7 +497,9 @@
                 },
                 "ghostwriter": {
                     "container": {
-                        "definition": "Ghostwriter\\Http\\Container\\HttpDefinition"
+                        "provider": [
+                            "Ghostwriter\\Http\\Container\\HttpProvider"
+                        ]
                     }
                 }
             },
@@ -538,7 +540,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-22T20:06:38+00:00"
+            "time": "2026-04-15T00:42:23+00:00"
         },
         {
             "name": "ghostwriter/json",


### PR DESCRIPTION
Updates the `ghostwriter/http` dependency from `0.1.0` to `0.1.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`