### PR TITLE
Update `boundwize/structarmed` to version `0.10.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.9.5",
+        "boundwize/structarmed": "^0.10.0",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/filesystem": "^0.2.0",
         "ghostwriter/phpunit-assertions": "^0.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "977d0c7e6188452e42e15645bb08a8f0",
+    "content-hash": "07c9012820686a57ed2e39776b58a938",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -1541,16 +1541,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.9.5",
+            "version": "0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "4c62dc582322ef9267d02bb81e9ba88e3ef963e0"
+                "reference": "5e488b5c1502a92e3cef8cf25b87b77e877b9804"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/4c62dc582322ef9267d02bb81e9ba88e3ef963e0",
-                "reference": "4c62dc582322ef9267d02bb81e9ba88e3ef963e0",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/5e488b5c1502a92e3cef8cf25b87b77e877b9804",
+                "reference": "5e488b5c1502a92e3cef8cf25b87b77e877b9804",
                 "shasum": ""
             },
             "require": {
@@ -1603,7 +1603,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.9.5"
+                "source": "https://github.com/boundwize/structarmed/tree/0.10.0"
             },
             "funding": [
                 {
@@ -1611,7 +1611,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T07:01:44+00:00"
+            "time": "2026-06-01T18:39:11+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the [`boundwize/structarmed`](https://packagist.org/packages/boundwize/structarmed) dependency from `0.9.5` to `0.10.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`